### PR TITLE
feat(worker): add People service-token access

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ The app uses a Cloudflare Worker proxy for live TMDB API calls. Local static tes
 
 If local lookup requests fail while the live site works, check the Worker origin allowlist before changing frontend code. The top lookup currently needs the Worker to allow TMDB movie paths `/3/search/movie` and `/3/movie/{movie_id}` as well as the existing collection, person, and TV paths.
 
-The tracked Worker source is in `cloudflare-worker/tmdb-proxy.js`. The actual TMDB bearer token must stay in Cloudflare as the `TMDB_BEARER_TOKEN` secret and should never be committed to Git.
+The tracked Worker source is in `cloudflare-worker/tmdb-proxy.js`. Its TMDB credential and narrow People generator credential stay in Cloudflare as separate `TMDB_BEARER_TOKEN` and `NUVIO_PEOPLE_SERVICE_TOKEN` secrets. Secret values must never be committed to Git. Browser access remains CORS-controlled; origin-free service access is limited to the exact `/3/person/{id}` pathname and is documented in `cloudflare-worker/README.md`.
 
 ## Notes
 

--- a/cloudflare-worker/README.md
+++ b/cloudflare-worker/README.md
@@ -2,23 +2,34 @@
 
 This folder tracks the Cloudflare Worker source used by the live TMDB lookup proxy.
 
-The Worker code is safe to keep in Git because it only references the secret name:
+The Worker code is safe to keep in Git because it only references secret names:
 
 ```js
 env.TMDB_BEARER_TOKEN
+env.NUVIO_PEOPLE_SERVICE_TOKEN
 ```
 
-Do not commit the actual TMDB bearer token.
+Do not commit either secret value.
 
-## Required Cloudflare Secret
+## Required Cloudflare Secrets
 
-Set this Worker secret in the Cloudflare dashboard:
+Set these Worker secrets in the Cloudflare dashboard:
 
 ```text
 TMDB_BEARER_TOKEN
+NUVIO_PEOPLE_SERVICE_TOKEN
 ```
 
-The value should be the TMDB API read access token.
+`TMDB_BEARER_TOKEN` is the TMDB API read access token. `NUVIO_PEOPLE_SERVICE_TOKEN`
+is a separate server-to-server credential for the `nuvio-people-assets` generator
+and must contain at least 32 characters. Never reuse, expose, log, or commit either
+value.
+
+Production was manually updated with the People service-token behavior on
+2026-08-06 before the matching repository change. Once the synchronizing change
+is merged, this tracked source is again the authoritative record. Merging a source
+change does not deploy the Worker; deployment remains a separate explicit
+operator action.
 
 ## Deploying Manually
 
@@ -27,7 +38,7 @@ For now, deployment is manual:
 1. Open the Cloudflare Worker dashboard.
 2. Open the TMDB proxy Worker.
 3. Replace the Worker code with `tmdb-proxy.js`.
-4. Confirm the `TMDB_BEARER_TOKEN` secret still exists.
+4. Confirm both required secrets still exist.
 5. Deploy the Worker.
 
 ## Origin Rules
@@ -39,6 +50,48 @@ https://davecollections.github.io
 ```
 
 It also allows local development from any `localhost` or `127.0.0.1` port.
+
+Browser requests remain controlled by this CORS allowlist and do not need the
+People service token. The service-token header is intentionally absent from the
+CORS allowed-header list because browser clients do not use it.
+
+## People Service Access
+
+An origin-free server-to-server request is accepted only when all of these are
+true:
+
+* the request is `GET`;
+* `X-Nuvio-Service-Token` exactly matches the configured
+  `NUVIO_PEOPLE_SERVICE_TOKEN` secret;
+* the configured secret is a string containing at least 32 characters; and
+* the pathname exactly matches `/3/person/{numeric ID}`.
+
+The People generator uses this single request shape:
+
+```text
+GET /3/person/31?append_to_response=combined_credits,images
+```
+
+The query string is forwarded to TMDB, so the response can include Person
+details, combined movie/TV credits, and official profile images. The pathname is
+still `/3/person/31`; the separate `/3/person/31/combined_credits` route is
+intentionally not service-token enabled. Search, Collection, Movie, TV, Keyword,
+and every other route continue to require an allowed browser Origin even when a
+valid service token is supplied.
+
+The service-token header is used only for the Worker's access decision. It is not
+forwarded to TMDB, returned in responses, or deliberately logged.
+
+Missing, empty, short, or incorrect service credentials receive `403 Origin not
+allowed` when no allowed browser Origin is present. Missing TMDB configuration
+receives `500 TMDB token not configured`; upstream network failure receives `502
+TMDB request failed`. Error responses remain `Cache-Control: no-store`.
+
+To rotate the People credential, generate a new high-entropy value of at least 32
+characters, update the Cloudflare Worker secret and the authorized generator's
+secret through their protected operator interfaces, verify the exact Person
+request, then retire the old value. Do not place either value in commands, logs,
+issues, pull requests, documentation, or repository files.
 
 ## Allowed TMDB Paths
 

--- a/cloudflare-worker/tmdb-proxy.js
+++ b/cloudflare-worker/tmdb-proxy.js
@@ -21,6 +21,8 @@ const ALLOWED_PATHS = [
   /^\/3\/search\/keyword$/,
 ];
 
+const PEOPLE_SERVICE_PATH = /^\/3\/person\/\d+$/;
+
 function isAllowedOrigin(origin) {
   if (!origin) {
     return false;
@@ -65,6 +67,15 @@ export default {
     const url = new URL(request.url);
     const origin = request.headers.get("Origin") || "";
 
+    const suppliedServiceToken =
+      request.headers.get("X-Nuvio-Service-Token") || "";
+
+    const hasPeopleServiceAccess =
+      PEOPLE_SERVICE_PATH.test(url.pathname) &&
+      typeof env.NUVIO_PEOPLE_SERVICE_TOKEN === "string" &&
+      env.NUVIO_PEOPLE_SERVICE_TOKEN.length >= 32 &&
+      suppliedServiceToken === env.NUVIO_PEOPLE_SERVICE_TOKEN;
+
     if (request.method === "OPTIONS") {
       return new Response(null, {
         status: 204,
@@ -78,7 +89,7 @@ export default {
       });
     }
 
-    if (!isAllowedOrigin(origin)) {
+    if (!isAllowedOrigin(origin) && !hasPeopleServiceAccess) {
       return textResponse("Origin not allowed", 403, origin);
     }
 

--- a/scripts/check-all.mjs
+++ b/scripts/check-all.mjs
@@ -32,6 +32,7 @@ function runNode(args) {
 
 runNode([path.join("scripts", "check-frontend.mjs")]);
 runNode(["--test", path.join("tests", "pages-public-paths.test.mjs")]);
+runNode(["--test", path.join("tests", "cloudflare-worker.test.mjs")]);
 runNode(["--test", path.join("tests", "artwork-runtime.test.mjs")]);
 runNode(["--test", path.join("tests", "cached-nuvio-export.test.mjs")]);
 runNode(["--test", path.join("tests", "nuvio-contracts.test.mjs")]);

--- a/tests/cloudflare-worker.test.mjs
+++ b/tests/cloudflare-worker.test.mjs
@@ -1,0 +1,209 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const workerSource = fs.readFileSync(
+	path.join(rootDir, "cloudflare-worker", "tmdb-proxy.js"),
+	"utf8",
+);
+const workerModuleUrl = `data:text/javascript;base64,${Buffer.from(workerSource).toString("base64")}`;
+const worker = (await import(workerModuleUrl)).default;
+
+const allowedOrigin = "https://davecollections.github.io";
+const serviceToken = "service-token-at-least-32-characters";
+const defaultEnv = {
+	TMDB_BEARER_TOKEN: "mock-tmdb-token",
+	NUVIO_PEOPLE_SERVICE_TOKEN: serviceToken,
+};
+
+function request(pathname, { method = "GET", origin, token } = {}) {
+	const headers = new Headers();
+	if (origin !== undefined) headers.set("Origin", origin);
+	if (token !== undefined) headers.set("X-Nuvio-Service-Token", token);
+	return new Request(`https://worker.example${pathname}`, { method, headers });
+}
+
+async function withMockFetch(callback, implementation = async () => new Response(
+	JSON.stringify({ ok: true }),
+	{ status: 200, headers: { "Content-Type": "application/json" } },
+)) {
+	const originalFetch = globalThis.fetch;
+	const calls = [];
+	globalThis.fetch = async (...args) => {
+		calls.push(args);
+		return implementation(...args);
+	};
+	try {
+		return await callback(calls);
+	} finally {
+		globalThis.fetch = originalFetch;
+	}
+}
+
+async function fetchWorker(pathname, options = {}, env = defaultEnv) {
+	return worker.fetch(request(pathname, options), env);
+}
+
+test("approved browser origins retain access without a service token", async () => {
+	await withMockFetch(async (calls) => {
+		for (const origin of [
+			allowedOrigin,
+			"http://localhost:4173",
+			"http://127.0.0.1:5173",
+		]) {
+			const response = await fetchWorker("/3/search/movie?query=Alien", { origin });
+			assert.equal(response.status, 200);
+			assert.equal(response.headers.get("Access-Control-Allow-Origin"), origin);
+		}
+		assert.equal(calls.length, 3);
+	});
+});
+
+test("disallowed or missing origins fail without valid service access", async () => {
+	await withMockFetch(async (calls) => {
+		for (const options of [
+			{ origin: "https://example.com" },
+			{},
+			{ token: "incorrect-service-token-at-least-32" },
+		]) {
+			const response = await fetchWorker("/3/person/31", options);
+			assert.equal(response.status, 403);
+			assert.equal(await response.text(), "Origin not allowed");
+			assert.equal(response.headers.get("Access-Control-Allow-Origin"), null);
+		}
+		assert.equal(calls.length, 0);
+	});
+});
+
+test("OPTIONS, unsupported methods, unsupported paths, and missing TMDB configuration retain existing responses", async () => {
+	await withMockFetch(async (calls) => {
+		const options = await fetchWorker("/3/search/person", { method: "OPTIONS", origin: allowedOrigin });
+		assert.equal(options.status, 204);
+		assert.equal(options.headers.get("Access-Control-Allow-Origin"), allowedOrigin);
+
+		const post = await fetchWorker("/3/search/person", { method: "POST", origin: allowedOrigin });
+		assert.equal(post.status, 405);
+		assert.equal(post.headers.get("Allow"), "GET, OPTIONS");
+
+		const unsupported = await fetchWorker("/3/configuration", { origin: allowedOrigin });
+		assert.equal(unsupported.status, 403);
+		assert.equal(await unsupported.text(), "TMDB path not allowed");
+
+		const missingTmdb = await fetchWorker(
+			"/3/person/31",
+			{ origin: allowedOrigin },
+			{ NUVIO_PEOPLE_SERVICE_TOKEN: serviceToken },
+		);
+		assert.equal(missingTmdb.status, 500);
+		assert.equal(await missingTmdb.text(), "TMDB token not configured");
+		assert.equal(calls.length, 0);
+	});
+});
+
+test("valid origin-free People service requests forward append_to_response and strip api_key", async () => {
+	await withMockFetch(async (calls) => {
+		for (const pathname of [
+			"/3/person/31",
+			"/3/person/31?append_to_response=combined_credits%2Cimages&api_key=browser-secret",
+		]) {
+			const response = await fetchWorker(pathname, { token: serviceToken });
+			assert.equal(response.status, 200);
+			assert.equal(response.headers.get("Access-Control-Allow-Origin"), null);
+		}
+
+		assert.equal(calls.length, 2);
+		const [upstreamUrl, upstreamInit] = calls[1];
+		assert.equal(
+			upstreamUrl.toString(),
+			"https://api.themoviedb.org/3/person/31?append_to_response=combined_credits%2Cimages",
+		);
+		assert.equal(upstreamUrl.searchParams.has("api_key"), false);
+		assert.equal(upstreamInit.headers.Authorization, "Bearer mock-tmdb-token");
+		assert.equal(Object.keys(upstreamInit.headers).some((name) => name.toLowerCase() === "x-nuvio-service-token"), false);
+	});
+});
+
+test("missing, incorrect, short, and empty configured service tokens fail closed", async () => {
+	await withMockFetch(async (calls) => {
+		const cases = [
+			[{ token: undefined }, defaultEnv],
+			[{ token: "wrong-token" }, defaultEnv],
+			[{ token: "short" }, { ...defaultEnv, NUVIO_PEOPLE_SERVICE_TOKEN: "short" }],
+			[{ token: "" }, { ...defaultEnv, NUVIO_PEOPLE_SERVICE_TOKEN: "" }],
+		];
+		for (const [options, env] of cases) {
+			const response = await fetchWorker("/3/person/31", options, env);
+			assert.equal(response.status, 403);
+			assert.equal(await response.text(), "Origin not allowed");
+		}
+		assert.equal(calls.length, 0);
+	});
+});
+
+test("valid service token is limited to the exact Person details pathname", async () => {
+	await withMockFetch(async (calls) => {
+		for (const pathname of [
+			"/3/person/31/combined_credits",
+			"/3/search/person",
+			"/3/collection/1241",
+			"/3/movie/550",
+			"/3/tv/1399",
+			"/3/search/keyword",
+			"/3/person/not-a-number",
+			"/3/person/31/",
+		]) {
+			const response = await fetchWorker(pathname, { token: serviceToken });
+			assert.equal(response.status, 403, pathname);
+			assert.equal(await response.text(), "Origin not allowed", pathname);
+		}
+		assert.equal(calls.length, 0);
+	});
+});
+
+test("upstream response, cache, error, and CORS behavior is preserved", async () => {
+	await withMockFetch(async () => {
+		const response = await fetchWorker("/3/person/31", { origin: allowedOrigin });
+		assert.equal(response.status, 201);
+		assert.equal(await response.text(), "created");
+		assert.equal(response.headers.get("Cache-Control"), "public, max-age=300");
+		assert.equal(response.headers.get("Content-Type"), "application/custom");
+		assert.equal(response.headers.get("Access-Control-Allow-Origin"), allowedOrigin);
+	}, async () => new Response("created", {
+		status: 201,
+		headers: { "Content-Type": "application/custom" },
+	}));
+
+	await withMockFetch(async () => {
+		const response = await fetchWorker("/3/person/31", { token: serviceToken });
+		assert.equal(response.status, 429);
+		assert.equal(await response.text(), "rate limited");
+		assert.equal(response.headers.get("Cache-Control"), "no-store");
+		assert.equal(response.headers.get("Access-Control-Allow-Origin"), null);
+	}, async () => new Response("rate limited", { status: 429 }));
+});
+
+test("network failures return sanitized 502 responses without leaking the service token", async () => {
+	const originalConsoleError = console.error;
+	const logged = [];
+	console.error = (...args) => logged.push(args.map(String).join(" "));
+	try {
+		await withMockFetch(async () => {
+			const response = await fetchWorker("/3/person/31", { token: serviceToken });
+			assert.equal(response.status, 502);
+			const responseText = await response.text();
+			assert.equal(responseText, "TMDB request failed");
+			assert.equal(response.headers.get("Cache-Control"), "no-store");
+			assert.doesNotMatch(responseText, new RegExp(serviceToken));
+			for (const [name, value] of response.headers) {
+				assert.doesNotMatch(`${name}: ${value}`, new RegExp(serviceToken));
+			}
+		}, async () => { throw new Error("simulated network failure"); });
+	} finally {
+		console.error = originalConsoleError;
+	}
+	assert.equal(logged.length, 1);
+	assert.doesNotMatch(logged.join("\n"), new RegExp(serviceToken));
+});


### PR DESCRIPTION
## Summary

Synchronises the repository’s canonical Cloudflare Worker with the People service-token behavior that was manually deployed on 2026-08-06 for `nuvio-people-assets`.

- accepts origin-free service access only for exact `/3/person/{positive numeric ID}`
- supports `GET /3/person/31?append_to_response=combined_credits,images`
- keeps the separate `/3/person/31/combined_credits` path service-token blocked
- preserves the existing browser CORS, method, path, query, cache, response, and error contracts
- documents the two-secret operator and rotation model

## Security boundaries

- header: `X-Nuvio-Service-Token`
- secret: `NUVIO_PEOPLE_SERVICE_TOKEN`, configured as a string of at least 32 characters
- token is neither forwarded upstream nor deliberately logged or reflected
- incoming `api_key` continues to be stripped
- no secret values are included in this change
- no Worker deployment was performed; production already contains the intended behavior

## Validation

- `node --test tests/cloudflare-worker.test.mjs`
- `node scripts/check-all.mjs`
- `.\\scripts\\check.cmd`
- `npm run build --prefix builder`
- `node scripts/prepare-pages-site.mjs`
- `node scripts/validate-pages-site.mjs`
- `git diff --check`

All passed with mocked upstream requests and no live TMDB calls.

Closes #81