### PR TITLE
Add Nuvio JSON export for bulk people lookup

### DIFF
--- a/css/mobile-fixes.css
+++ b/css/mobile-fixes.css
@@ -43,6 +43,14 @@
 	.nuvio-export-grid {
 		grid-template-columns: 1fr;
 	}
+
+	.nuvio-preview-grid {
+		grid-template-columns: 1fr;
+	}
+
+	.modal-panel {
+		padding: 14px;
+	}
 }
 
 @media (max-width: 390px) {

--- a/css/mobile-fixes.css
+++ b/css/mobile-fixes.css
@@ -68,6 +68,10 @@
 	.nuvio-preview-grid {
 		max-width: none;
 	}
+
+	.nuvio-toggle-help {
+		max-width: none;
+	}
 }
 
 @media (max-width: 390px) {

--- a/css/mobile-fixes.css
+++ b/css/mobile-fixes.css
@@ -61,10 +61,6 @@
 		font-size: 22px;
 	}
 
-	.nuvio-image-preview {
-		height: 112px;
-	}
-
 	.nuvio-toggle-option {
 		min-height: auto;
 	}

--- a/css/mobile-fixes.css
+++ b/css/mobile-fixes.css
@@ -72,6 +72,15 @@
 	.nuvio-toggle-help {
 		max-width: none;
 	}
+
+	.nuvio-import-help-grid {
+		grid-template-columns: 1fr;
+	}
+
+	.modal-footer {
+		align-items: flex-start;
+		gap: 12px;
+	}
 }
 
 @media (max-width: 390px) {

--- a/css/mobile-fixes.css
+++ b/css/mobile-fixes.css
@@ -39,6 +39,10 @@
 		right: 14px;
 		bottom: 88px;
 	}
+
+	.nuvio-export-grid {
+		grid-template-columns: 1fr;
+	}
 }
 
 @media (max-width: 390px) {

--- a/css/mobile-fixes.css
+++ b/css/mobile-fixes.css
@@ -65,8 +65,12 @@
 		height: 112px;
 	}
 
-	.nuvio-checkbox-option {
+	.nuvio-toggle-option {
 		min-height: auto;
+	}
+
+	.nuvio-preview-grid {
+		max-width: none;
 	}
 }
 

--- a/css/mobile-fixes.css
+++ b/css/mobile-fixes.css
@@ -49,7 +49,24 @@
 	}
 
 	.modal-panel {
+		max-height: calc(100vh - 24px);
 		padding: 14px;
+	}
+
+	.modal-backdrop {
+		padding: 12px;
+	}
+
+	.modal-header h2 {
+		font-size: 22px;
+	}
+
+	.nuvio-image-preview {
+		height: 112px;
+	}
+
+	.nuvio-checkbox-option {
+		min-height: auto;
 	}
 }
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -617,10 +617,11 @@ th.sortable:hover {
 	inset: 0;
 	z-index: 1200;
 	display: flex;
-	align-items: center;
+	align-items: flex-start;
 	justify-content: center;
-	padding: 18px;
+	padding: 24px 14px;
 	background: rgba(0, 0, 0, 0.72);
+	overflow: auto;
 }
 
 .modal-backdrop[hidden] {
@@ -628,12 +629,12 @@ th.sortable:hover {
 }
 
 .modal-panel {
-	width: min(860px, 100%);
-	max-height: calc(100vh - 36px);
+	width: min(720px, 100%);
+	max-height: calc(100vh - 48px);
 	overflow: auto;
-	padding: 18px;
+	padding: 16px;
 	border: 1px solid #1f2733;
-	border-radius: 14px;
+	border-radius: 12px;
 	background: #0f1218;
 	box-shadow: 0 22px 60px rgba(0, 0, 0, 0.5);
 	box-sizing: border-box;
@@ -644,26 +645,27 @@ th.sortable:hover {
 	align-items: center;
 	justify-content: space-between;
 	gap: 14px;
-	margin-bottom: 16px;
+	margin-bottom: 12px;
 }
 
 .modal-header h2 {
 	margin: 0;
+	font-size: 24px;
 }
 
 .modal-close {
-	width: 40px;
-	height: 40px;
+	width: 36px;
+	height: 36px;
 	padding: 0;
 	border-radius: 999px;
-	font-size: 26px;
+	font-size: 24px;
 	line-height: 1;
 }
 
 .nuvio-export-grid {
 	display: grid;
 	grid-template-columns: repeat(2, minmax(180px, 1fr));
-	gap: 12px;
+	gap: 10px 12px;
 }
 
 .nuvio-export-grid label {
@@ -680,20 +682,37 @@ th.sortable:hover {
 	max-width: none;
 }
 
+.nuvio-checkbox-option {
+	flex-direction: row;
+	align-items: center;
+	justify-content: flex-end;
+	min-height: 63px;
+}
+
+.nuvio-checkbox-option input {
+	width: auto;
+	margin: 0;
+}
+
+.nuvio-checkbox-option span {
+	color: #e6edf7;
+	font-size: 15px;
+}
+
 .nuvio-preview-grid {
 	display: grid;
 	grid-template-columns: repeat(2, minmax(180px, 1fr));
 	gap: 12px;
-	margin-top: 14px;
+	margin-top: 12px;
 }
 
 .nuvio-image-preview {
 	display: block;
 	width: 100%;
-	aspect-ratio: 16 / 9;
+	height: 132px;
 	object-fit: cover;
 	border: 1px solid #2b313b;
-	border-radius: 10px;
+	border-radius: 8px;
 	background: #151922;
 }
 
@@ -702,7 +721,7 @@ th.sortable:hover {
 	flex-wrap: wrap;
 	gap: 10px;
 	justify-content: flex-end;
-	margin-top: 16px;
+	margin-top: 14px;
 }
 
 .bulk-results {

--- a/css/styles.css
+++ b/css/styles.css
@@ -607,6 +607,35 @@ th.sortable:hover {
 	margin-top: 10px;
 }
 
+.nuvio-export-options {
+	max-width: 760px;
+	margin: 16px 0 4px;
+	padding: 14px;
+	border: 1px solid #1f2733;
+	border-radius: 12px;
+	background: rgba(11, 13, 16, 0.45);
+}
+
+.nuvio-export-grid {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(180px, 1fr));
+	gap: 12px;
+}
+
+.nuvio-export-grid label {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	color: #aeb7c2;
+	font-size: 13px;
+}
+
+.nuvio-export-grid input,
+.nuvio-export-grid select {
+	width: 100%;
+	max-width: none;
+}
+
 .bulk-results {
 	margin-top: 14px;
 	overflow-x: auto;

--- a/css/styles.css
+++ b/css/styles.css
@@ -640,6 +640,10 @@ th.sortable:hover {
 	box-sizing: border-box;
 }
 
+.modal-panel-help {
+	width: min(640px, 100%);
+}
+
 .modal-header {
 	display: flex;
 	align-items: center;
@@ -783,12 +787,63 @@ th.sortable:hover {
 	background: #151922;
 }
 
+.modal-footer {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	margin-top: 14px;
+}
+
 .modal-actions {
 	display: flex;
 	flex-wrap: wrap;
 	gap: 10px;
 	justify-content: flex-end;
-	margin-top: 14px;
+}
+
+.modal-help-button {
+	width: 38px;
+	height: 38px;
+	padding: 0;
+	border-radius: 999px;
+	font-size: 20px;
+	font-weight: 700;
+	line-height: 1;
+}
+
+.modal-backdrop-secondary {
+	z-index: 1300;
+}
+
+.nuvio-import-help {
+	color: #aeb7c2;
+	font-size: 13px;
+}
+
+.nuvio-import-help p {
+	margin: 0 0 10px;
+}
+
+.nuvio-import-help-grid {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: 14px;
+}
+
+.nuvio-import-help h3 {
+	margin: 8px 0 6px;
+	color: #e6edf7;
+	font-size: 14px;
+}
+
+.nuvio-import-help ol {
+	margin: 0;
+	padding-left: 18px;
+}
+
+.nuvio-import-help li {
+	margin: 4px 0;
+	line-height: 1.35;
 }
 
 .bulk-results {

--- a/css/styles.css
+++ b/css/styles.css
@@ -688,7 +688,10 @@ th.sortable:hover {
 	justify-content: space-between;
 	gap: 12px;
 	min-height: 63px;
-	padding: 0 2px;
+	padding: 10px 12px;
+	border: 1px solid #2b313b;
+	border-radius: 8px;
+	background: #111722;
 }
 
 .nuvio-toggle-option input {
@@ -700,6 +703,18 @@ th.sortable:hover {
 .nuvio-toggle-label {
 	color: #e6edf7;
 	font-size: 15px;
+}
+
+.nuvio-toggle-copy {
+	display: flex;
+	flex-direction: column;
+	gap: 3px;
+}
+
+.nuvio-toggle-help {
+	color: #8f9aaa;
+	font-size: 12px;
+	line-height: 1.3;
 }
 
 .nuvio-toggle-track {
@@ -747,13 +762,13 @@ th.sortable:hover {
 	grid-template-columns: repeat(2, minmax(180px, 1fr));
 	gap: 12px;
 	margin-top: 12px;
-	max-width: 560px;
+	max-width: 520px;
 }
 
 .nuvio-image-preview {
 	display: block;
 	width: 100%;
-	height: 96px;
+	aspect-ratio: 16 / 9;
 	object-fit: cover;
 	border: 1px solid #2b313b;
 	border-radius: 8px;

--- a/css/styles.css
+++ b/css/styles.css
@@ -629,7 +629,7 @@ th.sortable:hover {
 }
 
 .modal-panel {
-	width: min(680px, 100%);
+	width: min(704px, 100%);
 	max-height: calc(100vh - 48px);
 	overflow: auto;
 	padding: 16px;
@@ -664,8 +664,8 @@ th.sortable:hover {
 
 .nuvio-export-grid {
 	display: grid;
-	grid-template-columns: repeat(2, minmax(180px, 1fr));
-	gap: 10px 12px;
+	grid-template-columns: repeat(2, 320px);
+	gap: 10px 14px;
 }
 
 .nuvio-export-grid label {
@@ -682,43 +682,52 @@ th.sortable:hover {
 	max-width: none;
 }
 
-.nuvio-toggle-option {
+.nuvio-export-grid .nuvio-toggle-option {
+	display: flex;
 	flex-direction: row;
-	align-items: center;
-	justify-content: space-between;
-	gap: 12px;
-	min-height: 63px;
-	padding: 10px 12px;
+	align-items: flex-start;
+	justify-content: flex-start;
+	gap: 32px;
+	min-height: auto;
+	padding: 12px 14px;
 	border: 1px solid #2b313b;
 	border-radius: 8px;
 	background: #111722;
+	cursor: pointer;
 }
 
 .nuvio-toggle-option input {
 	position: absolute;
 	opacity: 0;
-	pointer-events: none;
 }
 
 .nuvio-toggle-label {
 	color: #e6edf7;
-	font-size: 15px;
+	font-size: 16px;
+	font-weight: 700;
+	line-height: 1.2;
+	white-space: nowrap;
 }
 
 .nuvio-toggle-copy {
 	display: flex;
 	flex-direction: column;
-	gap: 3px;
+	align-items: flex-start;
+	gap: 2px;
+	min-width: 0;
 }
 
 .nuvio-toggle-help {
 	color: #8f9aaa;
 	font-size: 12px;
 	line-height: 1.3;
+	display: block;
+	max-width: 210px;
 }
 
 .nuvio-toggle-track {
 	position: relative;
+	align-self: center;
 	width: 46px;
 	height: 26px;
 	flex: 0 0 auto;
@@ -742,27 +751,26 @@ th.sortable:hover {
 	transition: transform 0.18s ease;
 }
 
-.nuvio-toggle-option input:checked + .nuvio-toggle-label + .nuvio-toggle-track {
+.nuvio-toggle-option input:checked + .nuvio-toggle-copy + .nuvio-toggle-track {
 	border-color: #3b82f6;
 	background: #1d4ed8;
 }
 
-.nuvio-toggle-option input:checked + .nuvio-toggle-label + .nuvio-toggle-track::after {
+.nuvio-toggle-option input:checked + .nuvio-toggle-copy + .nuvio-toggle-track::after {
 	transform: translateX(20px);
 	background: #ffffff;
 }
 
-.nuvio-toggle-option input:focus-visible + .nuvio-toggle-label + .nuvio-toggle-track {
+.nuvio-toggle-option input:focus-visible + .nuvio-toggle-copy + .nuvio-toggle-track {
 	outline: 2px solid #93c5fd;
 	outline-offset: 2px;
 }
 
 .nuvio-preview-grid {
 	display: grid;
-	grid-template-columns: repeat(2, minmax(180px, 1fr));
-	gap: 12px;
+	grid-template-columns: repeat(2, 320px);
+	gap: 14px;
 	margin-top: 12px;
-	max-width: 520px;
 }
 
 .nuvio-image-preview {

--- a/css/styles.css
+++ b/css/styles.css
@@ -629,7 +629,7 @@ th.sortable:hover {
 }
 
 .modal-panel {
-	width: min(720px, 100%);
+	width: min(680px, 100%);
 	max-height: calc(100vh - 48px);
 	overflow: auto;
 	padding: 16px;
@@ -682,21 +682,64 @@ th.sortable:hover {
 	max-width: none;
 }
 
-.nuvio-checkbox-option {
+.nuvio-toggle-option {
 	flex-direction: row;
 	align-items: center;
-	justify-content: flex-end;
+	justify-content: space-between;
+	gap: 12px;
 	min-height: 63px;
+	padding: 0 2px;
 }
 
-.nuvio-checkbox-option input {
-	width: auto;
-	margin: 0;
+.nuvio-toggle-option input {
+	position: absolute;
+	opacity: 0;
+	pointer-events: none;
 }
 
-.nuvio-checkbox-option span {
+.nuvio-toggle-label {
 	color: #e6edf7;
 	font-size: 15px;
+}
+
+.nuvio-toggle-track {
+	position: relative;
+	width: 46px;
+	height: 26px;
+	flex: 0 0 auto;
+	border: 1px solid #334155;
+	border-radius: 999px;
+	background: #151922;
+	transition:
+		background 0.18s ease,
+		border-color 0.18s ease;
+}
+
+.nuvio-toggle-track::after {
+	content: "";
+	position: absolute;
+	top: 3px;
+	left: 3px;
+	width: 18px;
+	height: 18px;
+	border-radius: 999px;
+	background: #cbd5e1;
+	transition: transform 0.18s ease;
+}
+
+.nuvio-toggle-option input:checked + .nuvio-toggle-label + .nuvio-toggle-track {
+	border-color: #3b82f6;
+	background: #1d4ed8;
+}
+
+.nuvio-toggle-option input:checked + .nuvio-toggle-label + .nuvio-toggle-track::after {
+	transform: translateX(20px);
+	background: #ffffff;
+}
+
+.nuvio-toggle-option input:focus-visible + .nuvio-toggle-label + .nuvio-toggle-track {
+	outline: 2px solid #93c5fd;
+	outline-offset: 2px;
 }
 
 .nuvio-preview-grid {
@@ -704,12 +747,13 @@ th.sortable:hover {
 	grid-template-columns: repeat(2, minmax(180px, 1fr));
 	gap: 12px;
 	margin-top: 12px;
+	max-width: 560px;
 }
 
 .nuvio-image-preview {
 	display: block;
 	width: 100%;
-	height: 132px;
+	height: 96px;
 	object-fit: cover;
 	border: 1px solid #2b313b;
 	border-radius: 8px;

--- a/css/styles.css
+++ b/css/styles.css
@@ -608,12 +608,56 @@ th.sortable:hover {
 }
 
 .nuvio-export-options {
-	max-width: 760px;
-	margin: 16px 0 4px;
-	padding: 14px;
+	margin: 0;
+	padding: 0;
+}
+
+.modal-backdrop {
+	position: fixed;
+	inset: 0;
+	z-index: 1200;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 18px;
+	background: rgba(0, 0, 0, 0.72);
+}
+
+.modal-backdrop[hidden] {
+	display: none;
+}
+
+.modal-panel {
+	width: min(860px, 100%);
+	max-height: calc(100vh - 36px);
+	overflow: auto;
+	padding: 18px;
 	border: 1px solid #1f2733;
-	border-radius: 12px;
-	background: rgba(11, 13, 16, 0.45);
+	border-radius: 14px;
+	background: #0f1218;
+	box-shadow: 0 22px 60px rgba(0, 0, 0, 0.5);
+	box-sizing: border-box;
+}
+
+.modal-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 14px;
+	margin-bottom: 16px;
+}
+
+.modal-header h2 {
+	margin: 0;
+}
+
+.modal-close {
+	width: 40px;
+	height: 40px;
+	padding: 0;
+	border-radius: 999px;
+	font-size: 26px;
+	line-height: 1;
 }
 
 .nuvio-export-grid {
@@ -634,6 +678,31 @@ th.sortable:hover {
 .nuvio-export-grid select {
 	width: 100%;
 	max-width: none;
+}
+
+.nuvio-preview-grid {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(180px, 1fr));
+	gap: 12px;
+	margin-top: 14px;
+}
+
+.nuvio-image-preview {
+	display: block;
+	width: 100%;
+	aspect-ratio: 16 / 9;
+	object-fit: cover;
+	border: 1px solid #2b313b;
+	border-radius: 10px;
+	background: #151922;
+}
+
+.modal-actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 10px;
+	justify-content: flex-end;
+	margin-top: 16px;
 }
 
 .bulk-results {

--- a/index.html
+++ b/index.html
@@ -114,7 +114,10 @@
 
 						<label class="nuvio-toggle-option">
 							<input id="nuvio-hide-folder-title" type="checkbox" />
-							<span class="nuvio-toggle-label">Hide folder title</span>
+							<span class="nuvio-toggle-copy">
+								<span class="nuvio-toggle-label">Hide folder title</span>
+								<span class="nuvio-toggle-help">Turn on when your poster image already includes text.</span>
+							</span>
 							<span class="nuvio-toggle-track" aria-hidden="true"></span>
 						</label>
 					</div>

--- a/index.html
+++ b/index.html
@@ -60,41 +60,6 @@
 				<button id="clear-bulk-people" type="button">Clear</button>
 			</div>
 
-			<div class="nuvio-export-options" aria-label="Nuvio JSON export options">
-				<div class="nuvio-export-grid">
-					<label>
-						Collection name
-						<input id="nuvio-collection-name" placeholder="Favourite actors" />
-					</label>
-
-					<label>
-						Cover image URL
-						<input id="nuvio-cover-image-url" placeholder="Optional cover image URL" />
-					</label>
-
-					<label>
-						Folder hero URL
-						<input id="nuvio-folder-hero-url" placeholder="Optional folder hero image URL" />
-					</label>
-
-					<label>
-						Media type
-						<select id="nuvio-media-type">
-							<option value="MOVIE" selected>Movie</option>
-							<option value="TV">TV</option>
-						</select>
-					</label>
-
-					<label>
-						Source type
-						<select id="nuvio-source-type">
-							<option value="PERSON" selected>Person</option>
-							<option value="DIRECTOR">Director</option>
-						</select>
-					</label>
-				</div>
-			</div>
-
 			<p id="bulk-people-status" class="bulk-status"></p>
 
 			<p class="meta">
@@ -103,6 +68,69 @@
 
 			<div id="bulk-people-results" class="bulk-results"></div>
 		</section>
+
+		<div id="nuvio-export-modal" class="modal-backdrop" hidden>
+			<div class="modal-panel" role="dialog" aria-modal="true" aria-labelledby="nuvio-export-title">
+				<div class="modal-header">
+					<h2 id="nuvio-export-title">Create Nuvio JSON</h2>
+					<button id="close-nuvio-export-modal" class="modal-close" type="button" aria-label="Close Nuvio JSON export">
+						&times;
+					</button>
+				</div>
+
+				<div class="nuvio-export-options" aria-label="Nuvio JSON export options">
+					<div class="nuvio-export-grid">
+						<label>
+							Collection name
+							<input id="nuvio-collection-name" placeholder="Favourite actors" />
+						</label>
+
+						<label>
+							Media type
+							<select id="nuvio-media-type">
+								<option value="MOVIE" selected>Movie</option>
+								<option value="TV">TV</option>
+							</select>
+						</label>
+
+						<label>
+							Source type
+							<select id="nuvio-source-type">
+								<option value="PERSON" selected>Person</option>
+								<option value="DIRECTOR">Director</option>
+							</select>
+						</label>
+
+						<label>
+							Cover image URL
+							<input id="nuvio-cover-image-url" placeholder="Blank uses the actor/director default cover" />
+						</label>
+
+						<label>
+							Folder hero URL
+							<input id="nuvio-folder-hero-url" placeholder="Blank uses the actor/director default hero" />
+						</label>
+					</div>
+
+					<div class="nuvio-preview-grid" aria-label="Nuvio image previews">
+						<div>
+							<p class="meta">Collection cover preview</p>
+							<img id="nuvio-cover-preview" class="nuvio-image-preview" alt="Nuvio collection cover preview" />
+						</div>
+
+						<div>
+							<p class="meta">Folder hero preview</p>
+							<img id="nuvio-folder-hero-preview" class="nuvio-image-preview" alt="Nuvio folder hero preview" />
+						</div>
+					</div>
+				</div>
+
+				<div class="modal-actions">
+					<button id="download-nuvio-json" type="button">Download JSON</button>
+					<button id="cancel-nuvio-export" type="button">Cancel</button>
+				</div>
+			</div>
+		</div>
 
 		<div class="section-divider"></div>
 

--- a/index.html
+++ b/index.html
@@ -104,19 +104,19 @@
 
 						<label>
 							Cover image URL
-							<input id="nuvio-cover-image-url" placeholder="Blank uses the source type default cover" />
+							<input id="nuvio-cover-image-url" placeholder="Leave blank to use default" />
 						</label>
 
 						<label>
 							Folder hero URL
-							<input id="nuvio-folder-hero-url" placeholder="Blank uses the source type default hero" />
+							<input id="nuvio-folder-hero-url" placeholder="Leave blank to use default" />
 						</label>
 
 						<label class="nuvio-toggle-option">
 							<input id="nuvio-hide-folder-title" type="checkbox" />
 							<span class="nuvio-toggle-copy">
 								<span class="nuvio-toggle-label">Hide folder title</span>
-								<span class="nuvio-toggle-help">Turn on when your poster image already includes text.</span>
+								<span class="nuvio-toggle-help">Note: TMDB poster artwork does not include a title.</span>
 							</span>
 							<span class="nuvio-toggle-track" aria-hidden="true"></span>
 						</label>

--- a/index.html
+++ b/index.html
@@ -96,19 +96,25 @@
 						<label>
 							Source type
 							<select id="nuvio-source-type">
-								<option value="PERSON" selected>Person</option>
-								<option value="DIRECTOR">Director</option>
+								<option value="ACTOR" selected>Actors</option>
+								<option value="DIRECTOR">Directors</option>
+								<option value="PERSON">People</option>
 							</select>
 						</label>
 
 						<label>
 							Cover image URL
-							<input id="nuvio-cover-image-url" placeholder="Blank uses the actor/director default cover" />
+							<input id="nuvio-cover-image-url" placeholder="Blank uses the source type default cover" />
 						</label>
 
 						<label>
 							Folder hero URL
-							<input id="nuvio-folder-hero-url" placeholder="Blank uses the actor/director default hero" />
+							<input id="nuvio-folder-hero-url" placeholder="Blank uses the source type default hero" />
+						</label>
+
+						<label class="nuvio-checkbox-option">
+							<input id="nuvio-hide-folder-title" type="checkbox" />
+							<span>Hide folder title</span>
 						</label>
 					</div>
 

--- a/index.html
+++ b/index.html
@@ -112,9 +112,10 @@
 							<input id="nuvio-folder-hero-url" placeholder="Blank uses the source type default hero" />
 						</label>
 
-						<label class="nuvio-checkbox-option">
+						<label class="nuvio-toggle-option">
 							<input id="nuvio-hide-folder-title" type="checkbox" />
-							<span>Hide folder title</span>
+							<span class="nuvio-toggle-label">Hide folder title</span>
+							<span class="nuvio-toggle-track" aria-hidden="true"></span>
 						</label>
 					</div>
 

--- a/index.html
+++ b/index.html
@@ -60,6 +60,41 @@
 				<button id="clear-bulk-people" type="button">Clear</button>
 			</div>
 
+			<div class="nuvio-export-options" aria-label="Nuvio JSON export options">
+				<div class="nuvio-export-grid">
+					<label>
+						Collection name
+						<input id="nuvio-collection-name" placeholder="Favourite actors" />
+					</label>
+
+					<label>
+						Cover image URL
+						<input id="nuvio-cover-image-url" placeholder="Optional cover image URL" />
+					</label>
+
+					<label>
+						Folder hero URL
+						<input id="nuvio-folder-hero-url" placeholder="Optional folder hero image URL" />
+					</label>
+
+					<label>
+						Media type
+						<select id="nuvio-media-type">
+							<option value="MOVIE" selected>Movie</option>
+							<option value="TV">TV</option>
+						</select>
+					</label>
+
+					<label>
+						Source type
+						<select id="nuvio-source-type">
+							<option value="PERSON" selected>Person</option>
+							<option value="DIRECTOR">Director</option>
+						</select>
+					</label>
+				</div>
+			</div>
+
 			<p id="bulk-people-status" class="bulk-status"></p>
 
 			<p class="meta">

--- a/index.html
+++ b/index.html
@@ -116,7 +116,7 @@
 							<input id="nuvio-hide-folder-title" type="checkbox" />
 							<span class="nuvio-toggle-copy">
 								<span class="nuvio-toggle-label">Hide folder title</span>
-								<span class="nuvio-toggle-help">Note: TMDB poster artwork does not include a title.</span>
+								<span class="nuvio-toggle-help">Note: TMDB person images do not display the person's name.</span>
 							</span>
 							<span class="nuvio-toggle-track" aria-hidden="true"></span>
 						</label>
@@ -135,9 +135,57 @@
 					</div>
 				</div>
 
-				<div class="modal-actions">
-					<button id="download-nuvio-json" type="button">Download JSON</button>
-					<button id="cancel-nuvio-export" type="button">Cancel</button>
+				<div class="modal-footer">
+					<button id="open-nuvio-import-help" class="modal-help-button" type="button" aria-label="How to import into Nuvio">
+						?
+					</button>
+
+					<div class="modal-actions">
+						<button id="download-nuvio-json" type="button">Download JSON</button>
+						<button id="cancel-nuvio-export" type="button">Cancel</button>
+					</div>
+				</div>
+			</div>
+		</div>
+
+		<div id="nuvio-import-help-modal" class="modal-backdrop modal-backdrop-secondary" hidden>
+			<div class="modal-panel modal-panel-help" role="dialog" aria-modal="true" aria-labelledby="nuvio-import-help-title">
+				<div class="modal-header">
+					<h2 id="nuvio-import-help-title">Import into Nuvio</h2>
+					<button id="close-nuvio-import-help" class="modal-close" type="button" aria-label="Close Nuvio import help">
+						&times;
+					</button>
+				</div>
+
+				<div class="nuvio-import-help">
+					<p>Nuvio is currently in beta, so these import steps may change.</p>
+
+					<div class="nuvio-import-help-grid">
+						<div>
+							<h3>Web login</h3>
+							<ol>
+								<li>Log in to Nuvio.</li>
+								<li>Select the correct profile.</li>
+								<li>Open Collections.</li>
+								<li>Click Import.</li>
+								<li>Select the downloaded JSON file.</li>
+								<li>Choose Add as new, Merge, or Overwrite.</li>
+								<li>Click Add collections.</li>
+							</ol>
+						</div>
+
+						<div>
+							<h3>TV app</h3>
+							<ol>
+								<li>Open Nuvio and choose a profile.</li>
+								<li>Open Addons, then Collections.</li>
+								<li>Select Import.</li>
+								<li>Choose From File or From URL.</li>
+								<li>For From File, load the JSON from Downloads, then confirm import.</li>
+								<li>For From URL, enter the URL, fetch it, then confirm import.</li>
+							</ol>
+						</div>
+					</div>
 				</div>
 			</div>
 		</div>

--- a/js/bulk-people-lookup.js
+++ b/js/bulk-people-lookup.js
@@ -49,6 +49,32 @@ function getNuvioExportOptions() {
 	};
 }
 
+function updateNuvioImagePreviews() {
+	const options = getNuvioExportOptions();
+	const coverPreview = document.getElementById("nuvio-cover-preview");
+	const folderHeroPreview = document.getElementById("nuvio-folder-hero-preview");
+
+	coverPreview.src = options.coverImageUrl;
+	folderHeroPreview.src = options.folderHeroImageUrl;
+}
+
+function openNuvioExportModal() {
+	const modal = document.getElementById("nuvio-export-modal");
+	const defaultCollectionName = document.getElementById("nuvio-collection-name");
+
+	if (!defaultCollectionName.value.trim()) {
+		defaultCollectionName.value = "TMDB People Collection";
+	}
+
+	updateNuvioImagePreviews();
+	modal.hidden = false;
+	document.getElementById("nuvio-collection-name").focus();
+}
+
+function closeNuvioExportModal() {
+	document.getElementById("nuvio-export-modal").hidden = true;
+}
+
 function createNuvioSource(result, options) {
 	return {
 		title: result.name,
@@ -375,13 +401,13 @@ async function resolveBulkPeople() {
 		status.appendChild(downloadButton);
 
 		const nuvioJsonButton = createElement("button", {
-			text: "Download Nuvio JSON",
+			text: "Create Nuvio JSON from matches",
 			attrs: {
 				type: "button",
 			},
 		});
 
-		nuvioJsonButton.addEventListener("click", downloadNuvioJson);
+		nuvioJsonButton.addEventListener("click", openNuvioExportModal);
 		status.appendChild(document.createTextNode(" "));
 		status.appendChild(nuvioJsonButton);
 	}
@@ -396,6 +422,19 @@ function initBulkPeopleLookup() {
 		document.getElementById("bulk-people-input").value = "";
 		document.getElementById("bulk-people-status").innerText = "";
 		document.getElementById("bulk-people-results").replaceChildren();
+		closeNuvioExportModal();
 		lastBulkPeopleResults = [];
+	});
+
+	document.getElementById("close-nuvio-export-modal").addEventListener("click", closeNuvioExportModal);
+	document.getElementById("cancel-nuvio-export").addEventListener("click", closeNuvioExportModal);
+	document.getElementById("download-nuvio-json").addEventListener("click", downloadNuvioJson);
+	document.getElementById("nuvio-source-type").addEventListener("change", updateNuvioImagePreviews);
+	document.getElementById("nuvio-cover-image-url").addEventListener("input", updateNuvioImagePreviews);
+	document.getElementById("nuvio-folder-hero-url").addEventListener("input", updateNuvioImagePreviews);
+	document.getElementById("nuvio-export-modal").addEventListener("click", (event) => {
+		if (event.target.id === "nuvio-export-modal") {
+			closeNuvioExportModal();
+		}
 	});
 }

--- a/js/bulk-people-lookup.js
+++ b/js/bulk-people-lookup.js
@@ -93,6 +93,16 @@ function openNuvioExportModal() {
 
 function closeNuvioExportModal() {
 	document.getElementById("nuvio-export-modal").hidden = true;
+	closeNuvioImportHelpModal();
+}
+
+function openNuvioImportHelpModal() {
+	document.getElementById("nuvio-import-help-modal").hidden = false;
+	document.getElementById("close-nuvio-import-help").focus();
+}
+
+function closeNuvioImportHelpModal() {
+	document.getElementById("nuvio-import-help-modal").hidden = true;
 }
 
 function createNuvioSource(result, options) {
@@ -462,6 +472,8 @@ function initBulkPeopleLookup() {
 
 	document.getElementById("close-nuvio-export-modal").addEventListener("click", closeNuvioExportModal);
 	document.getElementById("cancel-nuvio-export").addEventListener("click", closeNuvioExportModal);
+	document.getElementById("open-nuvio-import-help").addEventListener("click", openNuvioImportHelpModal);
+	document.getElementById("close-nuvio-import-help").addEventListener("click", closeNuvioImportHelpModal);
 	document.getElementById("download-nuvio-json").addEventListener("click", downloadNuvioJson);
 	document.getElementById("nuvio-source-type").addEventListener("change", updateNuvioImagePreviews);
 	document.getElementById("nuvio-cover-image-url").addEventListener("input", updateNuvioImagePreviews);
@@ -469,6 +481,11 @@ function initBulkPeopleLookup() {
 	document.getElementById("nuvio-export-modal").addEventListener("click", (event) => {
 		if (event.target.id === "nuvio-export-modal") {
 			closeNuvioExportModal();
+		}
+	});
+	document.getElementById("nuvio-import-help-modal").addEventListener("click", (event) => {
+		if (event.target.id === "nuvio-import-help-modal") {
+			closeNuvioImportHelpModal();
 		}
 	});
 }

--- a/js/bulk-people-lookup.js
+++ b/js/bulk-people-lookup.js
@@ -307,9 +307,7 @@ async function resolveBulkPeople() {
 
 	for (const input of names) {
 		try {
-			const response = await tmdbJsonWithStatus(
-				`https://api.themoviedb.org/3/search/person?api_key=${TMDB_API_KEY}&query=${encodeURIComponent(input)}&page=1`,
-			);
+			const response = await tmdbJsonWithStatus(tmdbApiUrl("/3/search/person", { query: input, page: 1 }));
 
 			if (response.rateLimited) {
 				lastBulkPeopleResults.push({

--- a/js/bulk-people-lookup.js
+++ b/js/bulk-people-lookup.js
@@ -47,7 +47,7 @@ function createNuvioId(prefix) {
 }
 
 function getNuvioTmdbSourceType(sourceType) {
-	return "PERSON";
+	return sourceType === "DIRECTOR" ? "DIRECTOR" : "PERSON";
 }
 
 function getNuvioExportOptions() {

--- a/js/bulk-people-lookup.js
+++ b/js/bulk-people-lookup.js
@@ -1,7 +1,7 @@
 let lastBulkPeopleResults = [];
 
 const DEFAULT_NUVIO_IMAGES = {
-	PERSON: {
+	ACTOR: {
 		coverImageUrl:
 			"https://github.com/davecollections/nuvio-assets/blob/main/assets/collection%20covers/people/actors.jpg?raw=true",
 		folderHeroImageUrl:
@@ -12,6 +12,12 @@ const DEFAULT_NUVIO_IMAGES = {
 			"https://github.com/davecollections/nuvio-assets/blob/main/assets/collection%20covers/people/directors.jpg?raw=true",
 		folderHeroImageUrl:
 			"https://github.com/davecollections/nuvio-assets/blob/main/assets/collection%20covers/people/director%20hero.jpg?raw=true",
+	},
+	PERSON: {
+		coverImageUrl:
+			"https://github.com/davecollections/nuvio-assets/blob/main/assets/collection%20covers/people/people.jpg?raw=true",
+		folderHeroImageUrl:
+			"https://github.com/davecollections/nuvio-assets/blob/main/assets/collection%20covers/people/people%20hero%20backdrop.jpg?raw=true",
 	},
 };
 
@@ -32,20 +38,34 @@ function getMatchedBulkPeopleResults() {
 	return lastBulkPeopleResults.filter((result) => result.id);
 }
 
+function createNuvioId(prefix) {
+	if (window.crypto?.randomUUID) {
+		return window.crypto.randomUUID();
+	}
+
+	return `${prefix}-${Math.random().toString(16).slice(2, 10)}`;
+}
+
+function getNuvioTmdbSourceType(sourceType) {
+	return "PERSON";
+}
+
 function getNuvioExportOptions() {
 	const collectionName =
 		document.getElementById("nuvio-collection-name").value.trim() || "TMDB People Collection";
 	const customCoverImageUrl = document.getElementById("nuvio-cover-image-url").value.trim();
 	const customFolderHeroUrl = document.getElementById("nuvio-folder-hero-url").value.trim();
-	const sourceType = document.getElementById("nuvio-source-type").value || "PERSON";
-	const defaultImages = DEFAULT_NUVIO_IMAGES[sourceType] || DEFAULT_NUVIO_IMAGES.PERSON;
+	const sourceType = document.getElementById("nuvio-source-type").value || "ACTOR";
+	const defaultImages = DEFAULT_NUVIO_IMAGES[sourceType] || DEFAULT_NUVIO_IMAGES.ACTOR;
 
 	return {
 		collectionName,
 		coverImageUrl: customCoverImageUrl || defaultImages.coverImageUrl,
 		folderHeroImageUrl: customFolderHeroUrl || defaultImages.folderHeroImageUrl,
+		hideFolderTitle: document.getElementById("nuvio-hide-folder-title").checked,
 		mediaType: document.getElementById("nuvio-media-type").value || "MOVIE",
 		sourceType,
+		tmdbSourceType: getNuvioTmdbSourceType(sourceType),
 	};
 }
 
@@ -83,14 +103,21 @@ function createNuvioSource(result, options) {
 		filters: {},
 		provider: "tmdb",
 		mediaType: options.mediaType,
-		tmdbSourceType: options.sourceType,
+		tmdbSourceType: options.tmdbSourceType,
 	};
 }
 
 function createNuvioFolder(result, options) {
 	const folder = {
+		id: createNuvioId("folder"),
 		title: result.name,
 		sources: [createNuvioSource(result, options)],
+		hideTitle: options.hideFolderTitle,
+		tileShape: "POSTER",
+		coverEmoji: "",
+		focusGifUrl: "",
+		heroVideoUrl: "",
+		titleLogoUrl: "",
 	};
 
 	if (result.profileImageUrl) {
@@ -98,8 +125,11 @@ function createNuvioFolder(result, options) {
 	}
 
 	if (options.folderHeroImageUrl) {
-		folder.backdropImageUrl = options.folderHeroImageUrl;
+		folder.heroBackdropUrl = options.folderHeroImageUrl;
 	}
+
+	folder.catalogSources = [];
+	folder.focusGifEnabled = false;
 
 	return folder;
 }
@@ -108,12 +138,18 @@ function createNuvioCollectionJson() {
 	const options = getNuvioExportOptions();
 	const matchedPeople = getMatchedBulkPeopleResults();
 
-	return {
+	const collection = {
+		id: createNuvioId("collection"),
 		title: options.collectionName,
-		name: options.collectionName,
-		coverImageUrl: options.coverImageUrl,
 		folders: matchedPeople.map((result) => createNuvioFolder(result, options)),
+		pinToTop: false,
+		viewMode: "TABBED_GRID",
+		showAllTab: false,
+		backdropImageUrl: options.coverImageUrl,
+		focusGlowEnabled: true,
 	};
+
+	return [collection];
 }
 
 function downloadNuvioJson() {

--- a/js/bulk-people-lookup.js
+++ b/js/bulk-people-lookup.js
@@ -1,5 +1,9 @@
 let lastBulkPeopleResults = [];
 
+function getTmdbProfileImageUrl(profilePath) {
+	return profilePath ? `https://image.tmdb.org/t/p/w500${profilePath}` : "";
+}
+
 function getBulkPeopleNames() {
 	return document
 		.getElementById("bulk-people-input")
@@ -83,7 +87,16 @@ function downloadBulkPeopleCsv(mode) {
 		return;
 	}
 
-	const headers = ["input", "matched_name", "tmdb_person_id", "known_for", "credit_count", "match_type"];
+	const headers = [
+		"input",
+		"matched_name",
+		"tmdb_person_id",
+		"known_for",
+		"credit_count",
+		"profile_path",
+		"profile_image_url",
+		"match_type",
+	];
 
 	const csv =
 		headers.join(",") +
@@ -96,6 +109,8 @@ function downloadBulkPeopleCsv(mode) {
 					result.id || "",
 					result.knownFor || "",
 					result.creditCount || "",
+					result.profilePath || "",
+					result.profileImageUrl || "",
 					result.status,
 				]
 					.map(csvEscape)
@@ -177,6 +192,8 @@ async function resolveBulkPeople() {
 					id: "",
 					knownFor: "",
 					creditCount: "",
+					profilePath: "",
+					profileImageUrl: "",
 					status: "TMDB rate limit reached",
 				});
 
@@ -190,6 +207,8 @@ async function resolveBulkPeople() {
 					id: "",
 					knownFor: "",
 					creditCount: "",
+					profilePath: "",
+					profileImageUrl: "",
 					status: response.status ? `TMDB error HTTP ${response.status}` : "Network error",
 				});
 
@@ -207,6 +226,8 @@ async function resolveBulkPeople() {
 					id: match.person.id,
 					knownFor: match.person.known_for_department || "\u2014",
 					creditCount: knownCredits,
+					profilePath: match.person.profile_path || "",
+					profileImageUrl: getTmdbProfileImageUrl(match.person.profile_path),
 					status: match.matchType,
 				});
 			} else {
@@ -216,6 +237,8 @@ async function resolveBulkPeople() {
 					id: "",
 					knownFor: "",
 					creditCount: "",
+					profilePath: "",
+					profileImageUrl: "",
 					status: match.matchType,
 				});
 			}
@@ -226,6 +249,8 @@ async function resolveBulkPeople() {
 				id: "",
 				knownFor: "",
 				creditCount: "",
+				profilePath: "",
+				profileImageUrl: "",
 				status: "Lookup failed",
 			});
 		}

--- a/js/bulk-people-lookup.js
+++ b/js/bulk-people-lookup.js
@@ -1,7 +1,107 @@
 let lastBulkPeopleResults = [];
 
+const DEFAULT_NUVIO_IMAGES = {
+	PERSON: {
+		coverImageUrl:
+			"https://github.com/davecollections/nuvio-assets/blob/main/assets/collection%20covers/people/actors.jpg?raw=true",
+		folderHeroImageUrl:
+			"https://github.com/davecollections/nuvio-assets/blob/main/assets/collection%20covers/people/actor%20hero.jpg?raw=true",
+	},
+	DIRECTOR: {
+		coverImageUrl:
+			"https://github.com/davecollections/nuvio-assets/blob/main/assets/collection%20covers/people/directors.jpg?raw=true",
+		folderHeroImageUrl:
+			"https://github.com/davecollections/nuvio-assets/blob/main/assets/collection%20covers/people/director%20hero.jpg?raw=true",
+	},
+};
+
 function getTmdbProfileImageUrl(profilePath) {
 	return profilePath ? `https://image.tmdb.org/t/p/w500${profilePath}` : "";
+}
+
+function slugifyFilename(value) {
+	return (
+		String(value || "nuvio-people-collection")
+			.toLowerCase()
+			.replace(/[^a-z0-9]+/g, "-")
+			.replace(/^-+|-+$/g, "") || "nuvio-people-collection"
+	);
+}
+
+function getMatchedBulkPeopleResults() {
+	return lastBulkPeopleResults.filter((result) => result.id);
+}
+
+function getNuvioExportOptions() {
+	const collectionName =
+		document.getElementById("nuvio-collection-name").value.trim() || "TMDB People Collection";
+	const customCoverImageUrl = document.getElementById("nuvio-cover-image-url").value.trim();
+	const customFolderHeroUrl = document.getElementById("nuvio-folder-hero-url").value.trim();
+	const sourceType = document.getElementById("nuvio-source-type").value || "PERSON";
+	const defaultImages = DEFAULT_NUVIO_IMAGES[sourceType] || DEFAULT_NUVIO_IMAGES.PERSON;
+
+	return {
+		collectionName,
+		coverImageUrl: customCoverImageUrl || defaultImages.coverImageUrl,
+		folderHeroImageUrl: customFolderHeroUrl || defaultImages.folderHeroImageUrl,
+		mediaType: document.getElementById("nuvio-media-type").value || "MOVIE",
+		sourceType,
+	};
+}
+
+function createNuvioSource(result, options) {
+	return {
+		title: result.name,
+		sortBy: "popularity.desc",
+		tmdbId: Number(result.id),
+		filters: {},
+		provider: "tmdb",
+		mediaType: options.mediaType,
+		tmdbSourceType: options.sourceType,
+	};
+}
+
+function createNuvioFolder(result, options) {
+	const folder = {
+		title: result.name,
+		sources: [createNuvioSource(result, options)],
+	};
+
+	if (result.profileImageUrl) {
+		folder.coverImageUrl = result.profileImageUrl;
+	}
+
+	if (options.folderHeroImageUrl) {
+		folder.backdropImageUrl = options.folderHeroImageUrl;
+	}
+
+	return folder;
+}
+
+function createNuvioCollectionJson() {
+	const options = getNuvioExportOptions();
+	const matchedPeople = getMatchedBulkPeopleResults();
+
+	return {
+		title: options.collectionName,
+		name: options.collectionName,
+		coverImageUrl: options.coverImageUrl,
+		folders: matchedPeople.map((result) => createNuvioFolder(result, options)),
+	};
+}
+
+function downloadNuvioJson() {
+	const matchedPeople = getMatchedBulkPeopleResults();
+
+	if (!matchedPeople.length) {
+		return;
+	}
+
+	const options = getNuvioExportOptions();
+	const json = JSON.stringify(createNuvioCollectionJson(), null, "\t");
+	const filename = `${slugifyFilename(options.collectionName)}.nuvio.json`;
+
+	downloadTextFile(filename, `${json}\n`, "application/json");
 }
 
 function getBulkPeopleNames() {
@@ -273,6 +373,17 @@ async function resolveBulkPeople() {
 		downloadButton.addEventListener("click", () => downloadBulkPeopleCsv("people"));
 		status.appendChild(document.createTextNode(" "));
 		status.appendChild(downloadButton);
+
+		const nuvioJsonButton = createElement("button", {
+			text: "Download Nuvio JSON",
+			attrs: {
+				type: "button",
+			},
+		});
+
+		nuvioJsonButton.addEventListener("click", downloadNuvioJson);
+		status.appendChild(document.createTextNode(" "));
+		status.appendChild(nuvioJsonButton);
 	}
 }
 

--- a/js/config.js
+++ b/js/config.js
@@ -1,4 +1,5 @@
 const TMDB_API_KEY = "__TMDB_API_KEY__";
+const TMDB_PROXY_BASE_URL = "https://tmdb-id-lookup-proxy.dpegan20.workers.dev";
 const CACHE_VERSION = "__APP_ASSET_VERSION__";
 
 const countryDisplayNames =

--- a/js/tmdb-api.js
+++ b/js/tmdb-api.js
@@ -1,3 +1,28 @@
+function hasConfiguredTmdbProxy() {
+	return TMDB_PROXY_BASE_URL && !TMDB_PROXY_BASE_URL.includes("__");
+}
+
+function hasConfiguredTmdbApiKey() {
+	return TMDB_API_KEY && !TMDB_API_KEY.includes("__");
+}
+
+function tmdbApiUrl(path, params = {}) {
+	const baseUrl = hasConfiguredTmdbProxy() ? TMDB_PROXY_BASE_URL : "https://api.themoviedb.org";
+	const url = new URL(path, baseUrl);
+
+	Object.entries(params).forEach(([key, value]) => {
+		if (value !== undefined && value !== null && value !== "") {
+			url.searchParams.set(key, value);
+		}
+	});
+
+	if (!hasConfiguredTmdbProxy() && hasConfiguredTmdbApiKey()) {
+		url.searchParams.set("api_key", TMDB_API_KEY);
+	}
+
+	return url.toString();
+}
+
 async function tmdbJson(url) {
 	const res = await fetch(url);
 
@@ -48,9 +73,7 @@ async function tmdbJsonWithStatus(url) {
 
 async function getPersonKnownCredits(personId) {
 	try {
-		const credits = await tmdbJson(
-			`https://api.themoviedb.org/3/person/${personId}/combined_credits?api_key=${TMDB_API_KEY}`,
-		);
+		const credits = await tmdbJson(tmdbApiUrl(`/3/person/${personId}/combined_credits`));
 
 		if (!credits) {
 			return "\u2014";

--- a/js/tmdb-lookup.js
+++ b/js/tmdb-lookup.js
@@ -120,7 +120,7 @@ function personCard(person, knownCredits = "\u2014") {
 }
 
 async function getCollectionMovieCount(collectionId) {
-	const detailData = await tmdbJson(`https://api.themoviedb.org/3/collection/${collectionId}?api_key=${TMDB_API_KEY}`);
+	const detailData = await tmdbJson(tmdbApiUrl(`/3/collection/${collectionId}`));
 
 	if (!detailData || detailData.success === false) {
 		return null;
@@ -231,7 +231,7 @@ async function searchTmdbIds(page = 1) {
 			}
 
 			if (currentTmdbFilter === "all" || currentTmdbFilter === "actors" || currentTmdbFilter === "directors") {
-				const person = await tmdbJson(`https://api.themoviedb.org/3/person/${query}?api_key=${TMDB_API_KEY}`);
+				const person = await tmdbJson(tmdbApiUrl(`/3/person/${query}`));
 
 				if (person && person.success !== false) {
 					const isActor = person.known_for_department === "Acting";
@@ -250,13 +250,9 @@ async function searchTmdbIds(page = 1) {
 				}
 			}
 		} else {
-			const collectionSearch = await tmdbJson(
-				`https://api.themoviedb.org/3/search/collection?api_key=${TMDB_API_KEY}&query=${encodeURIComponent(query)}&page=${page}`,
-			);
+			const collectionSearch = await tmdbJson(tmdbApiUrl("/3/search/collection", { query, page }));
 
-			const personSearch = await tmdbJson(
-				`https://api.themoviedb.org/3/search/person?api_key=${TMDB_API_KEY}&query=${encodeURIComponent(query)}&page=${page}`,
-			);
+			const personSearch = await tmdbJson(tmdbApiUrl("/3/search/person", { query, page }));
 
 			const lookupResultLimit = getLookupResultLimit();
 


### PR DESCRIPTION
Closes #8.

Summary:
- Adds Nuvio JSON export for matched Bulk People Lookup results.
- Adds Actors, Directors, and People export presets with default collection/hero artwork.
- Routes TMDB API requests through the Cloudflare Worker proxy.
- Adds profile image URLs to bulk people results and CSV export.
- Adds compact Nuvio export modal, image previews, hide-title toggle, and import help popup.
- Creates Nuvio-compatible collections JSON arrays for import into Nuvio.

Tested:
- TMDB lookup through Cloudflare Worker.
- Bulk People Lookup with matched people.
- CSV export still works.
- Nuvio JSON export imports successfully into Nuvio.
- Nuvio import help popup opens/closes correctly.
- `node --check js/bulk-people-lookup.js`
- `node --check js/tmdb-api.js`
- `node --check js/tmdb-lookup.js`
- `git diff --check`