### PR TITLE
Make Builder fixture checks line-ending independent

### DIFF
--- a/scripts/check-all.mjs
+++ b/scripts/check-all.mjs
@@ -57,6 +57,7 @@ runNode(["--test", path.join("tests", "builder-add-source-foundation.test.mjs")]
 runNode(["--test", path.join("tests", "builder-add-source-ui.test.mjs")]);
 runNode(["--test", path.join("tests", "builder-people-foundation.test.mjs")]);
 runNode(["--test", path.join("tests", "builder-people-ui.test.mjs")]);
+runNode(["--test", path.join("tests", "fixture-line-endings.test.mjs")]);
 runNode(["--test", path.join("tests", "windows-validation.test.mjs")]);
 runNode([path.join("scripts", "check-builder-add-source-fixture.mjs")]);
 runNode([path.join("scripts", "check-builder-people-fixture.mjs")]);

--- a/scripts/check-builder-people-fixture.mjs
+++ b/scripts/check-builder-people-fixture.mjs
@@ -10,6 +10,7 @@ import {
 	resolvePersonFolderArtwork,
 } from "../builder/src/source-add/index.js";
 import { validateNuvioContract } from "../tests/helpers/nuvio-contract-validator.mjs";
+import { normalizeTextLineEndings } from "./lib/text-comparison.mjs";
 
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const evidenceDirectory = path.join(rootDir, "manual-tests", "nuvio-clients", "issue-74-builder-add-people");
@@ -115,8 +116,8 @@ if (writeMode) {
 	console.log("Generated the sanitized issue #74 People review fixture through production Builder APIs.");
 } else {
 	assert.equal(
-		fs.readFileSync(fixturePath, "utf8"),
-		fixtureText,
+		normalizeTextLineEndings(fs.readFileSync(fixturePath, "utf8")),
+		normalizeTextLineEndings(fixtureText),
 		"The issue #74 People review fixture is stale. Run this script with --write.",
 	);
 	console.log("Sanitized issue #74 People review fixture matches production Builder output.");

--- a/scripts/lib/text-comparison.mjs
+++ b/scripts/lib/text-comparison.mjs
@@ -1,0 +1,7 @@
+export function normalizeTextLineEndings(text) {
+	if (typeof text !== "string") {
+		throw new TypeError("normalizeTextLineEndings requires text input.");
+	}
+
+	return text.replace(/\r\n?/gu, "\n");
+}

--- a/tests/fixture-line-endings.test.mjs
+++ b/tests/fixture-line-endings.test.mjs
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { normalizeTextLineEndings } from "../scripts/lib/text-comparison.mjs";
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const fixtureRelativePath = "manual-tests/nuvio-clients/issue-74-builder-add-people/builder-generated-people-sources.json";
+const fixturePath = path.join(rootDir, ...fixtureRelativePath.split("/"));
+const desktopExportPath = path.join(
+	rootDir,
+	"manual-tests",
+	"nuvio-clients",
+	"issue-74-builder-add-people",
+	"results",
+	"nuvio-desktop-immediate-export.json",
+);
+const fixtureCheckerPath = path.join(rootDir, "scripts", "check-builder-people-fixture.mjs");
+
+function textContentsEqual(left, right) {
+	return normalizeTextLineEndings(left) === normalizeTextLineEndings(right);
+}
+
+function writeTemporaryTexts(t, contents) {
+	const directory = fs.mkdtempSync(path.join(os.tmpdir(), "tmdb-fixture-line-endings-"));
+	t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+	return contents.map((content, index) => {
+		const filePath = path.join(directory, `fixture-${index}.txt`);
+		fs.writeFileSync(filePath, content, "utf8");
+		return filePath;
+	});
+}
+
+function readText(filePath) {
+	return fs.readFileSync(filePath, "utf8");
+}
+
+test("LF and equivalent CRLF textual fixtures compare equal", (t) => {
+	const [lfPath, crlfPath] = writeTemporaryTexts(t, ["alpha\nbeta\n", "alpha\r\nbeta\r\n"]);
+	assert.equal(textContentsEqual(readText(lfPath), readText(crlfPath)), true);
+});
+
+test("LF and equivalent standalone-CR textual fixtures compare equal", (t) => {
+	const [lfPath, crPath] = writeTemporaryTexts(t, ["alpha\nbeta\n", "alpha\rbeta\r"]);
+	assert.equal(textContentsEqual(readText(lfPath), readText(crPath)), true);
+});
+
+test("mixed CRLF, standalone CR, and LF canonicalize consistently", (t) => {
+	const [lfPath, mixedPath] = writeTemporaryTexts(t, [
+		"alpha\nbeta\ngamma\ndelta\n",
+		"alpha\r\nbeta\rgamma\ndelta\r\n",
+	]);
+	assert.equal(textContentsEqual(readText(lfPath), readText(mixedPath)), true);
+});
+
+test("empty textual fixtures remain comparable", (t) => {
+	const [leftPath, rightPath] = writeTemporaryTexts(t, ["", ""]);
+	assert.equal(textContentsEqual(readText(leftPath), readText(rightPath)), true);
+});
+
+test("a changed character remains detectable", () => {
+	assert.equal(textContentsEqual("alpha\nbeta\n", "alpha\nzeta\n"), false);
+});
+
+test("a changed JSON value remains detectable", () => {
+	assert.equal(textContentsEqual('{\n  "value": 1\n}\n', '{\r\n  "value": 2\r\n}\r\n'), false);
+});
+
+test("added or removed textual content and final newlines remain detectable", () => {
+	assert.equal(textContentsEqual("alpha\nbeta\n", "alpha\nbeta\ngamma\n"), false);
+	assert.equal(textContentsEqual("alpha\nbeta\n", "alpha\n"), false);
+	assert.equal(textContentsEqual("alpha\nbeta\n", "alpha\nbeta"), false);
+});
+
+test("changed indentation remains detectable", () => {
+	assert.equal(textContentsEqual('{\n  "value": 1\n}\n', '{\r\n    "value": 1\r\n}\r\n'), false);
+});
+
+test("changed meaningful spaces and tabs remain detectable", () => {
+	assert.equal(textContentsEqual("alpha beta\n", "alpha  beta\r\n"), false);
+	assert.equal(textContentsEqual("alpha\tbeta\n", "alpha beta\r\n"), false);
+});
+
+test("changed ordering remains detectable", () => {
+	assert.equal(textContentsEqual("first\nsecond\n", "second\r\nfirst\r\n"), false);
+});
+
+test("binary comparisons remain byte-sensitive and outside text normalization", () => {
+	const lfBytes = Buffer.from("alpha\nbeta\n", "utf8");
+	const crlfBytes = Buffer.from("alpha\r\nbeta\r\n", "utf8");
+	assert.equal(lfBytes.equals(crlfBytes), false);
+	assert.throws(() => normalizeTextLineEndings(lfBytes), {
+		name: "TypeError",
+		message: "normalizeTextLineEndings requires text input.",
+	});
+});
+
+test("the committed issue #74 fixture passes equivalent Windows checkout behavior", (t) => {
+	const committedText = execFileSync("git", ["show", `HEAD:${fixtureRelativePath}`], {
+		cwd: rootDir,
+		encoding: "utf8",
+	});
+	const windowsCheckoutText = committedText.replace(/\n/gu, "\r\n");
+	const [windowsFixturePath] = writeTemporaryTexts(t, [windowsCheckoutText]);
+	const worktreeText = readText(fixturePath);
+
+	assert.notEqual(windowsCheckoutText, committedText);
+	assert.equal(textContentsEqual(readText(windowsFixturePath), committedText), true);
+	assert.equal(textContentsEqual(worktreeText, committedText), true);
+	assert.deepEqual(JSON.parse(readText(windowsFixturePath)), JSON.parse(committedText));
+});
+
+test("the issue #74 checker retains fixture and Desktop export contract validation", () => {
+	const exportBytesBefore = fs.readFileSync(desktopExportPath);
+	const output = execFileSync(process.execPath, [fixtureCheckerPath], {
+		cwd: rootDir,
+		encoding: "utf8",
+	});
+
+	assert.match(output, /Sanitized issue #74 People review fixture matches production Builder output\./u);
+	assert.match(
+		output,
+		/Owner-supplied Nuvio Desktop export preserves issue #74 grouping, distinct titles, source identities, and curated artwork\./u,
+	);
+	assert.deepEqual(fs.readFileSync(desktopExportPath), exportBytesBefore);
+});


### PR DESCRIPTION
## Summary

Makes textual Builder fixture comparisons deterministic across Windows and Linux.

The issue #74 People fixture was semantically identical on both platforms, but Windows checkout converted LF text to CRLF and caused a raw textual comparison to fail after PR #75 merged.

## What changed

- Canonicalized CRLF and standalone CR to LF at textual fixture comparison boundaries.
- Preserved all other whitespace and content.
- Kept binary comparisons byte-sensitive.
- Added focused cross-platform tests.
- Kept the retained issue #74 fixture and Nuvio Desktop evidence semantically unchanged.

## Validation

Local Windows validation passed:

- issue #74 fixture checker;
- full repository checks;
- scripts\check.cmd with All checks passed;
- Builder production build;
- Pages preparation and validation;
- Git whitespace checks.

GitHub-hosted Linux validation passed:

- Nuvio Contract Validation;
- focused portability tests;
- full repository checks;
- Builder build;
- Pages artifact validation.

No live TMDB requests or production-state writes occurred.

## Scope

This PR does not change:

- People product behavior;
- source serialization;
- fixture semantics;
- production routing;
- stable v1;
- Worker routes;
- Company or Network pipelines;
- production data;
- nuvio-assets;
- dependencies or lockfiles.

Closes #76