### PR TITLE
Add v2 collection compatibility regression corpus

### DIFF
--- a/docs/v2/BUILDER_KNOWLEDGE.md
+++ b/docs/v2/BUILDER_KNOWLEDGE.md
@@ -380,7 +380,20 @@ All four issue #38 evidence JSON files, including the untouched owner export, ar
 - A Nuvio.tv account-management profile export removed provider/region and U1–U6 fields, changed S2/S3/S5/S8 sorts, retained S4/S4C/S6/S6C/S7, and added structural/default fields. The responsible layer was not isolated, so this remains pipeline evidence rather than attribution to iOS sync, account storage, web normalization, or export serialization.
 - Direct TMDB evidence remains pending because no local bearer token was available. The offline plan contains exactly 60 bounded requests at its hard cap, including exact US/AU provider-8 effective-query shapes and the required all-monetization union on every provider case; no live request is part of repository checks.
 
-## 14. Open questions
+## 14. V2 collection compatibility regression corpus — issue #49
+
+**Confirmed by repository tests — issue [#49](https://github.com/davecollections/tmdb-id-lookup/issues/49), 2026-07-24:** the builder now has a small, manifest-driven, file-backed compatibility corpus that connects the existing focused import, domain, migration, serialization, validation, ID, and controller contracts without changing production modules.
+
+- Eight manifest entries separate canonical, preservation, identity, migration, and invalid pipelines and record counts, exact traversal/projection order, diagnostics, assertion mode, field policy, coverage tags, and references to existing Discover and migration evidence.
+- The compact canonical profile covers all seven supported native TMDB types across the evidence-backed Movie/TV combinations plus basic, genre, multiple, and duplicate-identity addon projections in two ordered collections, three folders, and fifteen sources.
+- The comprehensive preservation profile combines native, addon, imported Trakt, and opaque/community evidence across two collections, three folders, and six sources. It covers presentation/artwork fields, raw-only collection/source fields, unknown fields at every supported preservation level, missing/null/empty/false/zero distinctions, Discover-filter replacement, and stable second-cycle serialization.
+- File-backed identity cases distinguish permissive direct import from deterministic controller repair of missing, invalid, whitespace-padded, non-string, and duplicate collection/folder IDs. Builder-only internal IDs remain unique and absent from output, while serializer-required ID/title diagnostics stay explicit.
+- A controller removal/insertion case proves stable unaffected-source order, removal of the deleted source and its raw evidence, and no transfer of that evidence to the inserted source or projection.
+- The corpus reuses the issue #37/#38 projection-only addon migration and Desktop artifacts, asserting deterministic promotion order, exact `"None"` to `null` normalization, unknown projection preservation, and migration idempotence. It also reuses the issue #31 invalid fixtures instead of duplicating them.
+- Ten focused tests validate the manifest, fixture coverage, taxonomy, safety, Pages exclusion, exact/semantic/targeted policies, round trips, migration, and validation diagnostics. No production module, dependency, v1 runtime, Worker, route, or deployment policy changed.
+- No confirmed source-artwork field exists in current repository or client evidence. The corpus records that boundary and does not invent one.
+
+## 15. Open questions
 
 - Can a future Nuvio source model support direct individual movies or series?
 - Can multiple direct item references ever be exposed as a folder source?
@@ -390,7 +403,7 @@ All four issue #38 evidence JSON files, including the untouched owner export, ar
 - How should known TMDB list IDs be validated?
 - How should future public TMDB list search slot into the architecture?
 
-## 15. Update rules
+## 16. Update rules
 
 - Update this file when a test becomes confirmed or disproved.
 - Include the evidence level, review/test date, and source.
@@ -427,6 +440,7 @@ All four issue #38 evidence JSON files, including the untouched owner export, ar
 | 2026-07-21 | Shared pure artwork validation, resolution, loading, in-memory caching, retry, and offline fixture behaviour | [TMDB ID Lookup issue #45](https://github.com/davecollections/tmdb-id-lookup/issues/45) |
 | 2026-07-22 | V1 company/network lazy runtime consumption, automatic curated/TMDB/emoji fallback, async preparation, Copy/Download parity, and focus-GIF removal | [TMDB ID Lookup issue #46](https://github.com/davecollections/tmdb-id-lookup/issues/46) |
 | 2026-07-23 | Official TMDB Discover inventory/OAS, pinned NuvioTV `dev` and `0.7.19-beta`, pinned NuvioMobile `cmp-rewrite` and `0.3.1`, builder preservation audit, normalized compatibility matrix, bounded manual/direct test plans, and 29/29 owner observations on Desktop alpha plus retained official iOS | [TMDB ID Lookup issue #47](https://github.com/davecollections/tmdb-id-lookup/issues/47), [`TMDB_DISCOVER_COMPATIBILITY.md`](./TMDB_DISCOVER_COMPATIBILITY.md), and [`OWNER_RESULTS_2026-07-23.md`](../../manual-tests/tmdb-discover/OWNER_RESULTS_2026-07-23.md) |
+| 2026-07-24 | Manifest-driven canonical, preservation, identity, migration, and invalid profile corpus connecting current builder compatibility contracts without production changes | [TMDB ID Lookup issue #49](https://github.com/davecollections/tmdb-id-lookup/issues/49) and [`v2-compatibility/README.md`](../../tests/fixtures/nuvio/v2-compatibility/README.md) |
 
 ## Decision history
 
@@ -448,3 +462,4 @@ All four issue #38 evidence JSON files, including the untouched owner export, ar
 - **2026-07-22 — V1 automatic artwork refinement:** remove runtime-facing artwork controls and permanent status panels; automatically prefer published curated landscape artwork, then cached TMDB logos with visible titles, then title/emoji; degrade runtime failures into valid fallback exports; keep transient preparation feedback and Copy/Download parity; and leave the shared runtime, people migration, v2 integration, and tomato provenance question unchanged.
 - **2026-07-23 — Discover compatibility boundary:** treat official TMDB acceptance, client deserialization, request construction, hidden transformations, persistence, direct result effects, and visible device effects as separate evidence levels; retain the 14-field production contract unchanged; use the generated row-level matrix as the normalized research source; and defer all UI/schema expansion until bounded owner evidence and a separately approved issue.
 - **2026-07-23 — Discover owner-evidence checkpoint:** retain the official counts, 14-field contract, and static mappings; record the complete Desktop alpha and retained official iOS runs as build-specific observations; add a deterministic one-source-per-folder presentation without changing source identity or aggregate counts; keep NuvioTV/direct TMDB pending; and attribute account-export changes only to the observed pipeline until its responsible layer is isolated.
+- **2026-07-24 — Profile-level compatibility corpus:** connect existing focused builder contracts through a small manifest-driven fixture taxonomy; use exact equality only for intentional canonical output, semantic cycle stability for preservation profiles, and targeted assertions for identity, removal, migration, and invalid boundaries; reuse the existing Discover and addon-migration artifacts; and retain a strict test-only production boundary.

--- a/scripts/check-all.mjs
+++ b/scripts/check-all.mjs
@@ -16,6 +16,7 @@ runNode(["--test", path.join("tests", "pages-public-paths.test.mjs")]);
 runNode(["--test", path.join("tests", "artwork-runtime.test.mjs")]);
 runNode(["--test", path.join("tests", "cached-nuvio-export.test.mjs")]);
 runNode(["--test", path.join("tests", "nuvio-contracts.test.mjs")]);
+runNode(["--test", path.join("tests", "builder-compatibility-corpus.test.mjs")]);
 runNode(["--test", path.join("tests", "tmdb-discover-compatibility.test.mjs")]);
 runNode(["--test", path.join("tests", "builder-domain.test.mjs")]);
 runNode(["--test", path.join("tests", "builder-import.test.mjs")]);

--- a/tests/builder-compatibility-corpus.test.mjs
+++ b/tests/builder-compatibility-corpus.test.mjs
@@ -1,0 +1,734 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { createBuilderController } from "../builder/src/application/index.js";
+import {
+	checkInternalIdUniqueness,
+	SOURCE_CATEGORIES,
+	updateEditableValues,
+} from "../builder/src/domain/index.js";
+import { importNuvioCollections } from "../builder/src/import/index.js";
+import { migrateLegacyAddonProjections } from "../builder/src/migrate/index.js";
+import { serializeNuvioProject } from "../builder/src/serialize/index.js";
+import { isPagesPublicFilePath } from "../scripts/pages-public-paths.mjs";
+import {
+	NATIVE_TMDB_SOURCE_TYPES,
+	validateNuvioContract,
+} from "./helpers/nuvio-contract-validator.mjs";
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const fixtureRoot = path.join(rootDir, "tests", "fixtures", "nuvio");
+const corpusRoot = path.join(fixtureRoot, "v2-compatibility");
+const manifestPath = path.join(corpusRoot, "manifest.json");
+const manifest = readJson(manifestPath);
+const allowedCategories = new Set(["canonical", "preservation", "identity", "migration", "invalid"]);
+const allowedPipelines = new Set(["direct-importer", "builder-controller", "migration", "validation-only"]);
+const allowedAssertionModes = new Set(["exact-json", "semantic-equality", "targeted"]);
+const fieldPolicyKeys = [
+	"builderOwnedOverlaid",
+	"canonicalizedDefaulted",
+	"copiedCanonicalData",
+	"rawPreservedOnly",
+	"removed",
+];
+const requiredMediaCombinations = [
+	"LIST:MOVIE",
+	"LIST:TV",
+	"COLLECTION:MOVIE",
+	"COMPANY:MOVIE",
+	"NETWORK:TV",
+	"DISCOVER:MOVIE",
+	"DISCOVER:TV",
+	"PERSON:MOVIE",
+	"PERSON:TV",
+	"DIRECTOR:MOVIE",
+	"DIRECTOR:TV",
+];
+const requiredCoverageTags = [
+	"all-seven-native-types",
+	"evidence-backed-media",
+	"addon-basic",
+	"addon-genre",
+	"addon-multiple",
+	"addon-projection",
+	"projection-order",
+	"addon-metadata",
+	"duplicate-projection-identity",
+	"mixed-native-addon-opaque",
+	"imported-trakt",
+	"opaque-community",
+	"multiple-collections",
+	"multiple-folders",
+	"multiple-sources",
+	"presentation",
+	"folder-artwork",
+	"raw-only-collection-fields",
+	"raw-only-source-fields",
+	"unknown-collection",
+	"unknown-folder",
+	"unknown-source",
+	"unknown-filter",
+	"unknown-projection",
+	"missing-null-empty-false-zero",
+	"editable-over-raw",
+	"discover-filter-replacement",
+	"direct-import-ids",
+	"controller-id-repair",
+	"internal-id-uniqueness",
+	"serializer-required-text",
+	"source-removal",
+	"ordering",
+	"round-trip",
+	"migration",
+	"migration-idempotence",
+	"invalid",
+	"unsupported-direct-media",
+	"native-projection-boundary",
+	"addon-projection-boundary",
+	"discover-reference",
+	"migration-reference",
+	"source-artwork-boundary",
+];
+
+function readJson(file) {
+	return JSON.parse(fs.readFileSync(file, "utf8"));
+}
+
+function entryById(id) {
+	const entry = manifest.entries.find((candidate) => candidate.id === id);
+	assert.ok(entry, `Missing manifest entry: ${id}`);
+	return entry;
+}
+
+function fixturePath(relativePath) {
+	const resolved = path.resolve(fixtureRoot, ...relativePath.split("/"));
+	assert.ok(
+		resolved.startsWith(`${path.resolve(fixtureRoot)}${path.sep}`),
+		`Fixture path escapes tests/fixtures/nuvio: ${relativePath}`,
+	);
+	return resolved;
+}
+
+function loadEntry(entry) {
+	return readJson(fixturePath(entry.input));
+}
+
+function countingIdFactory(prefix = "internal") {
+	let index = 0;
+	return () => `${prefix}-${++index}`;
+}
+
+function sequenceIdFactory(...ids) {
+	let index = 0;
+	return () => {
+		if (index >= ids.length) {
+			throw new Error("Deterministic ID sequence exhausted.");
+		}
+		return ids[index++];
+	};
+}
+
+function codes(diagnostics) {
+	return diagnostics.map((diagnostic) => diagnostic.code);
+}
+
+function sourceIdentity(source) {
+	const provider = typeof source.provider === "string"
+		? source.provider.toLowerCase()
+		: (source.addonId ? "addon" : "");
+	if (provider === "tmdb") {
+		return `tmdb:${source.tmdbSourceType ?? ""}:${source.tmdbId ?? ""}:${source.mediaType ?? ""}`;
+	}
+	if (provider === "addon") {
+		return `addon:${source.addonId ?? ""}:${source.type ?? ""}:${source.catalogId ?? ""}:${source.genre ?? ""}`;
+	}
+	return `opaque:${source.provider ?? ""}:${source.type ?? ""}:${source.traktListId ?? source.catalogId ?? ""}:${source.title ?? ""}`;
+}
+
+function allFolders(collections) {
+	return collections.flatMap((collection) => collection.folders);
+}
+
+function countsFor(collections) {
+	const folders = allFolders(collections);
+	return {
+		collections: collections.length,
+		folders: folders.length,
+		sources: folders.reduce((total, folder) => total + (folder.sources ?? []).length, 0),
+		projections: folders.reduce((total, folder) => total + (folder.catalogSources ?? []).length, 0),
+	};
+}
+
+function assertValueContract(collections, entry, expectedCounts = entry.expectedCounts, expectedOrder = entry.expectedOrder) {
+	assert.deepEqual(countsFor(collections), expectedCounts, `${entry.id} counts`);
+	assert.deepEqual(
+		collections.map((collection) => collection.id),
+		expectedOrder.collections,
+		`${entry.id} collection order`,
+	);
+	for (const collection of collections) {
+		assert.deepEqual(
+			collection.folders.map((folder) => folder.id),
+			expectedOrder.foldersByCollection[collection.id],
+			`${entry.id} folder order for ${collection.id}`,
+		);
+		for (const folder of collection.folders) {
+			assert.deepEqual(
+				(folder.sources ?? []).map(sourceIdentity),
+				expectedOrder.sourcesByFolder[folder.id],
+				`${entry.id} source order for ${folder.id}`,
+			);
+			assert.deepEqual(
+				(folder.catalogSources ?? []).map(sourceIdentity),
+				expectedOrder.projectionsByFolder[folder.id],
+				`${entry.id} projection order for ${folder.id}`,
+			);
+		}
+	}
+}
+
+function assertDiagnosticShape(diagnostic, label) {
+	assert.deepEqual(Object.keys(diagnostic).sort(), ["code", "message", "path"], label);
+	assert.equal(typeof diagnostic.code, "string", label);
+	assert.equal(typeof diagnostic.path, "string", label);
+	assert.equal(typeof diagnostic.message, "string", label);
+}
+
+function listFiles(directory) {
+	return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+		const entryPath = path.join(directory, entry.name);
+		return entry.isDirectory() ? listFiles(entryPath) : [entryPath];
+	});
+}
+
+function relativeFromRoot(file) {
+	return path.relative(rootDir, file).replaceAll("\\", "/");
+}
+
+function relativeFromFixtureRoot(file) {
+	return path.relative(fixtureRoot, file).replaceAll("\\", "/");
+}
+
+test("manifest is deterministic complete and references every corpus fixture exactly once", () => {
+	assert.equal(manifest.version, 1);
+	assert.equal(manifest.issue, "https://github.com/davecollections/tmdb-id-lookup/issues/49");
+	assert.ok(manifest.inventory);
+	assert.equal(
+		manifest.inventory.deferredBoundaries.sourceArtwork,
+		"No confirmed source-artwork field exists in current repository or client evidence; no source artwork field is created or asserted.",
+	);
+	assert.ok(Array.isArray(manifest.entries));
+	assert.ok(manifest.entries.length >= 8);
+
+	const ids = new Set();
+	const inputPaths = new Set();
+	const referencedFixturePaths = new Set();
+	const coverageTags = new Set();
+	const representedNativeTypes = new Set();
+	const representedMediaCombinations = new Set();
+	const categories = new Set();
+
+	for (const entry of manifest.entries) {
+		assert.equal(typeof entry.id, "string");
+		assert.equal(ids.has(entry.id), false, `Duplicate fixture ID: ${entry.id}`);
+		ids.add(entry.id);
+
+		assert.ok(allowedCategories.has(entry.category), `${entry.id} category`);
+		assert.ok(allowedPipelines.has(entry.pipeline), `${entry.id} pipeline`);
+		assert.ok(allowedAssertionModes.has(entry.assertionMode), `${entry.id} assertion mode`);
+		assert.equal(typeof entry.purpose, "string", `${entry.id} purpose`);
+		assert.ok(entry.purpose.length > 0, `${entry.id} purpose`);
+		categories.add(entry.category);
+
+		assert.equal(typeof entry.input, "string", `${entry.id} input`);
+		assert.equal(inputPaths.has(entry.input), false, `Duplicate input path: ${entry.input}`);
+		inputPaths.add(entry.input);
+		referencedFixturePaths.add(entry.input);
+		assert.ok(fs.statSync(fixturePath(entry.input), { throwIfNoEntry: false })?.isFile(), `${entry.id} input`);
+
+		for (const key of ["sourceTypes", "mediaCombinations", "coverageTags", "evidenceReferences"]) {
+			assert.ok(Array.isArray(entry[key]), `${entry.id} ${key}`);
+		}
+		for (const nativeType of entry.sourceTypes.filter((value) => NATIVE_TMDB_SOURCE_TYPES.has(value))) {
+			representedNativeTypes.add(nativeType);
+		}
+		for (const mediaCombination of entry.mediaCombinations) {
+			representedMediaCombinations.add(mediaCombination);
+		}
+		for (const tag of entry.coverageTags) {
+			coverageTags.add(tag);
+		}
+
+		for (const countKey of ["collections", "folders", "sources", "projections"]) {
+			assert.ok(Number.isInteger(entry.expectedCounts[countKey]), `${entry.id} expectedCounts.${countKey}`);
+			assert.ok(entry.expectedCounts[countKey] >= 0, `${entry.id} expectedCounts.${countKey}`);
+		}
+		assert.deepEqual(
+			Object.keys(entry.materialFieldPolicy).sort(),
+			[...fieldPolicyKeys].sort(),
+			`${entry.id} material field policy`,
+		);
+		for (const key of fieldPolicyKeys) {
+			assert.ok(Array.isArray(entry.materialFieldPolicy[key]), `${entry.id} materialFieldPolicy.${key}`);
+		}
+
+		for (const key of ["importErrors", "importWarnings", "serializeErrors", "serializeWarnings", "validationErrors"]) {
+			assert.ok(Array.isArray(entry.expectedDiagnostics[key]), `${entry.id} expectedDiagnostics.${key}`);
+		}
+
+		for (const reference of entry.evidenceReferences) {
+			const evidencePath = path.resolve(rootDir, ...reference.split("/"));
+			assert.ok(
+				evidencePath.startsWith(`${path.resolve(rootDir)}${path.sep}`),
+				`${entry.id} evidence escapes the repository`,
+			);
+			assert.ok(fs.existsSync(evidencePath), `${entry.id} missing evidence: ${reference}`);
+		}
+	}
+
+	assert.deepEqual([...categories].sort(), [...allowedCategories].sort());
+	assert.deepEqual(
+		[...representedNativeTypes].sort(),
+		[...NATIVE_TMDB_SOURCE_TYPES].sort(),
+	);
+	for (const requiredCombination of requiredMediaCombinations) {
+		assert.ok(
+			representedMediaCombinations.has(requiredCombination),
+			`Missing evidence-backed media combination: ${requiredCombination}`,
+		);
+	}
+	for (const requiredTag of requiredCoverageTags) {
+		assert.ok(coverageTags.has(requiredTag), `Missing coverage tag: ${requiredTag}`);
+	}
+
+	const localJsonFiles = listFiles(corpusRoot)
+		.filter((file) => file.endsWith(".json") && file !== manifestPath)
+		.map(relativeFromFixtureRoot)
+		.sort();
+	const representedLocalJson = [...referencedFixturePaths]
+		.filter((relativePath) => relativePath.startsWith("v2-compatibility/"))
+		.sort();
+	assert.deepEqual(representedLocalJson, localJsonFiles);
+});
+
+test("corpus files are synthetic secret-free offline inputs outside the Pages public contract", () => {
+	const localFiles = listFiles(corpusRoot);
+	const forbiddenSecretPattern = /\b(?:api[_-]?key|authorization|bearer|password|secret|token)\b/i;
+	const windowsAbsolutePathPattern = /(?:^|[\s"'(])[A-Za-z]:[\\/]/m;
+
+	for (const file of localFiles) {
+		const repositoryPath = relativeFromRoot(file);
+		assert.equal(isPagesPublicFilePath(repositoryPath), false, repositoryPath);
+		if (file.endsWith(".json") && file !== manifestPath) {
+			const text = fs.readFileSync(file, "utf8");
+			assert.equal(forbiddenSecretPattern.test(text), false, repositoryPath);
+			assert.equal(windowsAbsolutePathPattern.test(text), false, repositoryPath);
+			visitJson(readJson(file), (value) => {
+				if (typeof value !== "string" || !/^https?:\/\//i.test(value)) {
+					return;
+				}
+				assert.equal(new URL(value).hostname, "example.invalid", `${repositoryPath}: ${value}`);
+			});
+		}
+	}
+
+	assert.equal(isPagesPublicFilePath("tests/builder-compatibility-corpus.test.mjs"), false);
+	assert.equal(isPagesPublicFilePath("manual-tests/tmdb-discover/fixture-manifest.json"), false);
+	assert.equal(isPagesPublicFilePath("manual-tests/nuvio-desktop/addon-projection-migration/builder-migrated-input.json"), false);
+});
+
+test("canonical profile imports classifies serializes and cycles with exact ordered JSON", () => {
+	const entry = entryById("canonical-native-addon-profile");
+	const input = loadEntry(entry);
+	const imported = importNuvioCollections(input, { idFactory: countingIdFactory() });
+
+	assert.equal(imported.ok, true, JSON.stringify(imported.errors));
+	assert.deepEqual(codes(imported.errors), entry.expectedDiagnostics.importErrors);
+	assert.deepEqual(codes(imported.warnings), entry.expectedDiagnostics.importWarnings);
+	assert.equal(checkInternalIdUniqueness(imported.project).unique, true);
+
+	const categories = imported.project.collections.flatMap((collection) => (
+		collection.folders.flatMap((folder) => folder.sources.map((source) => source.category))
+	));
+	assert.equal(categories.filter((category) => category === SOURCE_CATEGORIES.NATIVE_TMDB).length, 11);
+	assert.equal(categories.filter((category) => category === SOURCE_CATEGORIES.ADDON).length, 4);
+	assert.equal(categories.includes(SOURCE_CATEGORIES.OPAQUE), false);
+
+	const serializedA = serializeNuvioProject(imported.project);
+	assert.equal(serializedA.ok, true, JSON.stringify(serializedA.errors));
+	assert.deepEqual(codes(serializedA.errors), entry.expectedDiagnostics.serializeErrors);
+	assert.deepEqual(codes(serializedA.warnings), entry.expectedDiagnostics.serializeWarnings);
+	assertValueContract(serializedA.value, entry);
+	assert.deepEqual(serializedA.value, input);
+	assert.equal(validateNuvioContract(serializedA.value, { mode: "canonical-builder-output" }).valid, true);
+
+	const importedAgain = importNuvioCollections(serializedA.value, { idFactory: countingIdFactory("cycle") });
+	const serializedB = serializeNuvioProject(importedAgain.project);
+	assert.equal(serializedB.ok, true, JSON.stringify(serializedB.errors));
+	assert.deepEqual(serializedB.value, serializedA.value);
+
+	const duplicateProjections = serializedA.value[1].folders[0].catalogSources.slice(2);
+	assert.deepEqual(duplicateProjections.map((projection) => projection.unknownProjectionOrder), ["first", "second"]);
+});
+
+test("preservation profile cycles stably with exact classification counts and ordering", () => {
+	const entry = entryById("preservation-comprehensive-profile");
+	const input = loadEntry(entry);
+	const imported = importNuvioCollections(input, { idFactory: countingIdFactory() });
+
+	assert.equal(imported.ok, true, JSON.stringify(imported.errors));
+	assert.deepEqual(codes(imported.errors), entry.expectedDiagnostics.importErrors);
+	assert.deepEqual(codes(imported.warnings), entry.expectedDiagnostics.importWarnings);
+	assert.deepEqual(
+		imported.project.collections[0].folders[0].sources.map((source) => source.category),
+		["native-tmdb", "addon", "opaque", "addon", "opaque"],
+	);
+
+	const serializedA = serializeNuvioProject(imported.project);
+	assert.equal(serializedA.ok, true, JSON.stringify(serializedA.errors));
+	assert.deepEqual(codes(serializedA.warnings), entry.expectedDiagnostics.serializeWarnings);
+	assertValueContract(serializedA.value, entry);
+	assert.equal(validateNuvioContract(serializedA.value, { mode: "import-preservation" }).valid, true);
+
+	const importedAgain = importNuvioCollections(serializedA.value, { idFactory: countingIdFactory("cycle") });
+	assert.equal(importedAgain.ok, true, JSON.stringify(importedAgain.errors));
+	const serializedB = serializeNuvioProject(importedAgain.project);
+	assert.equal(serializedB.ok, true, JSON.stringify(serializedB.errors));
+	assert.deepEqual(serializedB.value, serializedA.value);
+});
+
+test("preservation overlays retain raw evidence and replace only recognized Discover filters", () => {
+	const entry = entryById("preservation-comprehensive-profile");
+	const imported = importNuvioCollections(loadEntry(entry), { idFactory: countingIdFactory() });
+	let project = imported.project;
+	let collection = project.collections[0];
+	let folder = collection.folders[0];
+	let discover = folder.sources[0];
+
+	project = updateEditableValues(project, collection.internalId, { title: "Edited Imported Profile" });
+	project = updateEditableValues(project, folder.internalId, { hideTitle: true });
+	project = updateEditableValues(project, discover.internalId, { filters: {} });
+	project = structuredClone(project);
+	collection = project.collections[0];
+	folder = collection.folders[0];
+	discover = folder.sources[0];
+	const oldAddon = folder.sources[1];
+
+	delete collection.editable.showAllTab;
+	delete oldAddon.editable.genre;
+
+	const serialized = serializeNuvioProject(project);
+	assert.equal(serialized.ok, true, JSON.stringify(serialized.errors));
+	const outputCollection = serialized.value[0];
+	const outputFolder = outputCollection.folders[0];
+	const outputDiscover = outputFolder.sources[0];
+	const outputAddon = outputFolder.sources[1];
+
+	assert.equal(outputCollection.title, "Edited Imported Profile");
+	assert.equal(outputCollection.showAllTab, 0);
+	assert.equal(outputCollection.backdropImageUrl, null);
+	assert.equal(outputCollection.focusGlowEnabled, false);
+	assert.deepEqual(outputCollection.unknownCollection, {
+		owner: "synthetic-community",
+		nested: { keep: true },
+	});
+	assert.deepEqual(outputCollection.unknownCollectionEmptyObject, {});
+	assert.deepEqual(outputCollection.unknownCollectionEmptyArray, []);
+	assert.equal(outputCollection.unknownCollectionFalse, false);
+	assert.equal(outputCollection.unknownCollectionZero, 0);
+
+	assert.equal(outputFolder.hideTitle, true);
+	assert.equal(outputFolder.focusGifUrl, "");
+	assert.equal(outputFolder.heroVideoUrl, null);
+	assert.equal(outputFolder.focusGifEnabled, false);
+	assert.deepEqual(outputFolder.unknownFolder, { layout: "community-grid" });
+
+	assert.deepEqual(outputDiscover.filters, {
+		futureFlag: false,
+		futureZero: 0,
+		futureNull: null,
+		futureEmptyObject: {},
+		futureEmptyArray: [],
+	});
+	assert.equal(outputDiscover.sortHow, "descending");
+	assert.deepEqual(outputDiscover.unknownSource, { keep: "discover" });
+	assert.equal(Object.hasOwn(outputDiscover.filters, "withGenres"), false);
+	assert.equal(Object.hasOwn(outputDiscover.filters, "voteAverageGte"), false);
+	assert.equal(Object.hasOwn(outputDiscover.filters, "withNetworks"), false);
+
+	assert.equal(outputAddon.genre, null);
+	assert.deepEqual(outputAddon.unknownSourceEvidence, { removeWithSource: true });
+	assert.deepEqual(outputFolder.catalogSources[0].unknownProjectionEvidence, { removeWithSource: true });
+	assert.equal(serialized.value[1].pinToTop, undefined);
+	assert.equal(serialized.value[1].folders[0].hideTitle, undefined);
+
+	const sourceArtworkFields = new Set([
+		"coverEmoji",
+		"coverImageUrl",
+		"focusGifEnabled",
+		"focusGifUrl",
+		"heroBackdropUrl",
+		"heroVideoUrl",
+		"titleLogoUrl",
+	]);
+	for (const source of allFolders(serialized.value).flatMap((candidate) => candidate.sources)) {
+		assert.equal(
+			Object.keys(source).some((key) => sourceArtworkFields.has(key)),
+			false,
+			`Invented source artwork field in ${sourceIdentity(source)}`,
+		);
+	}
+});
+
+test("controller removal and insertion drop only removed source evidence and preserve sibling order", () => {
+	const entry = entryById("preservation-comprehensive-profile");
+	const controller = createBuilderController({
+		idFactory: countingIdFactory(),
+		nuvioIdFactory: countingIdFactory("nuvio"),
+	});
+	assert.equal(controller.importValue(loadEntry(entry)).ok, true);
+
+	const importedFolder = controller.getState().project.collections[0].folders[0];
+	const oldSource = importedFolder.sources.find((source) => source.editable.catalogId === "old-evidence-catalog");
+	assert.ok(oldSource);
+	assert.equal(controller.removeNode(oldSource.internalId).ok, true);
+
+	const currentFolder = controller.getState().project.collections[0].folders[0];
+	const inserted = controller.createSource(currentFolder.internalId, {
+		category: SOURCE_CATEGORIES.ADDON,
+		index: 1,
+		editable: {
+			provider: "addon",
+			title: "Replacement Addon",
+			addonId: "example.synthetic.catalogs",
+			type: "movie",
+			catalogId: "replacement-catalog",
+			genre: null,
+		},
+	});
+	assert.equal(inserted.ok, true, JSON.stringify(inserted.errors));
+
+	const serialized = controller.serializeProject();
+	assert.equal(serialized.ok, true, JSON.stringify(serialized.errors));
+	assert.deepEqual(codes(serialized.warnings), [
+		"OPAQUE_SOURCE_PRESERVED",
+		"OPAQUE_SOURCE_PRESERVED",
+		"UNMATCHED_CATALOG_SOURCE_REMOVED",
+	]);
+
+	const folder = serialized.value[0].folders[0];
+	assert.deepEqual(folder.sources.map(sourceIdentity), [
+		"tmdb:DISCOVER::MOVIE",
+		"addon:example.synthetic.catalogs:movie:replacement-catalog:",
+		"opaque:trakt:list:synthetic-list-42:Imported Trakt List",
+		"addon:example.synthetic.catalogs:series:retained-catalog:Drama",
+		"opaque:community:curated-feed::Community Feed",
+	]);
+	assert.deepEqual(folder.catalogSources.map(sourceIdentity), [
+		"addon:example.synthetic.catalogs:movie:replacement-catalog:",
+		"addon:example.synthetic.catalogs:series:retained-catalog:Drama",
+	]);
+	assert.equal(JSON.stringify(serialized.value).includes("old-evidence-catalog"), false);
+	assert.equal(JSON.stringify(serialized.value).includes("removeWithSource"), false);
+	assert.equal(folder.sources[1].unknownSourceEvidence, undefined);
+	assert.equal(folder.catalogSources[0].unknownProjectionEvidence, undefined);
+	assert.deepEqual(folder.sources[3].unknownSourceEvidence, { keepWithSource: true });
+	assert.deepEqual(folder.catalogSources[1].unknownProjectionEvidence, { keepWithSource: true });
+});
+
+test("file-backed identity evidence separates direct import from controller repair", () => {
+	const entry = entryById("identity-direct-import-and-controller-repair");
+	const input = loadEntry(entry);
+	const direct = importNuvioCollections(input, { idFactory: countingIdFactory() });
+	assert.equal(direct.ok, true, JSON.stringify(direct.errors));
+	assert.deepEqual(codes(direct.warnings), entry.expectedDiagnostics.importWarnings);
+	assert.deepEqual(
+		direct.project.collections.map((collection) => collection.editable.id),
+		entry.identityExpectations.directCollectionIds,
+	);
+	assert.deepEqual(
+		direct.project.collections.flatMap((collection) => collection.folders.map((folder) => folder.editable.id)),
+		entry.identityExpectations.directFolderIds,
+	);
+	assert.equal(checkInternalIdUniqueness(direct.project).unique, true);
+
+	const directSerialized = serializeNuvioProject(direct.project);
+	assert.equal(directSerialized.ok, false);
+	assert.deepEqual(codes(directSerialized.errors), entry.expectedDiagnostics.serializeErrors);
+	assert.deepEqual(
+		directSerialized.errors.map((error) => error.path),
+		[
+			"$[0].folders[1].id",
+			"$[2].id",
+			"$[2].folders[0].id",
+			"$[3].id",
+		],
+	);
+
+	const controller = createBuilderController({
+		idFactory: countingIdFactory(),
+		nuvioIdFactory: countingIdFactory("nuvio"),
+	});
+	const controlled = controller.importValue(input);
+	assert.equal(controlled.ok, true, JSON.stringify(controlled.errors));
+	const repairedProject = controller.getState().project;
+	assert.deepEqual(
+		repairedProject.collections.map((collection) => collection.editable.id),
+		entry.identityExpectations.controllerCollectionIds,
+	);
+	assert.deepEqual(
+		repairedProject.collections.flatMap((collection) => collection.folders.map((folder) => folder.editable.id)),
+		entry.identityExpectations.controllerFolderIds,
+	);
+	assert.deepEqual(
+		repairedProject.collections.map((collection) => collection.editable.title),
+		entry.expectedOrder.collections,
+	);
+	for (const collection of repairedProject.collections) {
+		assert.deepEqual(
+			collection.folders.map((folder) => folder.editable.title),
+			entry.expectedOrder.foldersByCollection[collection.editable.title],
+		);
+	}
+	assert.equal(repairedProject.collections[1].rawImported.id, " padded ");
+	assert.equal(Object.hasOwn(repairedProject.collections[2].rawImported, "id"), false);
+	assert.equal(repairedProject.collections[3].rawImported.id, false);
+	assert.equal(checkInternalIdUniqueness(repairedProject).unique, true);
+
+	const controllerSerialized = controller.serializeProject();
+	assert.equal(controllerSerialized.ok, true, JSON.stringify(controllerSerialized.errors));
+	assert.deepEqual(countsFor(controllerSerialized.value), entry.expectedCounts);
+	assert.equal(JSON.stringify(controllerSerialized.value).includes("internal-"), false);
+});
+
+test("serializer required-text fixture returns exact stable codes and paths", () => {
+	const entry = entryById("invalid-serializer-required-text");
+	const input = loadEntry(entry);
+	const imported = importNuvioCollections(input, { idFactory: countingIdFactory() });
+	assert.equal(imported.ok, true, JSON.stringify(imported.errors));
+	assert.deepEqual(codes(imported.warnings), entry.expectedDiagnostics.importWarnings);
+
+	const serialized = serializeNuvioProject(imported.project);
+	assert.equal(serialized.ok, false);
+	assert.deepEqual(codes(serialized.errors), entry.expectedDiagnostics.serializeErrors);
+	assert.deepEqual(
+		serialized.errors.map((error) => error.path),
+		[
+			"$[0].id",
+			"$[0].title",
+			"$[0].folders[0].id",
+			"$[0].folders[0].title",
+		],
+	);
+	for (const diagnostic of serialized.errors) {
+		assertDiagnosticShape(diagnostic, entry.id);
+	}
+	assert.deepEqual(
+		validateNuvioContract(input, { mode: "canonical-builder-output" }).errors,
+		entry.expectedDiagnostics.validationErrors,
+	);
+});
+
+test("existing migration evidence remains deterministic ordered normalized and idempotent", () => {
+	const entry = entryById("migration-existing-addon-projection-evidence");
+	const input = loadEntry(entry);
+	assertValueContract(input, entry);
+
+	const imported = importNuvioCollections(input, { idFactory: countingIdFactory() });
+	assert.equal(imported.ok, true, JSON.stringify(imported.errors));
+	assert.deepEqual(codes(imported.warnings), entry.expectedDiagnostics.importWarnings);
+
+	const migrated = migrateLegacyAddonProjections(imported.project, {
+		idFactory: sequenceIdFactory("migration-source-1", "migration-source-2", "migration-source-3"),
+	});
+	assert.equal(migrated.ok, true, JSON.stringify(migrated.errors));
+	assert.deepEqual(migrated.changes, { foldersMigrated: 3, sourcesCreated: 3 });
+	assert.deepEqual(codes(migrated.warnings), [
+		"LEGACY_ADDON_PROJECTIONS_MIGRATED",
+		"LEGACY_ADDON_PROJECTIONS_MIGRATED",
+		"LEGACY_ADDON_PROJECTIONS_MIGRATED",
+	]);
+	const repeated = migrateLegacyAddonProjections(imported.project, {
+		idFactory: sequenceIdFactory("migration-source-1", "migration-source-2", "migration-source-3"),
+	});
+	assert.deepEqual(repeated, migrated);
+
+	const serializedA = serializeNuvioProject(migrated.project);
+	assert.equal(serializedA.ok, true, JSON.stringify(serializedA.errors));
+	assert.deepEqual(codes(serializedA.warnings), entry.expectedDiagnostics.serializeWarnings);
+	assertValueContract(
+		serializedA.value,
+		entry,
+		entry.expectedOutputCounts,
+		{
+			collections: entry.expectedOrder.collections,
+			foldersByCollection: entry.expectedOrder.foldersByCollection,
+			...entry.expectedOutputOrder,
+		},
+	);
+	assert.equal(validateNuvioContract(serializedA.value, { mode: "canonical-builder-output" }).valid, true);
+	assert.deepEqual(
+		allFolders(serializedA.value).flatMap((folder) => folder.sources.map((source) => source.genre)),
+		[null, "Action", null],
+	);
+	assert.deepEqual(
+		allFolders(serializedA.value).flatMap((folder) => folder.catalogSources.map((source) => source.genre)),
+		[null, "Action", null],
+	);
+	assert.deepEqual(
+		serializedA.value[0].folders[0].catalogSources[0].unknownProjectionSentinel,
+		{ preserve: true },
+	);
+
+	const importedAgain = importNuvioCollections(serializedA.value, { idFactory: countingIdFactory("cycle") });
+	const migratedAgain = migrateLegacyAddonProjections(importedAgain.project, {
+		idFactory: () => {
+			throw new Error("Idempotent migration must not consume IDs.");
+		},
+	});
+	assert.equal(migratedAgain.ok, true, JSON.stringify(migratedAgain.errors));
+	assert.deepEqual(migratedAgain.changes, { foldersMigrated: 0, sourcesCreated: 0 });
+	const serializedB = serializeNuvioProject(migratedAgain.project);
+	assert.equal(serializedB.ok, true, JSON.stringify(serializedB.errors));
+	assert.deepEqual(serializedB.value, serializedA.value);
+
+	const desktopInput = readJson(path.join(
+		rootDir,
+		"manual-tests",
+		"nuvio-desktop",
+		"addon-projection-migration",
+		"builder-migrated-input.json",
+	));
+	assert.deepEqual(
+		allFolders(desktopInput).flatMap((folder) => folder.sources.map(sourceIdentity)),
+		allFolders(serializedA.value).flatMap((folder) => folder.sources.map(sourceIdentity)),
+	);
+});
+
+test("validation-only entries retain exact existing error codes and JSON paths", () => {
+	for (const entry of manifest.entries.filter((candidate) => candidate.pipeline === "validation-only")) {
+		const input = loadEntry(entry);
+		assertValueContract(input, entry);
+		const result = validateNuvioContract(input, { mode: "canonical-builder-output" });
+		assert.equal(result.valid, false, entry.id);
+		assert.deepEqual(result.errors, entry.expectedDiagnostics.validationErrors, entry.id);
+	}
+});
+
+function visitJson(value, visitor) {
+	visitor(value);
+	if (Array.isArray(value)) {
+		for (const entry of value) {
+			visitJson(entry, visitor);
+		}
+		return;
+	}
+	if (value !== null && typeof value === "object") {
+		for (const entry of Object.values(value)) {
+			visitJson(entry, visitor);
+		}
+	}
+}

--- a/tests/fixtures/nuvio/v2-compatibility/README.md
+++ b/tests/fixtures/nuvio/v2-compatibility/README.md
@@ -1,0 +1,18 @@
+# V2 compatibility regression corpus
+
+Issue [#49](https://github.com/davecollections/tmdb-id-lookup/issues/49) adds profile-level evidence around the existing focused unit and contract suites. The corpus is manifest-driven, deterministic, offline, synthetic, and excluded from the Pages artifact.
+
+## Coverage inventory
+
+- Existing importer, serializer, migration, controller, automatic-ID, domain, and contract tests remain authoritative for their focused APIs and diagnostic details.
+- `canonical/native-addon-profile.json` connects all seven supported native TMDB types, evidence-backed Movie/TV combinations, multiple addon catalogs, genre metadata, duplicate projection identities, presentation fields, and exact collection/folder/source/projection ordering.
+- `preservation/comprehensive-imported-profile.json` connects native, addon, imported Trakt, and opaque/community evidence with unknown fields, raw-only values, missing/null/empty/false/zero distinctions, presentation/artwork fields, unrelated edits, and the source-removal boundary.
+- `identity/problematic-nuvio-ids.json` distinguishes direct-import acceptance from deterministic controller repair while keeping builder-only internal IDs separate and unique.
+- `invalid/serializer-required-text.json` gives file-backed serializer evidence for required collection/folder IDs and titles.
+- Existing issue #31 invalid fixtures remain the validation-only evidence for unsupported direct TMDB shapes, native projections, and addon projection violations.
+- Existing issue #37/#38 migration fixtures, generator, and Desktop evidence remain authoritative; the corpus references them instead of creating another legacy format.
+- The issue #47 Discover matrix and 29-source manual fixture remain authoritative; this corpus uses only a compact representative subset.
+
+Exact JSON equality is used for the compact canonical profile. Semantic cycle equality is used for preservation profiles because object property ordering is not a product contract. Targeted assertions are used for preservation overlays, identity repair, source removal, migration, and invalid diagnostics.
+
+Material fields are classified in `manifest.json` as builder-owned/overlaid, copied canonical data, canonicalized/defaulted, removed, or raw-preserved only. No confirmed source-artwork field exists in current repository or client evidence, so the corpus records that boundary without inventing one.

--- a/tests/fixtures/nuvio/v2-compatibility/canonical/native-addon-profile.json
+++ b/tests/fixtures/nuvio/v2-compatibility/canonical/native-addon-profile.json
@@ -1,0 +1,209 @@
+[
+  {
+    "id": "canonical-native",
+    "title": "Canonical Native Sources",
+    "pinToTop": true,
+    "viewMode": "ROWS",
+    "showAllTab": true,
+    "folders": [
+      {
+        "id": "native-discovery",
+        "title": "Lists and Discover",
+        "hideTitle": false,
+        "tileShape": "POSTER",
+        "coverEmoji": "🎬",
+        "focusGifUrl": "",
+        "heroVideoUrl": null,
+        "titleLogoUrl": "https://example.invalid/native-title-logo.png",
+        "coverImageUrl": "https://example.invalid/native-cover.webp",
+        "focusGifEnabled": false,
+        "heroBackdropUrl": "https://example.invalid/native-backdrop.webp",
+        "sources": [
+          {
+            "provider": "tmdb",
+            "title": "Movie List",
+            "tmdbSourceType": "LIST",
+            "tmdbId": 1101,
+            "mediaType": "MOVIE"
+          },
+          {
+            "provider": "tmdb",
+            "title": "TV List",
+            "tmdbSourceType": "LIST",
+            "tmdbId": "1102",
+            "mediaType": "TV"
+          },
+          {
+            "provider": "tmdb",
+            "title": "Movie Discover",
+            "tmdbSourceType": "DISCOVER",
+            "mediaType": "MOVIE",
+            "sortBy": "popularity.desc",
+            "filters": {
+              "withGenres": "28",
+              "withKeywords": "15097"
+            }
+          },
+          {
+            "provider": "tmdb",
+            "title": "TV Discover",
+            "tmdbSourceType": "DISCOVER",
+            "tmdbId": null,
+            "mediaType": "TV",
+            "sortBy": "vote_count.desc",
+            "filters": {
+              "withNetworks": "213",
+              "voteCountGte": 100
+            }
+          }
+        ],
+        "catalogSources": []
+      },
+      {
+        "id": "native-entities",
+        "title": "Collections and People",
+        "sources": [
+          {
+            "provider": "tmdb",
+            "title": "Movie Collection",
+            "tmdbSourceType": "COLLECTION",
+            "tmdbId": 2101,
+            "mediaType": "MOVIE"
+          },
+          {
+            "provider": "tmdb",
+            "title": "Movie Company",
+            "tmdbSourceType": "COMPANY",
+            "tmdbId": 3101,
+            "mediaType": "MOVIE"
+          },
+          {
+            "provider": "tmdb",
+            "title": "TV Network",
+            "tmdbSourceType": "NETWORK",
+            "tmdbId": 4101,
+            "mediaType": "TV"
+          },
+          {
+            "provider": "tmdb",
+            "title": "Person Movies",
+            "tmdbSourceType": "PERSON",
+            "tmdbId": 5101,
+            "mediaType": "MOVIE"
+          },
+          {
+            "provider": "tmdb",
+            "title": "Person TV",
+            "tmdbSourceType": "PERSON",
+            "tmdbId": 5101,
+            "mediaType": "TV"
+          },
+          {
+            "provider": "tmdb",
+            "title": "Director Movies",
+            "tmdbSourceType": "DIRECTOR",
+            "tmdbId": 6101,
+            "mediaType": "MOVIE"
+          },
+          {
+            "provider": "tmdb",
+            "title": "Director TV",
+            "tmdbSourceType": "DIRECTOR",
+            "tmdbId": 6101,
+            "mediaType": "TV"
+          }
+        ],
+        "catalogSources": []
+      }
+    ]
+  },
+  {
+    "id": "canonical-addons",
+    "title": "Canonical Addon Sources",
+    "pinToTop": false,
+    "viewMode": "TABBED",
+    "showAllTab": false,
+    "folders": [
+      {
+        "id": "addon-catalogs",
+        "title": "Addon Catalogs",
+        "hideTitle": true,
+        "tileShape": "LANDSCAPE",
+        "sources": [
+          {
+            "provider": "addon",
+            "title": "Popular Horror",
+            "addonId": "com.nuvio.tmdb.catalogs",
+            "type": "movie",
+            "catalogId": "popular-movies",
+            "genre": "Horror"
+          },
+          {
+            "provider": "addon",
+            "title": "Trending Series",
+            "addonId": "com.nuvio.tmdb.catalogs",
+            "type": "series",
+            "catalogId": "trending-series"
+          },
+          {
+            "id": "source-family-a",
+            "provider": "addon",
+            "title": "Family Movies A",
+            "addonId": "com.nuvio.tmdb.catalogs",
+            "type": "movie",
+            "catalogId": "family-movies",
+            "addonName": "Nuvio Catalog Addon",
+            "manifestUrl": "https://example.invalid/catalog-addon/manifest.json",
+            "showInHome": false,
+            "unknownSourceOrder": "first"
+          },
+          {
+            "id": "source-family-b",
+            "provider": "addon",
+            "title": "Family Movies B",
+            "addonId": "com.nuvio.tmdb.catalogs",
+            "type": "movie",
+            "catalogId": "family-movies",
+            "addonName": "Nuvio Catalog Addon",
+            "manifestUrl": "https://example.invalid/catalog-addon/manifest.json",
+            "showInHome": false,
+            "unknownSourceOrder": "second"
+          }
+        ],
+        "catalogSources": [
+          {
+            "addonId": "com.nuvio.tmdb.catalogs",
+            "type": "movie",
+            "catalogId": "popular-movies",
+            "genre": "Horror"
+          },
+          {
+            "addonId": "com.nuvio.tmdb.catalogs",
+            "type": "series",
+            "catalogId": "trending-series"
+          },
+          {
+            "id": "projection-family-a",
+            "addonId": "com.nuvio.tmdb.catalogs",
+            "type": "movie",
+            "catalogId": "family-movies",
+            "addonName": "Nuvio Catalog Addon",
+            "manifestUrl": "https://example.invalid/catalog-addon/manifest.json",
+            "showInHome": false,
+            "unknownProjectionOrder": "first"
+          },
+          {
+            "id": "projection-family-b",
+            "addonId": "com.nuvio.tmdb.catalogs",
+            "type": "movie",
+            "catalogId": "family-movies",
+            "addonName": "Nuvio Catalog Addon",
+            "manifestUrl": "https://example.invalid/catalog-addon/manifest.json",
+            "showInHome": false,
+            "unknownProjectionOrder": "second"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/tests/fixtures/nuvio/v2-compatibility/identity/problematic-nuvio-ids.json
+++ b/tests/fixtures/nuvio/v2-compatibility/identity/problematic-nuvio-ids.json
@@ -1,0 +1,41 @@
+[
+  {
+    "id": "same",
+    "title": "First Collection",
+    "folders": [
+      {
+        "id": "same",
+        "title": "Duplicate Folder ID",
+        "sources": [],
+        "catalogSources": []
+      },
+      {
+        "id": 7,
+        "title": "Non-string Folder ID",
+        "sources": [],
+        "catalogSources": []
+      }
+    ]
+  },
+  {
+    "id": " padded ",
+    "title": "Whitespace Collection ID",
+    "folders": []
+  },
+  {
+    "title": "Missing Collection ID",
+    "folders": [
+      {
+        "id": "",
+        "title": "Blank Folder ID",
+        "sources": [],
+        "catalogSources": []
+      }
+    ]
+  },
+  {
+    "id": false,
+    "title": "Boolean Collection ID",
+    "folders": []
+  }
+]

--- a/tests/fixtures/nuvio/v2-compatibility/invalid/serializer-required-text.json
+++ b/tests/fixtures/nuvio/v2-compatibility/invalid/serializer-required-text.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": "",
+    "title": " ",
+    "folders": [
+      {
+        "id": "",
+        "title": "",
+        "sources": [],
+        "catalogSources": []
+      }
+    ]
+  }
+]

--- a/tests/fixtures/nuvio/v2-compatibility/manifest.json
+++ b/tests/fixtures/nuvio/v2-compatibility/manifest.json
@@ -1,0 +1,789 @@
+{
+  "version": 1,
+  "issue": "https://github.com/davecollections/tmdb-id-lookup/issues/49",
+  "inventory": {
+    "existingUnitContracts": [
+      "tests/builder-domain.test.mjs",
+      "tests/builder-import.test.mjs",
+      "tests/builder-serializer.test.mjs",
+      "tests/builder-migration.test.mjs",
+      "tests/builder-controller.test.mjs",
+      "tests/builder-auto-ids-workspace-flow.test.mjs",
+      "tests/nuvio-contracts.test.mjs"
+    ],
+    "authoritativeManualEvidence": [
+      "manual-tests/nuvio-desktop/addon-projection-migration/README.md",
+      "manual-tests/tmdb-discover/README.md"
+    ],
+    "assertionModes": {
+      "exact-json": "The serialized JSON value must equal the intentional canonical input.",
+      "semantic-equality": "The second import/serialize cycle must equal the first while object property order remains non-contractual.",
+      "targeted": "Only the listed preservation, identity, migration, or invalid boundary is asserted."
+    },
+    "deferredBoundaries": {
+      "sourceArtwork": "No confirmed source-artwork field exists in current repository or client evidence; no source artwork field is created or asserted.",
+      "trakt": "Imported Trakt data is opaque preservation evidence only; creation, recognition, login, API, and networking remain unsupported.",
+      "directMedia": "Direct movie, direct series, season, episode, and custom-item native source types remain unsupported."
+    }
+  },
+  "entries": [
+    {
+      "id": "canonical-native-addon-profile",
+      "category": "canonical",
+      "purpose": "Connect all seven native TMDB types and evidence-backed media combinations with ordered addon compatibility projections.",
+      "input": "v2-compatibility/canonical/native-addon-profile.json",
+      "pipeline": "direct-importer",
+      "sourceTypes": [
+        "LIST",
+        "COLLECTION",
+        "COMPANY",
+        "NETWORK",
+        "DISCOVER",
+        "PERSON",
+        "DIRECTOR",
+        "addon"
+      ],
+      "mediaCombinations": [
+        "LIST:MOVIE",
+        "LIST:TV",
+        "COLLECTION:MOVIE",
+        "COMPANY:MOVIE",
+        "NETWORK:TV",
+        "DISCOVER:MOVIE",
+        "DISCOVER:TV",
+        "PERSON:MOVIE",
+        "PERSON:TV",
+        "DIRECTOR:MOVIE",
+        "DIRECTOR:TV",
+        "addon:movie",
+        "addon:series"
+      ],
+      "expectedCounts": {
+        "collections": 2,
+        "folders": 3,
+        "sources": 15,
+        "projections": 4
+      },
+      "expectedOrder": {
+        "collections": [
+          "canonical-native",
+          "canonical-addons"
+        ],
+        "foldersByCollection": {
+          "canonical-native": [
+            "native-discovery",
+            "native-entities"
+          ],
+          "canonical-addons": [
+            "addon-catalogs"
+          ]
+        },
+        "sourcesByFolder": {
+          "native-discovery": [
+            "tmdb:LIST:1101:MOVIE",
+            "tmdb:LIST:1102:TV",
+            "tmdb:DISCOVER::MOVIE",
+            "tmdb:DISCOVER::TV"
+          ],
+          "native-entities": [
+            "tmdb:COLLECTION:2101:MOVIE",
+            "tmdb:COMPANY:3101:MOVIE",
+            "tmdb:NETWORK:4101:TV",
+            "tmdb:PERSON:5101:MOVIE",
+            "tmdb:PERSON:5101:TV",
+            "tmdb:DIRECTOR:6101:MOVIE",
+            "tmdb:DIRECTOR:6101:TV"
+          ],
+          "addon-catalogs": [
+            "addon:com.nuvio.tmdb.catalogs:movie:popular-movies:Horror",
+            "addon:com.nuvio.tmdb.catalogs:series:trending-series:",
+            "addon:com.nuvio.tmdb.catalogs:movie:family-movies:",
+            "addon:com.nuvio.tmdb.catalogs:movie:family-movies:"
+          ]
+        },
+        "projectionsByFolder": {
+          "native-discovery": [],
+          "native-entities": [],
+          "addon-catalogs": [
+            "addon:com.nuvio.tmdb.catalogs:movie:popular-movies:Horror",
+            "addon:com.nuvio.tmdb.catalogs:series:trending-series:",
+            "addon:com.nuvio.tmdb.catalogs:movie:family-movies:",
+            "addon:com.nuvio.tmdb.catalogs:movie:family-movies:"
+          ]
+        }
+      },
+      "expectedDiagnostics": {
+        "importErrors": [],
+        "importWarnings": [],
+        "serializeErrors": [],
+        "serializeWarnings": [],
+        "validationErrors": []
+      },
+      "assertionMode": "exact-json",
+      "materialFieldPolicy": {
+        "builderOwnedOverlaid": [
+          "collection id/title/presentation",
+          "folder id/title/presentation/artwork",
+          "known native and addon source fields"
+        ],
+        "copiedCanonicalData": [
+          "ordered folders",
+          "ordered authoritative sources",
+          "ordered addon compatibility projections"
+        ],
+        "canonicalizedDefaulted": [],
+        "removed": [],
+        "rawPreservedOnly": [
+          "addon id/addonName/manifestUrl/showInHome metadata",
+          "duplicate projection order sentinels"
+        ]
+      },
+      "coverageTags": [
+        "all-seven-native-types",
+        "evidence-backed-media",
+        "addon-basic",
+        "addon-genre",
+        "addon-multiple",
+        "addon-projection",
+        "projection-order",
+        "addon-metadata",
+        "duplicate-projection-identity",
+        "multiple-collections",
+        "multiple-folders",
+        "presentation",
+        "folder-artwork",
+        "ordering",
+        "round-trip",
+        "discover-reference"
+      ],
+      "evidenceReferences": [
+        "tests/fixtures/nuvio/valid/all-native-tmdb-source-types.json",
+        "manual-tests/tmdb-discover/fixture-manifest.json"
+      ]
+    },
+    {
+      "id": "preservation-comprehensive-profile",
+      "category": "preservation",
+      "purpose": "Preserve a realistic multi-collection native, addon, Trakt, and opaque/community profile through unrelated edits and stable cycles.",
+      "input": "v2-compatibility/preservation/comprehensive-imported-profile.json",
+      "pipeline": "direct-importer",
+      "sourceTypes": [
+        "DISCOVER",
+        "COMPANY",
+        "addon",
+        "opaque-trakt",
+        "opaque-community"
+      ],
+      "mediaCombinations": [
+        "DISCOVER:MOVIE",
+        "COMPANY:MOVIE",
+        "addon:movie",
+        "addon:series",
+        "opaque:trakt",
+        "opaque:community"
+      ],
+      "expectedCounts": {
+        "collections": 2,
+        "folders": 3,
+        "sources": 6,
+        "projections": 2
+      },
+      "expectedOrder": {
+        "collections": [
+          "preservation-primary",
+          "preservation-secondary"
+        ],
+        "foldersByCollection": {
+          "preservation-primary": [
+            "preservation-mixed",
+            "preservation-empty"
+          ],
+          "preservation-secondary": [
+            "preservation-secondary-folder"
+          ]
+        },
+        "sourcesByFolder": {
+          "preservation-mixed": [
+            "tmdb:DISCOVER::MOVIE",
+            "addon:example.synthetic.catalogs:movie:old-evidence-catalog:",
+            "opaque:trakt:list:synthetic-list-42:Imported Trakt List",
+            "addon:example.synthetic.catalogs:series:retained-catalog:Drama",
+            "opaque:community:curated-feed::Community Feed"
+          ],
+          "preservation-empty": [],
+          "preservation-secondary-folder": [
+            "tmdb:COMPANY:9001:MOVIE"
+          ]
+        },
+        "projectionsByFolder": {
+          "preservation-mixed": [
+            "addon:example.synthetic.catalogs:movie:old-evidence-catalog:",
+            "addon:example.synthetic.catalogs:series:retained-catalog:Drama"
+          ],
+          "preservation-empty": [],
+          "preservation-secondary-folder": []
+        }
+      },
+      "expectedDiagnostics": {
+        "importErrors": [],
+        "importWarnings": [
+          "AMBIGUOUS_SOURCE_PRESERVED_OPAQUE",
+          "AMBIGUOUS_SOURCE_PRESERVED_OPAQUE"
+        ],
+        "serializeErrors": [],
+        "serializeWarnings": [
+          "OPAQUE_SOURCE_PRESERVED",
+          "OPAQUE_SOURCE_PRESERVED"
+        ],
+        "validationErrors": []
+      },
+      "assertionMode": "semantic-equality",
+      "materialFieldPolicy": {
+        "builderOwnedOverlaid": [
+          "known collection presentation",
+          "known folder presentation/artwork",
+          "known Discover filters",
+          "known addon identity"
+        ],
+        "copiedCanonicalData": [
+          "ordered folders",
+          "ordered authoritative sources",
+          "addon projections matching current authoritative addons"
+        ],
+        "canonicalizedDefaulted": [],
+        "removed": [
+          "recognized Discover filter keys omitted from an explicit replacement group",
+          "raw source and projection evidence belonging to a removed source"
+        ],
+        "rawPreservedOnly": [
+          "collection backdropImageUrl/focusGlowEnabled",
+          "source sortHow",
+          "Trakt traktListId/provider fields",
+          "community fields",
+          "unknown collection/folder/source/filter/projection fields"
+        ]
+      },
+      "coverageTags": [
+        "mixed-native-addon-opaque",
+        "imported-trakt",
+        "opaque-community",
+        "addon-projection",
+        "projection-order",
+        "multiple-collections",
+        "multiple-folders",
+        "multiple-sources",
+        "presentation",
+        "folder-artwork",
+        "raw-only-collection-fields",
+        "raw-only-source-fields",
+        "unknown-collection",
+        "unknown-folder",
+        "unknown-source",
+        "unknown-filter",
+        "unknown-projection",
+        "missing-null-empty-false-zero",
+        "editable-over-raw",
+        "discover-filter-replacement",
+        "source-removal",
+        "ordering",
+        "round-trip",
+        "source-artwork-boundary"
+      ],
+      "evidenceReferences": [
+        "tests/fixtures/nuvio/valid/opaque-community-import.json",
+        "manual-tests/tmdb-discover/README.md"
+      ]
+    },
+    {
+      "id": "identity-direct-import-and-controller-repair",
+      "category": "identity",
+      "purpose": "Distinguish direct-import acceptance of problematic Nuvio IDs from deterministic controller repair in traversal order.",
+      "input": "v2-compatibility/identity/problematic-nuvio-ids.json",
+      "pipeline": "builder-controller",
+      "sourceTypes": [],
+      "mediaCombinations": [],
+      "expectedCounts": {
+        "collections": 4,
+        "folders": 3,
+        "sources": 0,
+        "projections": 0
+      },
+      "expectedOrder": {
+        "collections": [
+          "First Collection",
+          "Whitespace Collection ID",
+          "Missing Collection ID",
+          "Boolean Collection ID"
+        ],
+        "foldersByCollection": {
+          "First Collection": [
+            "Duplicate Folder ID",
+            "Non-string Folder ID"
+          ],
+          "Whitespace Collection ID": [],
+          "Missing Collection ID": [
+            "Blank Folder ID"
+          ],
+          "Boolean Collection ID": []
+        },
+        "sourcesByFolder": {
+          "Duplicate Folder ID": [],
+          "Non-string Folder ID": [],
+          "Blank Folder ID": []
+        },
+        "projectionsByFolder": {
+          "Duplicate Folder ID": [],
+          "Non-string Folder ID": [],
+          "Blank Folder ID": []
+        }
+      },
+      "expectedDiagnostics": {
+        "importErrors": [],
+        "importWarnings": [],
+        "serializeErrors": [
+          "FOLDER_ID_REQUIRED",
+          "COLLECTION_ID_REQUIRED",
+          "FOLDER_ID_REQUIRED",
+          "COLLECTION_ID_REQUIRED"
+        ],
+        "serializeWarnings": [],
+        "validationErrors": []
+      },
+      "assertionMode": "targeted",
+      "materialFieldPolicy": {
+        "builderOwnedOverlaid": [
+          "controller-repaired collection/folder IDs"
+        ],
+        "copiedCanonicalData": [
+          "collection/folder titles and traversal order"
+        ],
+        "canonicalizedDefaulted": [
+          "missing, invalid, duplicate, whitespace-padded, and non-string collection/folder IDs repaired by the controller"
+        ],
+        "removed": [],
+        "rawPreservedOnly": [
+          "original imported collection/folder ID evidence"
+        ]
+      },
+      "coverageTags": [
+        "direct-import-ids",
+        "controller-id-repair",
+        "internal-id-uniqueness",
+        "serializer-required-text",
+        "ordering"
+      ],
+      "identityExpectations": {
+        "directCollectionIds": [
+          "same",
+          " padded ",
+          "",
+          false
+        ],
+        "directFolderIds": [
+          "same",
+          7,
+          ""
+        ],
+        "controllerCollectionIds": [
+          "same",
+          "nuvio-3",
+          "nuvio-4",
+          "nuvio-6"
+        ],
+        "controllerFolderIds": [
+          "nuvio-1",
+          "nuvio-2",
+          "nuvio-5"
+        ]
+      },
+      "evidenceReferences": [
+        "tests/builder-import.test.mjs",
+        "tests/builder-auto-ids-workspace-flow.test.mjs"
+      ]
+    },
+    {
+      "id": "invalid-serializer-required-text",
+      "category": "invalid",
+      "purpose": "Record file-backed serializer diagnostics for nonblank collection/folder IDs and titles.",
+      "input": "v2-compatibility/invalid/serializer-required-text.json",
+      "pipeline": "direct-importer",
+      "sourceTypes": [],
+      "mediaCombinations": [],
+      "expectedCounts": {
+        "collections": 1,
+        "folders": 1,
+        "sources": 0,
+        "projections": 0
+      },
+      "expectedOrder": {
+        "collections": [
+          " "
+        ],
+        "foldersByCollection": {
+          " ": [
+            ""
+          ]
+        },
+        "sourcesByFolder": {
+          "": []
+        },
+        "projectionsByFolder": {
+          "": []
+        }
+      },
+      "expectedDiagnostics": {
+        "importErrors": [],
+        "importWarnings": [],
+        "serializeErrors": [
+          "COLLECTION_ID_REQUIRED",
+          "COLLECTION_TITLE_REQUIRED",
+          "FOLDER_ID_REQUIRED",
+          "FOLDER_TITLE_REQUIRED"
+        ],
+        "serializeWarnings": [],
+        "validationErrors": [
+          {
+            "code": "COLLECTION_INVALID",
+            "path": "$[0]"
+          }
+        ]
+      },
+      "assertionMode": "targeted",
+      "materialFieldPolicy": {
+        "builderOwnedOverlaid": [
+          "collection/folder id and title"
+        ],
+        "copiedCanonicalData": [],
+        "canonicalizedDefaulted": [],
+        "removed": [],
+        "rawPreservedOnly": []
+      },
+      "coverageTags": [
+        "serializer-required-text",
+        "invalid"
+      ],
+      "evidenceReferences": [
+        "tests/builder-serializer.test.mjs"
+      ]
+    },
+    {
+      "id": "migration-existing-addon-projection-evidence",
+      "category": "migration",
+      "purpose": "Reuse the supported projection-only addon migration and its Desktop evidence without inventing another legacy format.",
+      "input": "compatibility/legacy-projection-only-input.json",
+      "pipeline": "migration",
+      "sourceTypes": [
+        "addon"
+      ],
+      "mediaCombinations": [
+        "addon:movie",
+        "addon:series",
+        "addon:anime"
+      ],
+      "expectedCounts": {
+        "collections": 1,
+        "folders": 3,
+        "sources": 0,
+        "projections": 3
+      },
+      "expectedOutputCounts": {
+        "collections": 1,
+        "folders": 3,
+        "sources": 3,
+        "projections": 3
+      },
+      "expectedOrder": {
+        "collections": [
+          "compat-legacy-addon"
+        ],
+        "foldersByCollection": {
+          "compat-legacy-addon": [
+            "compat-legacy-movie",
+            "compat-legacy-series",
+            "compat-legacy-anime"
+          ]
+        },
+        "sourcesByFolder": {
+          "compat-legacy-movie": [],
+          "compat-legacy-series": [],
+          "compat-legacy-anime": []
+        },
+        "projectionsByFolder": {
+          "compat-legacy-movie": [
+            "addon:example.sanitised.metadata:movie:movie-catalog:None"
+          ],
+          "compat-legacy-series": [
+            "addon:example.sanitised.metadata:series:series-catalog:Action"
+          ],
+          "compat-legacy-anime": [
+            "addon:example.sanitised.metadata:anime:anime-catalog:None"
+          ]
+        }
+      },
+      "expectedOutputOrder": {
+        "sourcesByFolder": {
+          "compat-legacy-movie": [
+            "addon:example.sanitised.metadata:movie:movie-catalog:"
+          ],
+          "compat-legacy-series": [
+            "addon:example.sanitised.metadata:series:series-catalog:Action"
+          ],
+          "compat-legacy-anime": [
+            "addon:example.sanitised.metadata:anime:anime-catalog:"
+          ]
+        },
+        "projectionsByFolder": {
+          "compat-legacy-movie": [
+            "addon:example.sanitised.metadata:movie:movie-catalog:"
+          ],
+          "compat-legacy-series": [
+            "addon:example.sanitised.metadata:series:series-catalog:Action"
+          ],
+          "compat-legacy-anime": [
+            "addon:example.sanitised.metadata:anime:anime-catalog:"
+          ]
+        }
+      },
+      "expectedDiagnostics": {
+        "importErrors": [],
+        "importWarnings": [
+          "MISSING_SOURCES",
+          "LEGACY_CATALOG_SOURCES_ONLY",
+          "LEGACY_CATALOG_SOURCES_ONLY",
+          "MISSING_SOURCES",
+          "LEGACY_CATALOG_SOURCES_ONLY"
+        ],
+        "serializeErrors": [],
+        "serializeWarnings": [],
+        "validationErrors": []
+      },
+      "assertionMode": "targeted",
+      "materialFieldPolicy": {
+        "builderOwnedOverlaid": [
+          "migrated addon provider/addonId/type/catalogId/genre"
+        ],
+        "copiedCanonicalData": [
+          "folder/projection ordering and raw projection metadata"
+        ],
+        "canonicalizedDefaulted": [
+          "exact genre value None to null"
+        ],
+        "removed": [],
+        "rawPreservedOnly": [
+          "unknown projection metadata and imported presentation"
+        ]
+      },
+      "coverageTags": [
+        "migration",
+        "migration-idempotence",
+        "addon-projection",
+        "projection-order",
+        "migration-reference",
+        "round-trip"
+      ],
+      "evidenceReferences": [
+        "tests/fixtures/nuvio/compatibility/legacy-nuvio-normalised.json",
+        "manual-tests/nuvio-desktop/addon-projection-migration/builder-migrated-input.json",
+        "manual-tests/nuvio-desktop/addon-projection-migration/generation-report.json",
+        "manual-tests/nuvio-desktop/addon-projection-migration/nuvio-desktop-export.json",
+        "manual-tests/nuvio-desktop/addon-projection-migration/round-trip-report.json"
+      ]
+    },
+    {
+      "id": "invalid-unsupported-direct-movie",
+      "category": "invalid",
+      "purpose": "Retain the current validation boundary for a guessed direct native TMDB movie source.",
+      "input": "invalid/unsupported-direct-movie-source.json",
+      "pipeline": "validation-only",
+      "sourceTypes": [
+        "DIRECT_MOVIE"
+      ],
+      "mediaCombinations": [
+        "DIRECT_MOVIE:MOVIE"
+      ],
+      "expectedCounts": {
+        "collections": 1,
+        "folders": 1,
+        "sources": 1,
+        "projections": 0
+      },
+      "expectedOrder": {
+        "collections": [
+          "collection-invalid-direct-movie"
+        ],
+        "foldersByCollection": {
+          "collection-invalid-direct-movie": [
+            "folder-invalid-direct-movie"
+          ]
+        },
+        "sourcesByFolder": {
+          "folder-invalid-direct-movie": [
+            "tmdb:DIRECT_MOVIE:2001:MOVIE"
+          ]
+        },
+        "projectionsByFolder": {
+          "folder-invalid-direct-movie": []
+        }
+      },
+      "expectedDiagnostics": {
+        "importErrors": [],
+        "importWarnings": [],
+        "serializeErrors": [],
+        "serializeWarnings": [],
+        "validationErrors": [
+          {
+            "code": "UNSUPPORTED_TMDB_SOURCE_TYPE",
+            "path": "$[0].folders[0].sources[0]"
+          }
+        ]
+      },
+      "assertionMode": "targeted",
+      "materialFieldPolicy": {
+        "builderOwnedOverlaid": [],
+        "copiedCanonicalData": [],
+        "canonicalizedDefaulted": [],
+        "removed": [],
+        "rawPreservedOnly": [
+          "unsupported source remains importable only as opaque evidence"
+        ]
+      },
+      "coverageTags": [
+        "invalid",
+        "unsupported-direct-media"
+      ],
+      "evidenceReferences": [
+        "tests/nuvio-contracts.test.mjs"
+      ]
+    },
+    {
+      "id": "invalid-native-catalog-projection",
+      "category": "invalid",
+      "purpose": "Retain the current validation boundary that native TMDB sources never belong in catalogSources.",
+      "input": "invalid/native-source-in-catalog-sources.json",
+      "pipeline": "validation-only",
+      "sourceTypes": [
+        "COMPANY"
+      ],
+      "mediaCombinations": [
+        "COMPANY:MOVIE"
+      ],
+      "expectedCounts": {
+        "collections": 1,
+        "folders": 1,
+        "sources": 1,
+        "projections": 1
+      },
+      "expectedOrder": {
+        "collections": [
+          "collection-invalid-native-projection"
+        ],
+        "foldersByCollection": {
+          "collection-invalid-native-projection": [
+            "folder-invalid-native-projection"
+          ]
+        },
+        "sourcesByFolder": {
+          "folder-invalid-native-projection": [
+            "tmdb:COMPANY:1003:MOVIE"
+          ]
+        },
+        "projectionsByFolder": {
+          "folder-invalid-native-projection": [
+            "tmdb:COMPANY:1003:MOVIE"
+          ]
+        }
+      },
+      "expectedDiagnostics": {
+        "importErrors": [],
+        "importWarnings": [],
+        "serializeErrors": [],
+        "serializeWarnings": [],
+        "validationErrors": [
+          {
+            "code": "NATIVE_SOURCE_IN_CATALOG_SOURCES",
+            "path": "$[0].folders[0].catalogSources[0]"
+          }
+        ]
+      },
+      "assertionMode": "targeted",
+      "materialFieldPolicy": {
+        "builderOwnedOverlaid": [],
+        "copiedCanonicalData": [],
+        "canonicalizedDefaulted": [],
+        "removed": [],
+        "rawPreservedOnly": []
+      },
+      "coverageTags": [
+        "invalid",
+        "native-projection-boundary"
+      ],
+      "evidenceReferences": [
+        "tests/nuvio-contracts.test.mjs"
+      ]
+    },
+    {
+      "id": "invalid-addon-projection-without-source",
+      "category": "invalid",
+      "purpose": "Retain the authoritative sources boundary for addon compatibility projections.",
+      "input": "invalid/addon-only-in-catalog-sources.json",
+      "pipeline": "validation-only",
+      "sourceTypes": [
+        "addon"
+      ],
+      "mediaCombinations": [
+        "addon:movie"
+      ],
+      "expectedCounts": {
+        "collections": 1,
+        "folders": 1,
+        "sources": 0,
+        "projections": 1
+      },
+      "expectedOrder": {
+        "collections": [
+          "collection-invalid-addon-only"
+        ],
+        "foldersByCollection": {
+          "collection-invalid-addon-only": [
+            "folder-invalid-addon-only"
+          ]
+        },
+        "sourcesByFolder": {
+          "folder-invalid-addon-only": []
+        },
+        "projectionsByFolder": {
+          "folder-invalid-addon-only": [
+            "addon:com.nuvio.tmdb.catalogs:movie:trending-movies:"
+          ]
+        }
+      },
+      "expectedDiagnostics": {
+        "importErrors": [],
+        "importWarnings": [],
+        "serializeErrors": [],
+        "serializeWarnings": [],
+        "validationErrors": [
+          {
+            "code": "ADDON_SOURCE_MISSING_FROM_SOURCES",
+            "path": "$[0].folders[0].catalogSources[0]"
+          }
+        ]
+      },
+      "assertionMode": "targeted",
+      "materialFieldPolicy": {
+        "builderOwnedOverlaid": [],
+        "copiedCanonicalData": [],
+        "canonicalizedDefaulted": [],
+        "removed": [],
+        "rawPreservedOnly": []
+      },
+      "coverageTags": [
+        "invalid",
+        "addon-projection-boundary"
+      ],
+      "evidenceReferences": [
+        "tests/nuvio-contracts.test.mjs"
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/nuvio/v2-compatibility/preservation/comprehensive-imported-profile.json
+++ b/tests/fixtures/nuvio/v2-compatibility/preservation/comprehensive-imported-profile.json
@@ -1,0 +1,180 @@
+[
+  {
+    "id": "preservation-primary",
+    "title": "Imported Mixed Profile",
+    "pinToTop": false,
+    "viewMode": "",
+    "showAllTab": 0,
+    "backdropImageUrl": null,
+    "focusGlowEnabled": false,
+    "unknownCollection": {
+      "owner": "synthetic-community",
+      "nested": {
+        "keep": true
+      }
+    },
+    "unknownCollectionNull": null,
+    "unknownCollectionEmptyString": "",
+    "unknownCollectionEmptyObject": {},
+    "unknownCollectionEmptyArray": [],
+    "unknownCollectionFalse": false,
+    "unknownCollectionZero": 0,
+    "folders": [
+      {
+        "id": "preservation-mixed",
+        "title": "Native Addon Trakt and Community",
+        "hideTitle": false,
+        "tileShape": "LANDSCAPE",
+        "coverEmoji": "",
+        "focusGifUrl": "",
+        "heroVideoUrl": null,
+        "titleLogoUrl": "https://example.invalid/preservation-title-logo.png",
+        "coverImageUrl": "",
+        "focusGifEnabled": false,
+        "heroBackdropUrl": null,
+        "unknownFolder": {
+          "layout": "community-grid"
+        },
+        "unknownFolderNull": null,
+        "unknownFolderEmptyObject": {},
+        "unknownFolderEmptyArray": [],
+        "unknownFolderFalse": false,
+        "unknownFolderZero": 0,
+        "sources": [
+          {
+            "provider": "tmdb",
+            "title": null,
+            "tmdbSourceType": "DISCOVER",
+            "tmdbId": null,
+            "mediaType": "MOVIE",
+            "sortBy": "popularity.desc",
+            "sortHow": "descending",
+            "filters": {
+              "withGenres": "",
+              "voteAverageGte": 0,
+              "withNetworks": null,
+              "futureFlag": false,
+              "futureZero": 0,
+              "futureNull": null,
+              "futureEmptyObject": {},
+              "futureEmptyArray": []
+            },
+            "unknownSource": {
+              "keep": "discover"
+            }
+          },
+          {
+            "id": "raw-old-addon-source",
+            "provider": "addon",
+            "title": "",
+            "addonId": "example.synthetic.catalogs",
+            "type": "movie",
+            "catalogId": "old-evidence-catalog",
+            "genre": null,
+            "addonName": "Synthetic Catalogs",
+            "manifestUrl": "https://example.invalid/synthetic/manifest.json",
+            "showInHome": false,
+            "sortHow": "client-order",
+            "unknownSourceEvidence": {
+              "removeWithSource": true
+            }
+          },
+          {
+            "provider": "trakt",
+            "title": "Imported Trakt List",
+            "type": "list",
+            "traktListId": "synthetic-list-42",
+            "providerVersion": 7,
+            "rawOnlyOptions": {
+              "preserve": true
+            }
+          },
+          {
+            "provider": "addon",
+            "title": "Retained Addon",
+            "addonId": "example.synthetic.catalogs",
+            "type": "series",
+            "catalogId": "retained-catalog",
+            "genre": "Drama",
+            "unknownSourceEvidence": {
+              "keepWithSource": true
+            }
+          },
+          {
+            "provider": "community",
+            "title": "Community Feed",
+            "type": "curated-feed",
+            "communityProvider": "synthetic",
+            "communityOptions": {
+              "empty": {},
+              "items": []
+            },
+            "unknownBoolean": false
+          }
+        ],
+        "catalogSources": [
+          {
+            "id": "raw-old-addon-projection",
+            "addonId": "example.synthetic.catalogs",
+            "type": "movie",
+            "catalogId": "old-evidence-catalog",
+            "genre": null,
+            "addonName": "Synthetic Catalogs",
+            "manifestUrl": "https://example.invalid/synthetic/manifest.json",
+            "showInHome": false,
+            "unknownProjectionEvidence": {
+              "removeWithSource": true
+            },
+            "unknownProjectionFalse": false,
+            "unknownProjectionZero": 0,
+            "unknownProjectionNull": null
+          },
+          {
+            "addonId": "example.synthetic.catalogs",
+            "type": "series",
+            "catalogId": "retained-catalog",
+            "genre": "Drama",
+            "unknownProjectionEvidence": {
+              "keepWithSource": true
+            }
+          }
+        ]
+      },
+      {
+        "id": "preservation-empty",
+        "title": "Empty Imported Folder",
+        "sources": [],
+        "catalogSources": [],
+        "unknownEmptyFolderState": {
+          "enabled": false,
+          "count": 0,
+          "items": []
+        }
+      }
+    ]
+  },
+  {
+    "id": "preservation-secondary",
+    "title": "Imported Secondary Profile",
+    "folders": [
+      {
+        "id": "preservation-secondary-folder",
+        "title": "Missing Optional Presentation",
+        "sources": [
+          {
+            "provider": "tmdb",
+            "title": "Company Movies",
+            "tmdbSourceType": "COMPANY",
+            "tmdbId": 9001,
+            "mediaType": "MOVIE",
+            "unknownSecondarySource": "preserved"
+          }
+        ],
+        "catalogSources": []
+      }
+    ],
+    "unknownSecondaryCollection": {
+      "missingKnownPresentationKeys": true
+    }
+  }
+]


### PR DESCRIPTION
Closes #49

## Summary

- add a small manifest-driven v2 collection compatibility regression corpus
- cover canonical native TMDB and addon profiles, mixed preservation cases, imported Trakt and opaque/community data, identity repair, migration, and invalid boundaries
- verify collection, folder, source, and addon-projection ordering
- verify unknown-field, presentation, artwork, null/empty-value, removal, and round-trip preservation contracts
- register the focused corpus suite in the repository checks
- update the builder knowledge base with the confirmed issue #49 contract

## Verification

- `node --test tests/builder-compatibility-corpus.test.mjs` — 10/10
- related builder contract tests — 190/190
- `node scripts/check-all.mjs` — 346/346
- `.\scripts\check.cmd` — 346/346
- `npm run build --prefix builder` — 53 modules
- `node scripts/prepare-pages-site.mjs` — passed
- `node scripts/validate-pages-site.mjs` — passed
- deployment containment check — passed
- `git diff --check` — passed

## Production impact

None.

No production source modules, v1 runtime, Worker code, dependencies, lockfiles, routes, or deployment policies changed. The corpus is synthetic, offline, and excluded from the Pages artifact.

## Deferred boundaries

- no new source types or schema expansion
- no live TMDB, addon, Trakt, or Nuvio requests
- imported Trakt remains opaque preservation-only evidence
- no unsupported source-artwork field was invented
- production defects, if discovered later, require separate reviewed issues