### PR TITLE
fix(validation): repair Windows line endings and exit codes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,5 @@ manual-tests/nuvio-clients/issue-59-builder-reordering/*.md text eol=lf
 manual-tests/nuvio-clients/issue-59-builder-reordering/*.json text eol=lf
 manual-tests/nuvio-clients/issue-59-builder-reordering/nuvio-desktop-export.json -text
 manual-tests/nuvio-clients/issue-59-builder-reordering/nuviotv-web-export.json -text
+
+manual-tests/nuvio-clients/issue-65-builder-add-source/builder-generated-tmdb-collection.json text eol=lf

--- a/scripts/check-all.mjs
+++ b/scripts/check-all.mjs
@@ -3,6 +3,25 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const controlledTestExitCode = process.env.TMDB_ID_LOOKUP_CHECK_TEST_EXIT_CODE;
+
+if (
+	process.env.TMDB_ID_LOOKUP_CHECK_TEST_MODE === "1" &&
+	controlledTestExitCode !== undefined
+) {
+	const parsedExitCode = Number(controlledTestExitCode);
+	if (
+		!Number.isInteger(parsedExitCode) ||
+		parsedExitCode < 0 ||
+		parsedExitCode > 255 ||
+		String(parsedExitCode) !== controlledTestExitCode
+	) {
+		throw new Error("TMDB_ID_LOOKUP_CHECK_TEST_EXIT_CODE must be a canonical integer from 0 through 255.");
+	}
+
+	console.log(`Controlled check-all test exit: ${parsedExitCode}.`);
+	process.exit(parsedExitCode);
+}
 
 function runNode(args) {
 	execFileSync(process.execPath, args, {
@@ -33,6 +52,7 @@ runNode(["--test", path.join("tests", "builder-node-editing.test.mjs")]);
 runNode(["--test", path.join("tests", "builder-auto-ids-workspace-flow.test.mjs")]);
 runNode(["--test", path.join("tests", "builder-add-source-foundation.test.mjs")]);
 runNode(["--test", path.join("tests", "builder-add-source-ui.test.mjs")]);
+runNode(["--test", path.join("tests", "windows-validation.test.mjs")]);
 runNode([path.join("scripts", "check-builder-add-source-fixture.mjs")]);
 runNode([path.join("scripts", "generate-migration-round-trip.mjs"), "--check"]);
 runNode([path.join("scripts", "check-migration-round-trip-export.mjs")]);

--- a/scripts/check.cmd
+++ b/scripts/check.cmd
@@ -4,10 +4,13 @@ setlocal
 set "ROOT=%~dp0.."
 set "BUNDLED_NODE=%USERPROFILE%\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe"
 
-if exist "%BUNDLED_NODE%" (
-	"%BUNDLED_NODE%" "%ROOT%\scripts\check-all.mjs"
-	exit /b %ERRORLEVEL%
-)
+if "%TMDB_ID_LOOKUP_CHECK_TEST_MODE%"=="1" if defined TMDB_ID_LOOKUP_CHECK_TEST_NODE set "BUNDLED_NODE=%TMDB_ID_LOOKUP_CHECK_TEST_NODE%"
 
+if not exist "%BUNDLED_NODE%" goto system_node
+
+"%BUNDLED_NODE%" "%ROOT%\scripts\check-all.mjs"
+exit /b %ERRORLEVEL%
+
+:system_node
 node "%ROOT%\scripts\check-all.mjs"
 exit /b %ERRORLEVEL%

--- a/tests/windows-validation.test.mjs
+++ b/tests/windows-validation.test.mjs
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const fixtureRelativePath = "manual-tests/nuvio-clients/issue-65-builder-add-source/builder-generated-tmdb-collection.json";
+const fixturePath = path.join(rootDir, ...fixtureRelativePath.split("/"));
+const fixtureCheckerPath = path.join(rootDir, "scripts", "check-builder-add-source-fixture.mjs");
+
+function runWindowsCheck(controlledExitCode) {
+	return spawnSync(
+		process.env.ComSpec ?? "cmd.exe",
+		["/d", "/s", "/c", "scripts\\check.cmd"],
+		{
+			cwd: rootDir,
+			encoding: "utf8",
+			env: {
+				...process.env,
+				TMDB_ID_LOOKUP_CHECK_TEST_MODE: "1",
+				TMDB_ID_LOOKUP_CHECK_TEST_NODE: process.execPath,
+				TMDB_ID_LOOKUP_CHECK_TEST_EXIT_CODE: String(controlledExitCode),
+			},
+		},
+	);
+}
+
+function subprocessResult(result) {
+	return [
+		`status=${result.status}`,
+		`signal=${result.signal}`,
+		`stdout=${result.stdout}`,
+		`stderr=${result.stderr}`,
+	].join("\n");
+}
+
+test("issue #65 generated fixture has effective LF attributes and unchanged semantic JSON", () => {
+	const attributeOutput = execFileSync(
+		"git",
+		["check-attr", "-z", "text", "eol", "--", fixtureRelativePath],
+		{ cwd: rootDir, encoding: "utf8" },
+	);
+	const attributeFields = attributeOutput.split("\0");
+	assert.equal(attributeFields.pop(), "");
+	assert.deepEqual(attributeFields, [
+		fixtureRelativePath,
+		"text",
+		"set",
+		fixtureRelativePath,
+		"eol",
+		"lf",
+	]);
+
+	const fixtureBytes = fs.readFileSync(fixturePath);
+	const fixtureText = fixtureBytes.toString("utf8");
+	assert.match(fixtureText, /\n/u);
+	assert.doesNotMatch(fixtureText, /\r\n/u);
+
+	const committedFixtureBytes = execFileSync(
+		"git",
+		["show", `HEAD:${fixtureRelativePath}`],
+		{ cwd: rootDir },
+	);
+	assert.deepEqual(
+		JSON.parse(fixtureText),
+		JSON.parse(committedFixtureBytes.toString("utf8")),
+	);
+
+	const checkerOutput = execFileSync(
+		process.execPath,
+		[fixtureCheckerPath],
+		{ cwd: rootDir, encoding: "utf8" },
+	);
+	assert.match(
+		checkerOutput,
+		/Sanitized issue #65 TMDB COLLECTION review fixture matches production Builder output\./u,
+	);
+});
+
+test("scripts/check.cmd returns zero when its controlled child succeeds", {
+	skip: process.platform !== "win32",
+}, () => {
+	const result = runWindowsCheck(0);
+
+	assert.equal(result.error, undefined, subprocessResult(result));
+	assert.equal(result.signal, null, subprocessResult(result));
+	assert.equal(result.status, 0, subprocessResult(result));
+	assert.match(result.stdout, /Controlled check-all test exit: 0\./u);
+});
+
+test("scripts/check.cmd propagates its controlled child failure code", {
+	skip: process.platform !== "win32",
+}, () => {
+	const result = runWindowsCheck(37);
+
+	assert.equal(result.error, undefined, subprocessResult(result));
+	assert.equal(result.signal, null, subprocessResult(result));
+	assert.equal(result.status, 37, subprocessResult(result));
+	assert.match(result.stdout, /Controlled check-all test exit: 37\./u);
+});


### PR DESCRIPTION
## Summary

Repairs two Windows validation defects discovered during post-merge verification of the TMDB collection Add Source work.

## Included

- enforce LF checkout for the generated TMDB collection evidence fixture;
- preserve the fixture’s existing bytes and semantic JSON content;
- ensure `scripts/check.cmd` returns the actual child-process exit code;
- prevent failed validation from being reported as successful;
- add focused Windows regression coverage for line endings and wrapper exit codes;
- add a guarded test-only controlled-exit seam for deterministic wrapper testing.

## Validation

- Windows validation regression tests: 3/3 passed
- TMDB collection fixture checker passed
- aggregate repository checks passed
- `scripts/check.cmd` normal run exited 0
- controlled wrapper success exited 0
- controlled wrapper failure propagated exit code 37
- Add Source foundation tests passed 36/36
- Add Source UI tests passed 20/20
- Builder production build passed
- Pages preparation and validation passed

## Scope

This is validation-infrastructure maintenance only.

It does not change:

- Builder product behavior;
- TMDB collection source output;
- canonical fixture content;
- V1;
- Worker routes;
- dependencies or lockfiles;
- Pages publication scope;
- issue #65 evidence;
- `nuvio-assets`.

Closes #67