### PR TITLE
Recover and document the V2 product plan and workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,9 @@ Before v2 product, UX, startup, template, recipe, Search/Add, presentation, or p
 ## Git and issue workflow
 
 - Never work directly on `main`.
-- Each meaningful task requires an approved GitHub issue and one dedicated branch from an updated `main`.
+- Discussion, discovery, comparison, and read-only investigation do not require a GitHub issue.
+- Before making a meaningful repository change, create or approve one focused GitHub issue and one dedicated branch from updated `main`.
+- A substantial investigation may use an issue for durable tracking when helpful, but an issue is not required merely to explore an idea.
 - Use one issue per branch. Inspect unexpected main commits, including legitimate automated maintenance, before synchronising them into task work.
 - Keep work limited to the approved issue; do not include unrelated cleanup.
 - Do not open a pull request unless Dave asks.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,12 +10,17 @@ Before v2, builder, Nuvio schema, or export work, read:
 - `docs/v2/BUILDER_KNOWLEDGE.md`
 - the relevant GitHub issue
 
-Repository evidence and confirmed manual tests override old assumptions.
+Before v2 product, UX, startup, template, recipe, Search/Add, presentation, or project-workflow work, also read:
+
+- `docs/v2/BUILDER_PRODUCT_PLAN.md`
+- `docs/v2/PROJECT_WORKFLOW.md`
+
+`BUILDER_PRODUCT_PLAN.md` is the durable product-direction source. `PROJECT_WORKFLOW.md` is the durable Dave/ChatGPT/Codex process. Repository implementation, deterministic tests, and confirmed manual evidence override obsolete plans. Do not silently treat an open product decision as a confirmed requirement.
 
 ## Product boundaries
 
 - v1 is the stable TMDB ID lookup and Nuvio JSON export application at the repository root.
-- v2 is planned as a mobile-first visual Nuvio Collection Builder powered primarily by TMDB.
+- v2 is the active, isolated mobile-first visual Nuvio Collection Builder under `/builder/`, powered primarily by TMDB. It is not yet advertised as a released replacement for v1.
 - Existing lookup and copy-ID workflows remain part of the product.
 - Do not rewrite or remove stable v1 features merely to modernise the code.
 - React/Vite under `/builder/` is the confirmed builder direction; keep domain, parsing, validation, migration, serialization, and ID logic framework-independent.
@@ -24,9 +29,11 @@ Repository evidence and confirmed manual tests override old assumptions.
 ## Git and issue workflow
 
 - Never work directly on `main`.
-- Each meaningful task requires a GitHub issue and a dedicated branch from an updated `main`.
+- Each meaningful task requires an approved GitHub issue and one dedicated branch from an updated `main`.
+- Use one issue per branch. Inspect unexpected main commits, including legitimate automated maintenance, before synchronising them into task work.
 - Keep work limited to the approved issue; do not include unrelated cleanup.
 - Do not open a pull request unless Dave asks.
+- After Dave authorises it, a pull request is the normal final review gate for meaningful v2 work.
 - Do not merge, close the issue, or delete the branch until Dave explicitly approves after review and testing.
 - Stop and report conflicts, unexpected local changes, or ambiguous scope.
 - Use clear commits and report the final commit hash.
@@ -78,6 +85,7 @@ For future builder work:
 - Follow a modern, dark, sleek direction with restrained TMDB-inspired blue, cyan, and green accents.
 - The visual direction is not warm or cosy.
 - Do not copy reference-site branding, wording, or layouts.
+- For long-running phases, prepare a handover before context loss rather than relying on chat memory.
 
 ## Verification
 

--- a/docs/v2/BUILDER_KNOWLEDGE.md
+++ b/docs/v2/BUILDER_KNOWLEDGE.md
@@ -1,19 +1,21 @@
 # TMDB ID Lookup v2 — Builder Knowledge Base
 
-Status: Planning and contract groundwork
+Status: Active isolated builder and contract groundwork
 
-Last reviewed: 2026-07-23
+Last reviewed: 2026-07-25
 
-This is a living record of confirmed v2/Nuvio findings, current decisions, unsupported behaviour, and open questions. GitHub issues remain the source of truth for implementation scope.
+This is a living record of confirmed v2/Nuvio findings, current decisions, unsupported behaviour, and open questions. GitHub issues remain the source of truth for implementation scope. See [`BUILDER_PRODUCT_PLAN.md`](./BUILDER_PRODUCT_PLAN.md) for durable product direction and [`PROJECT_WORKFLOW.md`](./PROJECT_WORKFLOW.md) for the Dave/ChatGPT/Codex process.
 
 ## 1. Product direction
 
 - v1 is working and stable.
 - v2 changes the product from primarily an ID lookup/export utility into the visual **TMDB Collection Builder**, built for Nuvio collections and powered primarily by TMDB.
+- The active React/Vite builder remains isolated under `/builder/`, unlinked, and `noindex, nofollow`; it is not a released replacement for v1.
 - Lookup and copy-ID tools remain available.
 - v2 should be mobile-first, modern, and sleek.
-- No login is required.
+- No login is required for the complete core build-and-export journey. Any future Nuvio connection must remain optional.
 - Playback is outside project scope and should normally remain unmentioned.
+- Startup routes, Dave’s 1-Click Setup, templates/recipes, the Kaptain onboarding comparison, product privacy, branding, and the optional Nuvio connection are maintained in the product plan rather than duplicated here. Exact template contents, final naming, and the connection product contract remain open.
 
 ## 2. Evidence levels
 
@@ -21,6 +23,7 @@ Future findings must use one of these labels:
 
 - **Manually confirmed in Nuvio:** observed in an actual Nuvio client using a recorded input.
 - **Confirmed from current Nuvio source code:** directly supported by the reviewed, pinned Nuvio source revision.
+- **Confirmed by current official Nuvio documentation:** explicitly documented by Nuvio on the cited page and review date; this does not prove undocumented client behaviour.
 - **Confirmed by repository tests:** behaviour or an invariant demonstrated by deterministic repository tests and successful CI.
 - **Confirmed by live deployment:** behaviour directly verified on the deployed production site through recorded HTTP or browser checks.
 - **Strongly inferred:** consistent with available code or behaviour but not directly verified end to end.
@@ -393,7 +396,33 @@ All four issue #38 evidence JSON files, including the untouched owner export, ar
 - Ten focused tests validate the manifest, fixture coverage, taxonomy, safety, Pages exclusion, exact/semantic/targeted policies, round trips, migration, and validation diagnostics. No production module, dependency, v1 runtime, Worker, route, or deployment policy changed.
 - No confirmed source-artwork field exists in current repository or client evidence. The corpus records that boundary and does not invent one.
 
-## 15. Open questions
+## 15. Official Nuvio API and integration boundary
+
+**Confirmed by current official Nuvio documentation, reviewed 2026-07-25:** the [Nuvio Public API](https://nuvio.tv/docs) documents Supabase-based email/password authentication, access/refresh tokens, up to six profiles, profile-scoped resources, and collection pull/push operations. A collection push replaces the profile's complete `collections_json` blob; omission removes collections and an empty array clears it. No separate collection import, merge, or targeted-update endpoint was identified on the reviewed page. This confirms an authenticated collection transport, but not a safe merge/update UI, device-pairing contract, or approved Builder credential-storage design.
+
+The official API's small addon-backed collection example is not presented as a complete collection-source schema. It does not override repository tests and manual evidence that `sources` is authoritative and `catalogSources` is an addon compatibility projection/fallback.
+
+Keep three manifest/source concepts separate:
+
+- **Collection sources** are source objects inside Nuvio collection/folder JSON and follow this repository's evidence-backed source rules.
+- **Stremio-style addons** are profile-scoped addon manifest URLs documented by the API's addon sync.
+- **Nuvio integrations/plugins** are supplementary profile-scoped URLs. The separate [Nuvio Integration Development Guide](https://nuvio.tv/docs?doc=plugins-repo) documents repository `manifest.json` files that register integration JavaScript for local Hermes execution.
+
+The API documents addon and plugin sync as full-replace operations too. Plugin-repository manifests are not collection sources or Stremio addon manifests, and plugin repositories are not core TMDB Collection Builder scope. The official account page at [nuvio.tv/account/login](https://nuvio.tv/account/login) confirms an account-management surface for synced integrations and collections, but it was not used for authenticated testing. The reviewed public documentation did not establish device-pairing endpoints or behaviour; device pairing remains unverified.
+
+## 16. Roadmap checkpoint
+
+The current dependency-aware sequence is:
+
+1. product/workflow recovery;
+2. collection/folder presentation settings;
+3. mandatory Dave UI/flow review;
+4. review corrections;
+5. source creation and Search/Add.
+
+Quick Setup, Dave's 1-Click Setup, templates/recipes, the Kaptain comparison, privacy positioning, branding, and optional Nuvio connection are product-plan topics in [`BUILDER_PRODUCT_PLAN.md`](./BUILDER_PRODUCT_PLAN.md). They do not change the current technical implementation gate.
+
+## 17. Open questions
 
 - Can a future Nuvio source model support direct individual movies or series?
 - Can multiple direct item references ever be exposed as a folder source?
@@ -402,8 +431,10 @@ All four issue #38 evidence JSON files, including the untouched owner export, ar
 - Which future controls need explicit property-removal semantics beyond assigning supported empty or null values?
 - How should known TMDB list IDs be validated?
 - How should future public TMDB list search slot into the architecture?
+- Can the documented full-replace collection API support a safe product-level Add, Merge, or targeted Update journey, and what backup/conflict protocol would be required?
+- Does Nuvio publish a supported device-pairing or browser-handoff contract suitable for third-party builders?
 
-## 16. Update rules
+## 18. Update rules
 
 - Update this file when a test becomes confirmed or disproved.
 - Include the evidence level, review/test date, and source.
@@ -441,6 +472,8 @@ All four issue #38 evidence JSON files, including the untouched owner export, ar
 | 2026-07-22 | V1 company/network lazy runtime consumption, automatic curated/TMDB/emoji fallback, async preparation, Copy/Download parity, and focus-GIF removal | [TMDB ID Lookup issue #46](https://github.com/davecollections/tmdb-id-lookup/issues/46) |
 | 2026-07-23 | Official TMDB Discover inventory/OAS, pinned NuvioTV `dev` and `0.7.19-beta`, pinned NuvioMobile `cmp-rewrite` and `0.3.1`, builder preservation audit, normalized compatibility matrix, bounded manual/direct test plans, and 29/29 owner observations on Desktop alpha plus retained official iOS | [TMDB ID Lookup issue #47](https://github.com/davecollections/tmdb-id-lookup/issues/47), [`TMDB_DISCOVER_COMPATIBILITY.md`](./TMDB_DISCOVER_COMPATIBILITY.md), and [`OWNER_RESULTS_2026-07-23.md`](../../manual-tests/tmdb-discover/OWNER_RESULTS_2026-07-23.md) |
 | 2026-07-24 | Manifest-driven canonical, preservation, identity, migration, and invalid profile corpus connecting current builder compatibility contracts without production changes | [TMDB ID Lookup issue #49](https://github.com/davecollections/tmdb-id-lookup/issues/49) and [`v2-compatibility/README.md`](../../tests/fixtures/nuvio/v2-compatibility/README.md) |
+| 2026-07-24 | Full owner-supplied V1 and V2 conversation histories, reviewed to recover explicit product and workflow intent without committing or reproducing the exports | Private owner-supplied research evidence for [issue #51](https://github.com/davecollections/tmdb-id-lookup/issues/51) |
+| 2026-07-25 | Current public authentication, profiles, full-replace collection sync, addon/plugin sync, account-management surface, and integration-repository boundary | [Nuvio Public API](https://nuvio.tv/docs), [Nuvio Integration Development Guide](https://nuvio.tv/docs?doc=plugins-repo), and [Nuvio account login](https://nuvio.tv/account/login) |
 
 ## Decision history
 
@@ -463,3 +496,5 @@ All four issue #38 evidence JSON files, including the untouched owner export, ar
 - **2026-07-23 — Discover compatibility boundary:** treat official TMDB acceptance, client deserialization, request construction, hidden transformations, persistence, direct result effects, and visible device effects as separate evidence levels; retain the 14-field production contract unchanged; use the generated row-level matrix as the normalized research source; and defer all UI/schema expansion until bounded owner evidence and a separately approved issue.
 - **2026-07-23 — Discover owner-evidence checkpoint:** retain the official counts, 14-field contract, and static mappings; record the complete Desktop alpha and retained official iOS runs as build-specific observations; add a deterministic one-source-per-folder presentation without changing source identity or aggregate counts; keep NuvioTV/direct TMDB pending; and attribute account-export changes only to the observed pipeline until its responsible layer is isolated.
 - **2026-07-24 — Profile-level compatibility corpus:** connect existing focused builder contracts through a small manifest-driven fixture taxonomy; use exact equality only for intentional canonical output, semantic cycle stability for preservation profiles, and targeted assertions for identity, removal, migration, and invalid boundaries; reuse the existing Discover and addon-migration artifacts; and retain a strict test-only production boundary.
+- **2026-07-24 — Product and workflow history recovery:** review the complete owner-supplied V1 and V2 conversation exports to recover explicit product and process intent; reconcile it through current implementation, tests, manual evidence, and GitHub history; preserve unaccepted proposals as proposals or open decisions; and keep the private exports and conversational material outside the repository.
+- **2026-07-25 — Official Nuvio documentation review:** recognise the documented authenticated, profile-scoped, full-replace collection transport while keeping optional connection design deferred; distinguish collection sources, Stremio-style addon manifests, and Nuvio plugin-repository manifests; keep plugin repositories outside core Builder scope; and leave device pairing, safe merge/update semantics, token handling, and recovery unverified.

--- a/docs/v2/BUILDER_PRODUCT_PLAN.md
+++ b/docs/v2/BUILDER_PRODUCT_PLAN.md
@@ -1,0 +1,405 @@
+# TMDB Collection Builder — Product Plan
+
+Status: Durable product direction for the isolated v2 Builder
+
+Last reviewed: 2026-07-25
+
+This document records the current product direction recovered from the owner-supplied V1 and V2 project histories and reconciled with the repository, tests, manual Nuvio evidence, current GitHub history, and official Nuvio documentation. It is not a release claim or an implementation specification.
+
+Decision labels mean:
+
+- **Confirmed:** an owner decision that agrees with current repository evidence.
+- **Confirmed direction:** an approved direction whose detailed design remains future work.
+- **Deferred:** intentionally later than the current roadmap gate.
+- **Open decision:** evidence or owner approval is still required.
+- **Rejected:** not part of the intended product.
+- **Superseded:** replaced by a later decision or stronger evidence.
+
+Implementation, deterministic tests, and confirmed manual Nuvio evidence override obsolete plans. [`BUILDER_KNOWLEDGE.md`](./BUILDER_KNOWLEDGE.md) owns the detailed technical contract.
+
+## 1. Product purpose
+
+**Confirmed**
+
+- V1 remains the stable TMDB ID lookup and Nuvio JSON export utility at the repository root.
+- V2 is the mobile-first visual **TMDB Collection Builder**, made for Nuvio and powered primarily by TMDB.
+- Lookup and copy-ID capabilities remain part of the broader product.
+- Playback is outside scope.
+- V2 must not replace or destabilise V1.
+- The Builder should make collection creation approachable without requiring knowledge of TMDB IDs, raw JSON, source envelopes, `catalogSources`, Discover syntax, or Nuvio implementation details.
+
+The Builder is active but isolated under `/builder/`. It is still unlinked and marked `noindex, nofollow`; this document does not describe it as publicly released.
+
+## 2. Audience
+
+**Confirmed direction**
+
+The product must serve:
+
+- beginners who want a ready-made, bounded setup;
+- people who want a short guided path to a personalised setup;
+- users who need to import and safely edit an existing configuration;
+- advanced users who want manual control;
+- mobile users who need large tap targets and manageable steps;
+- users who want large curated setups without facing one enormous form or raw JSON.
+
+Progressive disclosure should let a beginner reach a useful result while preserving the depth needed by an experienced user.
+
+## 3. Product identity and trust promise
+
+**Confirmed**
+
+- The product name remains **TMDB Collection Builder**.
+- A supporting line such as **Made for Nuvio** may be used; final wording needs later review.
+- The visual direction is modern, dark, sleek, and mobile-first, with restrained TMDB-inspired blue, cyan, and green accents. It is not warm or cosy.
+- No account, personal TMDB API key, or personal information is required to complete the core build-and-export journey.
+- Core importing and editing remain local-first in the browser.
+- **Copy JSON** and **Download JSON** are complete supported paths, not fallback-only features.
+
+**Confirmed direction**
+
+A future Nuvio connection may require Nuvio authentication, but it must remain optional. Product copy must therefore avoid absolute promises such as “no login ever.” The core Builder must not depend on that connection.
+
+## 4. Startup experience
+
+**Confirmed direction**
+
+The intended Builder home presents four routes:
+
+1. **Quick Setup** — answer a few plain-language questions and generate a useful editable setup.
+2. **Use a Template** — choose a curated recipe and customise the generated result.
+3. **Import Existing JSON** — open a current configuration through the preservation-first importer.
+4. **Start Manually** — enter the Builder with a clean hierarchy and full control.
+
+The audience and mental model differ for each route, so they should not be collapsed into one technical import/create form. Users must also be able to return to a meaningful Builder home instead of being trapped in the workspace.
+
+**Current implementation boundary**
+
+The current welcome screen supports starting a clean collection plus local-file or pasted-JSON import. The four-route experience is planned, not implemented.
+
+“Project” is primarily an internal data-model term. It should not become prominent user-facing language unless future persistence gives it a clear user meaning. The Builder does not currently store or manage multiple cloud projects.
+
+## 5. Dave’s 1-Click Setup
+
+**Confirmed direction**
+
+**Dave’s 1-Click Setup** is the working name for the beginner-friendly guided Quick Setup feature. “One-click” means little prior knowledge and a short decision flow, not necessarily one literal button.
+
+The feature:
+
+- generates the normal editable Builder hierarchy;
+- does not create a locked or separate output format;
+- opens the generated setup in the full Builder;
+- allows normal rename, reorder, remove, add, presentation, artwork, review, and export actions;
+- uses sensible defaults and curated recipes;
+- avoids generating the maximum possible setup by default.
+
+The recovered initial questions are:
+
+1. Movies, series, or both?
+2. Which genres do you prefer?
+3. Do you mostly use TV, phone, or both?
+4. Which optional must-haves matter, such as anime, international content, awards, family content, or new releases?
+
+These questions are the confirmed starting direction. Exact copy, optional questions, and branching remain design work.
+
+## 6. Templates and recipes
+
+**Confirmed direction**
+
+Templates are curated starting points. Recipes are inspectable rules that generate ordinary editable Builder data; they are not opaque finished JSON and should remain distinct from serialization output. Recipes may eventually support reusable rules, dynamic dates, dependencies, and versioning.
+
+Recovered candidate presets include:
+
+- Essential;
+- Complete;
+- Full or Dave’s Full Setup;
+- Movies;
+- Series;
+- Family;
+- Dave’s Recommended Setup or Dave’s Setup.
+
+Their exact public names, contents, sizes, and order are **open decisions** for a dedicated recipe-design issue. A useful proposed naming hierarchy is:
+
+- **Quick Setup** — startup route;
+- **Dave’s 1-Click Setup** — guided feature;
+- **Dave’s Recommended Setup** — default curated recipe;
+- **Essential / Complete / Full** — increasing setup sizes.
+
+This hierarchy is a recommendation, not final naming.
+
+An Ultra MAX-scale setup is useful compatibility and advanced-product evidence. It must not become the only template or the beginner default. Curated defaults should expose a manageable subset while leaving the larger catalogue searchable.
+
+## 7. Kaptain comparison and boundaries
+
+**Confirmed comparison lesson**
+
+Kaptain’s broad onboarding pattern offered:
+
+- Set Up & Send to Nuvio;
+- Just give me the collection;
+- Build it manually.
+
+The useful lesson is the separation of audiences before exposing complexity. Kaptain primarily starts with a large curated collection and lets users remove or customise it. TMDB Collection Builder is broader: a user may start with guided setup, a template, entity/search creation, manual creation, or preservation-first import.
+
+Adopt as product principles:
+
+- simple onboarding and plain-language questions;
+- device-aware defaults;
+- guided walkthrough concepts;
+- quick and advanced paths;
+- a clear review before final output.
+
+**Rejected**
+
+- copying Kaptain’s collection, code, branding, wording, layout, files, or artwork;
+- guessing source identities from visible behaviour;
+- replacing the preservation-first importer with a simpler lossy importer;
+- making one enormous setup the only starting experience.
+
+External comparison sites are design evidence, not product or technical authority.
+
+## 8. Search and Add
+
+**Confirmed product principle**
+
+Users choose what they want; the Builder creates the required Nuvio hierarchy.
+
+Search/Add should cover, within the confirmed compatibility contract:
+
+- Actor;
+- Director;
+- Company or Studio;
+- Network;
+- Franchise or TMDB Collection;
+- Genre;
+- Decade;
+- Language;
+- Country;
+- Streaming provider;
+- Custom TMDB Discover.
+
+Suitable categories should support both single and bulk selection. For example, a user can create an Actors collection, select several search results, and let the Builder create the appropriate folders and native `PERSON` sources. The user should not repeat collection → folder → source setup for every actor.
+
+Likely destination concepts are:
+
+- create a new collection;
+- add to an existing collection;
+- add as a folder or source where the hierarchy makes that appropriate.
+
+Exact action labels remain open. A visible plus symbol must perform the creation action a user reasonably expects.
+
+## 9. Search-result information
+
+**Confirmed direction**
+
+Results must contain enough context to distinguish similar entities without reproducing every column from the V1 lookup tables.
+
+For companies and networks, useful fields may include:
+
+- name;
+- TMDB ID where it assists identification;
+- entity type;
+- title count;
+- logo or approved artwork preview when available.
+
+Title counts should reuse the existing V1 cache and maintenance tooling where appropriate instead of creating unnecessary live requests. Result detail must remain proportionate to the choice being made.
+
+## 10. Automatic hierarchy and hidden IDs
+
+**Confirmed and implemented foundation**
+
+- Collection and folder Nuvio IDs are generated automatically.
+- Nuvio-facing IDs remain hidden from ordinary users.
+- Missing, blank, invalid, or duplicate IDs are repaired silently where current controller behaviour permits.
+- Builder-only internal IDs remain separate from Nuvio-facing IDs and never enter output.
+- Users should not need to understand UUIDs.
+- Predictable hierarchy should be generated automatically rather than requiring unnecessary clicks.
+
+Hidden does not mean unvalidated. Diagnostics and automatic repair protect output without turning identifiers into a normal editing task.
+
+## 11. Presentation and device-aware defaults
+
+**Confirmed Nuvio behaviour from repository evidence**
+
+- **Rows** presents folder/source groups as streaming-style rows.
+- **Tabs** with Show All disabled presents individual tabs and defaults to the first tab.
+- **Tabs** with Show All enabled adds **All** as the first/default tab.
+- These are collection-level settings.
+
+**Confirmed direction**
+
+The TV / phone / both Quick Setup answer may select safer initial presentation defaults. Defaults must stay editable and be based on current client evidence rather than assumptions. Exact per-device defaults remain open.
+
+Presentation settings are the next planned implementation area after this documentation recovery.
+
+## 12. TMDB Discover experience
+
+**Confirmed direction**
+
+Discover should use understandable controls instead of making raw filter syntax the primary interface. Movies and series are separate source requests; selecting both may generate two sources. Advanced options should use progressive disclosure.
+
+Product use cases include:
+
+- 1990s Action;
+- Shark Movies;
+- provider and region filtering;
+- language and country;
+- company and network;
+- genre and keyword;
+- date ranges;
+- rating and vote count.
+
+Only fields and combinations inside the confirmed Nuvio compatibility contract may become supported controls. TMDB accepting a parameter is not enough to prove Nuvio compatibility. Composite concepts such as Romantic Comedy may require a curated recipe or keyword logic and must not be presented as a single official TMDB genre. Runtime-length filtering remains unsupported unless later evidence expands the contract.
+
+See [`TMDB_DISCOVER_COMPATIBILITY.md`](./TMDB_DISCOVER_COMPATIBILITY.md) for the current evidence boundary.
+
+## 13. Artwork behaviour
+
+**Confirmed direction**
+
+Artwork should normally feel automatic rather than technical:
+
+1. use approved published curated artwork when available;
+2. otherwise use a suitable cached TMDB image or logo where the applicable consumer supports it;
+3. otherwise retain a visible title and emoji fallback.
+
+Imported or custom nonblank artwork must be preserved unless the user changes it. Runtime-owned automatic artwork may refresh under a later approved policy. Builder-only ownership metadata must never leak into Nuvio JSON. Missing artwork must not prevent collection creation.
+
+The separate `nuvio-assets` project owns artwork production, replacement, review, publication, runtime schema, and asset-contract decisions. TMDB ID Lookup consumes its published runtime. Questions owned by that project must be taken there instead of guessed in V2.
+
+This plan does not add or alter artwork behaviour.
+
+## 14. Import and editing
+
+**Confirmed and partly implemented**
+
+- Existing JSON import is a first-class startup route.
+- The preservation-first importer and serializer are core product advantages.
+- Unknown and community fields survive unrelated edits.
+- Opaque sources remain preservable, movable, and removable without being guessed into known source types.
+- Imported artwork and presentation values remain protected unless changed by the user.
+- Import and export should be understandable without requiring raw-JSON editing.
+
+Nuvio client import behaviour can be destructive or can change by client and version. Instructions must therefore remain dated and updateable, warn before replacement, and distinguish observed behaviour from assumptions.
+
+## 15. Review, export, and installation journey
+
+**Confirmed direction**
+
+The intended journey is:
+
+1. choose a starting route;
+2. generate or import a setup;
+3. edit it in the full Builder;
+4. review collection, folder, and source counts plus warnings;
+5. validate the output;
+6. Copy JSON or Download JSON;
+7. follow current, evidence-backed Nuvio import guidance;
+8. later, optionally Send to Nuvio through a verified integration.
+
+Review should disclose external dependencies and what will be added or replaced. Manual export must remain available after any future connection feature.
+
+## 16. Optional future Nuvio connection
+
+**Deferred, with a partially confirmed external contract**
+
+Official Nuvio public API documentation reviewed 2026-07-25 explicitly documents:
+
+- email/password authentication and access/refresh tokens;
+- up to six profiles with profile-scoped resources;
+- collection pull and push operations;
+- full replacement of the profile’s complete `collections_json` blob, where omitted collections are removed and an empty array clears it.
+
+Source: [Nuvio Public API](https://nuvio.tv/docs), reviewed 2026-07-25.
+
+No separate collection import, merge, or targeted-update endpoint was identified on the reviewed page. This establishes that an authenticated collection transport exists. It does **not** make connection part of the core Builder or establish a safe product flow. Before implementation, a dedicated issue still needs verified answers for:
+
+- supported authentication, browser handoff, or device pairing;
+- profile selection;
+- how an intended Add / Merge / Overwrite experience can be provided over a documented full-replace API;
+- initial setup versus later update targeting;
+- token storage, refresh, expiry, disconnect, and revocation;
+- privacy disclosures;
+- backup, conflict, partial-failure, and recovery behaviour;
+- whether a safe update is possible without destructive replacement.
+
+The reviewed documentation did not establish a public device-pairing contract. That remains unverified. The Builder must not infer its design from a third-party “Connect” button, ask users to paste credentials into an unreviewed flow, or expose long-lived tokens without an approved security model.
+
+Manual Copy/Download remains complete and supported.
+
+### Integration terminology boundary
+
+**Confirmed from official documentation reviewed 2026-07-25**
+
+These are three different concepts:
+
+1. **Nuvio collection sources** — source objects inside collection/folder JSON; the repository’s evidence-backed `sources` and compatibility `catalogSources` rules apply.
+2. **Stremio-style addons** — profile-scoped addon manifest URLs used by Nuvio’s addon sync.
+3. **Nuvio integration/plugin repositories** — repository `manifest.json` files that register locally executed integration JavaScript for Hermes.
+
+The third concept is documented in the [Nuvio Integration Development Guide](https://nuvio.tv/docs?doc=plugins-repo), reviewed 2026-07-25. Plugin repositories are not part of the TMDB Collection Builder’s core scope. Their manifests must not be treated as collection sources or Stremio addon manifests.
+
+## 17. Branding
+
+**Deferred product direction**
+
+- A Dave Collections master brand is preferred to a product logo that could imply official TMDB endorsement.
+- Product colourways may distinguish Nuvio and possible future tools.
+- The product title should remain ordinary UI text rather than being permanently embedded in a logo.
+- Final logo design is deferred and must not delay functional Builder work.
+
+Trakt integration remains outside current project scope; a possible future colourway is not approval to begin Trakt work.
+
+## 18. Roadmap and mandatory gates
+
+**Confirmed current dependency-aware direction**
+
+1. Product-plan and workflow recovery — this issue.
+2. Collection/folder presentation settings.
+3. Mandatory Dave UI and flow review.
+4. Resolve the review findings.
+5. Source creation and Search/Add.
+6. Advanced Discover creation.
+7. Deliberate V2 artwork-runtime integration at the appropriate typed-source stage.
+8. Quick Setup, templates, and recipe engine after underlying creation flows are reliable.
+9. Review/export usability.
+10. Optional Nuvio connection only after its product, authentication, security, and replacement contract is verified.
+
+This is a dependency map, not a rigid release schedule. Each step requires its own approved issue and may be refined by stronger evidence.
+
+## 19. Open decisions
+
+| Decision | Why it remains open |
+| --- | --- |
+| Final public name for the one-click feature | Dave’s 1-Click Setup is the working name; final product copy needs review. |
+| Final template names | Essential, Complete, Full, and Dave’s Setup are recovered concepts, not approved public labels. |
+| Exact Essential / Complete / Full contents | Requires a dedicated recipe-design issue and size/performance judgement. |
+| Category toggles before generation | The right balance between speed and control has not been designed. |
+| Default collection ordering | Recovered examples differ and should be tested with real setups. |
+| Region/provider questions | Regional relevance and provider-filter semantics need product and compatibility decisions. |
+| Exact TV / phone / both defaults | Must follow current client evidence and owner UI review. |
+| Startup-screen visual layout | The four routes are decided; their presentation is not. |
+| Exact Search/Add action wording | Destination concepts are known, but button labels and branching need UX work. |
+| Direct Nuvio connection flow | Transport exists, but full replacement, authentication, safe updates, and recovery need design and verification. |
+| Saved Builder project format | Not needed for the current local JSON flow; revisit only when persistence needs justify it. |
+| Removal of `noindex` | Requires explicit release-readiness approval. |
+| Final Dave Collections branding | Preferred direction is recorded; design remains deferred. |
+
+## 20. Explicit product non-goals
+
+**Rejected or out of scope**
+
+- playback;
+- a recommendation engine;
+- mandatory accounts;
+- mandatory cloud project storage;
+- requiring personal TMDB API keys;
+- guessing unsupported Nuvio source types;
+- replacing or rewriting stable V1 merely to modernise it;
+- copying Kaptain or Ultra MAX implementations;
+- converting imported opaque data into guessed known sources;
+- treating Stremio addon manifests or Nuvio plugin-repository manifests as collection-source JSON;
+- making optional integrations mandatory;
+- plugin-repository development as a core Builder feature;
+- Trakt integration without a future explicitly approved issue.

--- a/docs/v2/PROJECT_WORKFLOW.md
+++ b/docs/v2/PROJECT_WORKFLOW.md
@@ -71,10 +71,16 @@ The planning chat recommends effort for each task based on scope and risk.
 
 ## 4. Issue and branch workflow
 
+### Discovery before issues
+
+Dave and the ChatGPT planning/review chat may discuss, compare, investigate, and decide whether repository work is justified before an issue or branch exists. Read-only product or repository research does not require either, and no issue is needed when the decision is to take no action. Do not turn every conversation into an issue.
+
+Once Dave approves a durable repository change, its focused issue records the decided scope and enough context to explain why the change is being made. A substantial investigation may use an issue earlier when durable tracking is helpful, but exploratory discussion alone does not require one.
+
 The normal sequence is:
 
-1. Review the backlog, current repository, and relevant evidence.
-2. Define one focused issue.
+1. Discuss, investigate, and decide whether repository work is justified.
+2. Once a durable repository change is approved, define one focused issue.
 3. Update `main`, then create one dedicated branch.
 4. Implement only that issue.
 5. Run repository and issue-specific checks.
@@ -97,7 +103,7 @@ The following remain absolute:
 
 ## 5. Repository preflight
 
-Before a meaningful task:
+Before repository-changing work begins:
 
 ```powershell
 git fetch origin --prune
@@ -109,11 +115,11 @@ git rev-parse HEAD
 git rev-parse origin/main
 ```
 
-Confirm that `main` equals `origin/main` and the worktree is clean. Inspect every unexpected newer commit before continuing. Legitimate automated maintenance may be accepted only after confirming that it does not overlap the issue. Stop for conflicts, unexpected manual changes, unrelated local work, or ambiguous scope.
+This formal Git preflight is not required for ordinary conversation or read-only product research. Before edits begin, confirm that `main` equals `origin/main` and the worktree is clean. Inspect every unexpected newer commit before continuing. Legitimate automated maintenance may be accepted only after confirming that it does not overlap the issue. Stop for conflicts, unexpected manual changes, unrelated local work, or ambiguous scope.
 
 ## 6. Scope control
 
-- Use one issue and one dedicated branch for one bounded outcome.
+- Once repository work starts, use one issue and one dedicated branch for one bounded outcome.
 - Do not begin a second issue on the current branch.
 - Do not work directly on `main`.
 - Do not force-push or rewrite reviewed commits.

--- a/docs/v2/PROJECT_WORKFLOW.md
+++ b/docs/v2/PROJECT_WORKFLOW.md
@@ -1,0 +1,206 @@
+# TMDB ID Lookup — Project Workflow
+
+Status: Durable owner, planning, repository, and review process
+
+Last reviewed: 2026-07-25
+
+This document describes how Dave, the ChatGPT planning/review chat, Codex, GitHub, and repository evidence work together. Repository-specific enforceable rules remain in [`AGENTS.md`](../../AGENTS.md); current product direction is in [`BUILDER_PRODUCT_PLAN.md`](./BUILDER_PRODUCT_PLAN.md).
+
+## 1. Roles
+
+### Dave
+
+- Owns product decisions and final approval.
+- Supplies manual UI, artwork, and Nuvio-client evidence where repository checks cannot establish behaviour.
+- Approves issue scope, pull-request creation, merge, and branch cleanup.
+- May challenge ChatGPT or Codex and expects them to challenge risky assumptions appropriately.
+
+### ChatGPT planning and review chat
+
+- Investigates, reconstructs product context, and prepares focused Codex prompts.
+- Reviews completed branches and pull requests independently.
+- Tracks continuity and prepares handovers.
+- Does not edit the repository unless Dave explicitly asks.
+- Separates evidence, inference, recommendation, and owner decision.
+
+### Codex
+
+- Reads repository guidance, the relevant issue, and required specialist documentation.
+- Performs only the approved repository changes.
+- Runs checks, commits, pushes, and reports evidence.
+- Stops at owner, manual-test, pull-request, and merge gates.
+- Does not broaden scope to solve adjacent problems.
+
+## 2. New chat versus same chat
+
+Start a new Codex chat when:
+
+- starting a new GitHub issue;
+- beginning a separately scoped implementation task;
+- the previous issue is complete;
+- fresh context is needed to load substantially updated repository guidance.
+
+Continue in the same Codex chat when:
+
+- refining the current issue;
+- addressing review findings for that issue;
+- committing or pushing follow-up changes on the same branch;
+- opening the approved pull request for the same issue;
+- completing the approved merge and cleanup for that issue.
+
+Only the first prompt of a new chat should provide the Codex chat name. Do not repeatedly instruct the same chat to rename itself.
+
+Every prompt should say near the top either:
+
+- **Start a new Codex chat in the project**, or
+- **Continue in the current Codex chat**.
+
+Provide prompts as one uninterrupted copyable block where practical.
+
+## 3. Model, effort, and speed guidance
+
+This is an operating preference, not a repository requirement:
+
+- Model: GPT-5.6 SOL.
+- Speed: Fast.
+- High effort: contained changes, UI fixes, and straightforward migrations.
+- Xtra High effort: architecture, shared modules, importers, serializers, cache pipelines, compatibility research, and normal substantial features.
+- Ultra effort: broad audits, major restructuring, or unusually risky cross-system work.
+
+The planning chat recommends effort for each task based on scope and risk.
+
+## 4. Issue and branch workflow
+
+The normal sequence is:
+
+1. Review the backlog, current repository, and relevant evidence.
+2. Define one focused issue.
+3. Update `main`, then create one dedicated branch.
+4. Implement only that issue.
+5. Run repository and issue-specific checks.
+6. Complete owner/manual testing where evidence requires it.
+7. Have the ChatGPT planning/review chat independently review the branch.
+8. Dave approves opening a pull request.
+9. Run PR checks and final review against the unchanged reviewed head.
+10. Dave approves merge and the merge method.
+11. Merge through the pull request.
+12. Confirm issue closure, delete approved local/remote branches, and return to clean synchronized `main`.
+
+Earlier V1 work sometimes merged feature branches directly. That practice is **superseded for meaningful V2 work**: a pull request is now the normal final integration gate.
+
+The following remain absolute:
+
+- one issue per branch;
+- do not open a pull request unless Dave asks;
+- do not merge unless Dave explicitly approves;
+- do not close the issue or delete branches before successful merge and approval.
+
+## 5. Repository preflight
+
+Before a meaningful task:
+
+```powershell
+git fetch origin --prune
+git switch main
+git pull --ff-only origin main
+git status --short
+git branch --show-current
+git rev-parse HEAD
+git rev-parse origin/main
+```
+
+Confirm that `main` equals `origin/main` and the worktree is clean. Inspect every unexpected newer commit before continuing. Legitimate automated maintenance may be accepted only after confirming that it does not overlap the issue. Stop for conflicts, unexpected manual changes, unrelated local work, or ambiguous scope.
+
+## 6. Scope control
+
+- Use one issue and one dedicated branch for one bounded outcome.
+- Do not begin a second issue on the current branch.
+- Do not work directly on `main`.
+- Do not force-push or rewrite reviewed commits.
+- Do not include unrelated cleanup.
+- Do not hide production fixes inside documentation or test-only tasks.
+- Do not add dependencies without explicit approval.
+- Preserve stable V1 and the current Builder contract unless the issue explicitly changes them.
+- Treat a comparison project as research, not permission to copy code, wording, branding, layout, data, or artwork.
+
+## 7. Review and testing gates
+
+Repository checks do not replace manual UI or Nuvio-client testing where visual or runtime evidence matters.
+
+- Dave’s UI/flow review is mandatory after major visible phases and specifically after collection/folder presentation work before source creation begins.
+- Visual judgement, artwork publication, import behaviour, and client compatibility may require owner evidence.
+- Report material findings as soon as they are known.
+- A failed check, conflict, or ambiguous evidence stops progression until resolved.
+- Do not open a pull request or merge while required checks or evidence are pending or failing.
+- Do not present a build-specific observation as a universal Nuvio guarantee.
+
+## 8. Pull requests
+
+- Pull requests are the normal final integration gate for meaningful V2 work.
+- Codex does not open one automatically.
+- The ChatGPT planning/review chat reviews the completed pushed branch first.
+- Dave authorises pull-request creation.
+- The PR body links the issue and uses closing syntax where appropriate.
+- The final head SHA must remain the SHA that was reviewed; later changes require renewed review.
+- Choose the merge method explicitly.
+- Do not squash or rebase when the approved workflow specifies a normal merge commit.
+
+## 9. Final reports
+
+Every Codex implementation report includes:
+
+- issue number and URL;
+- branch and commit SHA;
+- complete changed-file list;
+- checks and results;
+- production behaviour impact;
+- assumptions and unverified points;
+- whether production files changed;
+- confirmation that no unrelated changes were made;
+- current branch and worktree status;
+- the recommended next step without beginning it.
+
+PR and merge reports also include:
+
+- PR URL;
+- final checks;
+- merge SHA and method;
+- issue-closure state;
+- local and remote branch-cleanup state;
+- final `main` synchronization.
+
+## 10. Cross-project artwork boundary
+
+- `nuvio-assets` owns artwork generation, replacement, review, publication, runtime schema, and asset-contract questions.
+- `tmdb-id-lookup` consumes the approved published runtime.
+- V2 must not silently work around an assets-owned defect.
+- Exact entity type plus TMDB ID is authoritative; names do not substitute for typed identity.
+- When repository evidence is insufficient, prepare a focused question for the assets chat.
+- Do not mix repository writes between the two workstreams or use a V2 issue to alter the assets repository.
+
+## 11. Continuity and chat handovers
+
+The project has previously reached the end of a long planning chat without a useful warning. Long phases therefore need proactive continuity management.
+
+Before a major new phase in an already long chat, prepare a handover rather than waiting for context failure. Include:
+
+- current repository and relevant branch SHA;
+- completed issues and pull requests;
+- current architecture and evidence boundaries;
+- confirmed product decisions;
+- unresolved questions;
+- the next approved step.
+
+Repository documents remain the durable source of truth. Conversational handovers should not be committed unless they are specifically needed and approved. The planning chat should warn Dave when continuity risk is becoming material, but must not promise a precise context percentage when none is available.
+
+## 12. Decision quality
+
+Dave’s standing expectation is:
+
+- do not agree merely for the sake of agreeing;
+- acknowledge useful ideas;
+- challenge risky, inconsistent, unnecessarily complex, or low-value ideas;
+- offer a better bounded alternative when one exists;
+- do not overengineer;
+- distinguish technical fact, recorded evidence, inference, recommendation, and owner decision;
+- keep unresolved product choices open instead of silently converting them into requirements.


### PR DESCRIPTION
Closes #51

## Summary

- recover the durable V2 product direction from the complete owner-supplied V1 and V2 project histories
- add a status-labelled Builder product plan covering startup routes, Dave’s 1-Click Setup, templates, Search/Add, presentation, Discover, artwork, preservation, export, branding, and deferred connection work
- add a durable Dave / ChatGPT / Codex workflow covering discovery, issue and branch rules, chat continuity, pull-request gates, testing, reporting, artwork ownership, and handovers
- clarify that discussion, comparison, discovery, and read-only investigation do not require a GitHub issue
- require a focused issue and branch once an approved repository change is ready to begin
- update `AGENTS.md` with concise required-reading, repository-change, PR, product-authority, and continuity rules
- update the Builder knowledge base with the recovered roadmap and the current official Nuvio API/integration boundary
- keep undecided naming, recipe contents, device defaults, connection security, safe update behaviour, saved-project format, branding, and release readiness explicitly open

## Decision and evidence handling

- current implementation, deterministic tests, and confirmed manual Nuvio evidence remain authoritative
- later owner corrections supersede earlier conversation statements
- accepted recommendations are distinguished from unaccepted proposals
- private conversation exports were used only as research evidence and were not committed or reproduced
- collection sources, Stremio-style addon manifests, and Nuvio plugin-repository manifests remain separate concepts
- the documented authenticated collection transport is full-profile replacement; safe merge/update, device pairing, token handling, and recovery remain deferred
- exploratory conversation does not require an issue; approved repository-changing work does

## Workflow clarification

The recovered workflow now explicitly distinguishes:

- discussion, discovery, comparison, and read-only investigation, which may occur without an issue or branch;
- optional issues for substantial investigations when durable tracking is useful;
- approved repository changes, which require one focused issue and one dedicated branch before edits begin.

Issues should retain enough context to explain the approved change, but do not need to reproduce the complete preceding conversation.

## Verification

- `.\scripts\check.cmd`
- `node scripts/check-all.mjs`
- `npm run build --prefix builder`
- `node scripts/prepare-pages-site.mjs`
- `node scripts/validate-pages-site.mjs`
- `git diff --check`
- relative Markdown-link validation
- changed-file scope audit
- transcript, privacy, credential, and Pages-artifact containment checks
- generated-output tracking audit

## Production impact

None.

No production code, Builder behaviour, V1 behaviour, tests, fixtures, dependencies, workflows, assets, deployment configuration, Worker configuration, authentication, or runtime behaviour changed.

## Deferred work

- collection and folder presentation settings
- mandatory Dave UI and flow review
- source creation and Search/Add
- advanced Discover controls
- V2 artwork-runtime integration
- Quick Setup, templates, and recipes
- optional direct Nuvio connection