### PR TITLE
Make Builder client evidence line-ending safe on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,7 @@
 manual-tests/nuvio-desktop/addon-projection-migration/*.json text eol=lf
 manual-tests/nuvio-desktop/addon-projection-migration/nuvio-desktop-export.json -text
+
+manual-tests/nuvio-clients/issue-59-builder-reordering/*.md text eol=lf
+manual-tests/nuvio-clients/issue-59-builder-reordering/*.json text eol=lf
+manual-tests/nuvio-clients/issue-59-builder-reordering/nuvio-desktop-export.json -text
+manual-tests/nuvio-clients/issue-59-builder-reordering/nuviotv-web-export.json -text

--- a/tests/builder-reordering-client-evidence.test.mjs
+++ b/tests/builder-reordering-client-evidence.test.mjs
@@ -14,6 +14,19 @@ import { isPagesPublicFilePath } from "../scripts/pages-public-paths.mjs";
 
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const checkerPath = path.join("scripts", "check-builder-reordering-client-evidence.mjs");
+const evidenceAttributePolicy = new Map([
+	["README.md", { text: "set", eol: "lf" }],
+	["builder-reordered-input.json", { text: "set", eol: "lf" }],
+	["completed-evidence.md", { text: "set", eol: "lf" }],
+	["expected-order.json", { text: "set", eol: "lf" }],
+	["generation-report.json", { text: "set", eol: "lf" }],
+	["mobile-owner-evidence.json", { text: "set", eol: "lf" }],
+	["nuvio-desktop-export.json", { text: "unset" }],
+	["nuviotv-web-export.json", { text: "unset" }],
+	["seed-profile.json", { text: "set", eol: "lf" }],
+	["tv-owner-evidence.json", { text: "set", eol: "lf" }],
+	["verification-report.json", { text: "set", eol: "lf" }],
+]);
 
 function sha256(bytes) {
 	return createHash("sha256").update(bytes).digest("hex");
@@ -95,6 +108,36 @@ test("issue #59 client evidence remains outside the Pages public-path contract",
 			isPagesPublicFilePath(`manual-tests/nuvio-clients/issue-59-builder-reordering/${fileName}`),
 			false,
 			`${fileName} must remain repository-only evidence.`,
+		);
+	}
+});
+
+test("issue #59 client evidence has deterministic effective Git attributes", () => {
+	const evidencePaths = [...evidenceAttributePolicy.keys()].map((fileName) => (
+		path.relative(rootDir, path.join(evidenceDirectory, fileName)).split(path.sep).join("/")
+	));
+	const output = execFileSync(
+		"git",
+		["check-attr", "-z", "text", "eol", "--", ...evidencePaths],
+		{ cwd: rootDir, encoding: "utf8" },
+	);
+	const fields = output.split("\0");
+	assert.equal(fields.pop(), "");
+	assert.equal(fields.length % 3, 0);
+
+	const attributesByFile = new Map();
+	for (let index = 0; index < fields.length; index += 3) {
+		const fileName = path.basename(fields[index]);
+		const attributes = attributesByFile.get(fileName) ?? {};
+		attributes[fields[index + 1]] = fields[index + 2];
+		attributesByFile.set(fileName, attributes);
+	}
+
+	for (const [fileName, expected] of evidenceAttributePolicy) {
+		assert.deepEqual(
+			attributesByFile.get(fileName),
+			expected.text === "unset" ? { text: "unset", eol: "lf" } : expected,
+			`${fileName} has unexpected effective Git attributes.`,
 		);
 	}
 });


### PR DESCRIPTION
## Summary

- Makes the deterministic issue #59 client-evidence verification portable on Windows.
- Requires LF checkout materialisation for ordinary evidence JSON and Markdown files.
- Preserves the Desktop and web raw-export files as exact bytes using `-text`.
- Adds regression coverage for Git’s effective `text` and `eol` attributes across all eleven evidence files.

## Problem

The evidence checker validates exact working-tree byte sizes and SHA-256 values.

On Windows with `core.autocrlf=true`, evidence files without explicit attributes were checked out as CRLF. For example:

- committed `builder-reordered-input.json`: 8,545 bytes;
- Windows working tree before this correction: 8,841 bytes;
- difference: 296 bytes across 296 lines.

The committed evidence blobs and approved hashes were unchanged.

## Changes

- Adds explicit `.gitattributes` policies for the issue #59 evidence directory.
- Keeps ordinary JSON and Markdown as `text eol=lf`.
- Keeps `nuvio-desktop-export.json` and `nuviotv-web-export.json` byte-preserved with `-text`.
- Tests the effective Git attributes using path-safe `git check-attr -z text eol` arguments.

## Validation

- Focused evidence suite: 4/4.
- Direct evidence checker passed.
- Both full validation entry points: 415/415.
- Builder production build passed.
- Pages preparation and validation passed.
- No evidence path, identifier or export hash appeared in the Pages artifact.
- All eleven evidence files retained their original modes and exact blob IDs.
- Evidence sizes, hashes and content remained unchanged.
- `git diff --check` passed.

## Boundaries

This PR changes no:

- Builder production behaviour;
- client evidence content or expected hashes;
- dependency or lockfile;
- v1 or Worker code;
- workflow or Pages-publication boundary;
- artwork runtime or Network Poster behaviour;
- `nuvio-assets` file.

The branch is based on the reviewed PR #60 merge commit. Current main contains one unrelated automated `data/genre-counts.json` update, which was intentionally not integrated into the issue branch.

Closes #61
