### PR TITLE
Add TMDB attribution compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,9 +198,15 @@ If local lookup requests fail while the live site works, check the Worker origin
 
 The tracked Worker source is in `cloudflare-worker/tmdb-proxy.js`. Its TMDB credential and narrow People generator credential stay in Cloudflare as separate `TMDB_BEARER_TOKEN` and `NUVIO_PEOPLE_SERVICE_TOKEN` secrets. Secret values must never be committed to Git. Browser access remains CORS-controlled; origin-free service access is limited to the exact `/3/person/{id}` pathname and is documented in `cloudflare-worker/README.md`.
 
-## Notes
+## TMDB Attribution
 
-This project uses the TMDB API but is not endorsed or certified by TMDB.
+The V1 site displays the official TMDB logo with this required notice:
+
+> This website uses TMDB and the TMDB APIs but is not endorsed, certified, or otherwise approved by TMDB.
+
+V2 must include visible TMDB attribution UI before its `noindex` state is removed or it is released or promoted for public use. That UI must use an official TMDB logo, keep the TMDB mark less prominent than the application identity, and display the same notice exactly.
+
+## Notes
 
 Company names, logos, posters, and trademarks remain the property of their respective owners.
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -576,6 +576,40 @@ th.sortable:hover {
 	text-align: center;
 }
 
+.tmdb-attribution {
+	align-items: center;
+	background: #111823;
+	border: 1px solid #2a3748;
+	border-radius: 10px;
+	display: flex;
+	gap: 12px;
+	justify-content: center;
+	margin: 0 auto 12px;
+	padding: 12px 14px;
+}
+
+.tmdb-attribution-logo-link {
+	flex: 0 0 auto;
+	line-height: 0;
+}
+
+.tmdb-attribution-logo {
+	display: block;
+	height: auto;
+	width: 42px;
+}
+
+.tmdb-attribution-notice {
+	color: #c8d0da;
+	font-size: 13px;
+	font-weight: 500;
+	line-height: 1.5;
+	margin: 0;
+	max-width: 640px;
+	min-width: 0;
+	text-align: left;
+}
+
 .footer-line {
 	align-items: center;
 	display: flex;

--- a/docs/v2/BUILDER_KNOWLEDGE.md
+++ b/docs/v2/BUILDER_KNOWLEDGE.md
@@ -11,6 +11,7 @@ This is a living record of confirmed v2/Nuvio findings, current decisions, unsup
 - v1 is working and stable.
 - v2 changes the product from primarily an ID lookup/export utility into the visual **TMDB Collection Builder**, built for Nuvio collections and powered primarily by TMDB.
 - The active React/Vite builder remains isolated under `/builder/`, unlinked, and `noindex, nofollow`; it is not a released replacement for v1.
+- **Confirmed owner requirement — issue [#85](https://github.com/davecollections/tmdb-id-lookup/issues/85):** before that `noindex` state is removed or V2 is released or promoted for public use, the Builder shell must include visible TMDB attribution using an official TMDB logo, with the TMDB mark less prominent than the application identity, and the exact notice: **“This website uses TMDB and the TMDB APIs but is not endorsed, certified, or otherwise approved by TMDB.”** Issue #85 documents the V2 requirement only and does not implement Builder attribution UI.
 - Lookup and copy-ID tools remain available.
 - v2 should be mobile-first, modern, and sleek.
 - No login is required for the complete core build-and-export journey. Any future Nuvio connection must remain optional.
@@ -670,6 +671,8 @@ Quick Setup, Dave's 1-Click Setup, templates/recipes, the Kaptain comparison, pr
 | 2026-08-02 | Registry-backed physical Movie Collection and People source editing; automatic/default/custom title intent; bounded People count/cache reuse; evidenced People sort editing; bounded identity changes; prominent duplicate/stale/validation alerts; exact-target/stale-state and same-folder duplicate guards; one-shot minimal controller updates; raw/unknown/order/projection preservation; responsive accessible modal; and a sanitized pending client-evidence package | [TMDB ID Lookup issue #78](https://github.com/davecollections/tmdb-id-lookup/issues/78), [`BUILDER_SOURCE_EDITING.md`](./BUILDER_SOURCE_EDITING.md), and [`issue-78-source-editing/`](../../manual-tests/nuvio-clients/issue-78-source-editing/) |
 
 ## Decision history
+
+- **2026-08-06 — TMDB attribution release gate:** make V1 attribution compliant with the official TMDB mark and exact notice; record the same visible attribution as mandatory V2 shell work before `noindex` removal, release, or public promotion; and keep V2 UI implementation outside issue #85.
 
 - **2026-07-10 — Planning checkpoint:** treat `sources` as authoritative, use `catalogSources` only as the addon compatibility projection/fallback, preserve unknown imported data, and gate the isolated React/Vite candidate behind contract and deployment proof.
 - **2026-07-10 — Contract baseline:** add evidence-classified fixtures and stable invariant checks before any builder framework, production parser, serializer, or exporter work.

--- a/docs/v2/BUILDER_PRODUCT_PLAN.md
+++ b/docs/v2/BUILDER_PRODUCT_PLAN.md
@@ -55,6 +55,7 @@ Progressive disclosure should let a beginner reach a useful result while preserv
 - No account, personal TMDB API key, or personal information is required to complete the core build-and-export journey.
 - Core importing and editing remain local-first in the browser.
 - **Copy JSON** and **Download JSON** are complete supported paths, not fallback-only features.
+- Before the Builder's `noindex` state is removed or V2 is released or promoted for public use, its visible UI must identify TMDB use with an official TMDB logo and prominently display: **“This website uses TMDB and the TMDB APIs but is not endorsed, certified, or otherwise approved by TMDB.”** The TMDB mark must remain less prominent than the application identity.
 
 **Confirmed direction**
 
@@ -388,6 +389,7 @@ The third concept is documented in the [Nuvio Integration Development Guide](htt
 - Product colourways may distinguish Nuvio and possible future tools.
 - The product title should remain ordinary UI text rather than being permanently embedded in a logo.
 - Final logo design is deferred and must not delay functional Builder work.
+- TMDB attribution is a separate mandatory release requirement, not the Builder's primary branding. Its official mark must not become more prominent than the application identity.
 
 Trakt integration remains outside current project scope; a possible future colourway is not approval to begin Trakt work.
 

--- a/index.html
+++ b/index.html
@@ -1406,9 +1406,20 @@
 		</div>
 
 		<footer class="site-footer">
-			<p class="footer-line">
-				Uses TMDB API <span aria-hidden="true">·</span> Not endorsed or certified by TMDB
-			</p>
+			<div class="tmdb-attribution">
+				<a class="tmdb-attribution-logo-link" href="https://www.themoviedb.org/" target="_blank" rel="noopener noreferrer" aria-label="Visit TMDB">
+					<img
+						class="tmdb-attribution-logo"
+						src="https://www.themoviedb.org/assets/2/v4/logos/v2/blue_square_2-d537fb228cf3ded904ef09b136fe3fec72548ebc1fea3fbbd1ad9e36364db38b.svg"
+						alt="TMDB"
+						width="42"
+						height="30"
+						loading="lazy"
+						decoding="async"
+					/>
+				</a>
+				<p class="tmdb-attribution-notice">This website uses TMDB and the TMDB APIs but is not endorsed, certified, or otherwise approved by TMDB.</p>
+			</div>
 
 			<p class="footer-line footer-credits">
 				Artwork credit retained pending provenance review:

--- a/scripts/check-all.mjs
+++ b/scripts/check-all.mjs
@@ -31,6 +31,7 @@ function runNode(args) {
 }
 
 runNode([path.join("scripts", "check-frontend.mjs")]);
+runNode(["--test", path.join("tests", "tmdb-attribution.test.mjs")]);
 runNode(["--test", path.join("tests", "pages-public-paths.test.mjs")]);
 runNode(["--test", path.join("tests", "cloudflare-worker.test.mjs")]);
 runNode(["--test", path.join("tests", "artwork-runtime.test.mjs")]);

--- a/tests/tmdb-attribution.test.mjs
+++ b/tests/tmdb-attribution.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const html = fs.readFileSync(path.join(rootDir, "index.html"), "utf8");
+const styles = fs.readFileSync(path.join(rootDir, "css", "styles.css"), "utf8");
+
+const requiredNotice =
+	"This website uses TMDB and the TMDB APIs but is not endorsed, certified, or otherwise approved by TMDB.";
+const officialLogoUrl =
+	"https://www.themoviedb.org/assets/2/v4/logos/v2/blue_square_2-d537fb228cf3ded904ef09b136fe3fec72548ebc1fea3fbbd1ad9e36364db38b.svg";
+
+test("v1 displays the exact required TMDB notice with the official logo", () => {
+	assert.equal(html.split(requiredNotice).length - 1, 1);
+	assert.equal(html.split(officialLogoUrl).length - 1, 1);
+	assert.match(html, /<img\b[^>]*class="tmdb-attribution-logo"[^>]*alt="TMDB"[^>]*>/s);
+});
+
+test("the TMDB mark stays restrained and the attribution notice stays readable", () => {
+	assert.match(styles, /\.tmdb-attribution-logo\s*{[^}]*height:\s*auto;[^}]*width:\s*42px;/s);
+	assert.match(styles, /\.tmdb-attribution-notice\s*{[^}]*color:\s*#c8d0da;[^}]*font-size:\s*13px;/s);
+});


### PR DESCRIPTION
Closes #85

## Summary

- replaces the V1 footer’s informal TMDB line with a visible attribution block
- uses the official fingerprinted TMDB SVG directly and preserves its intrinsic aspect ratio
- displays the required notice verbatim while keeping the TMDB mark subordinate to the application title
- records visible TMDB attribution as a mandatory V2 pre-release/public-use requirement in README and the durable V2 product/knowledge docs
- adds a focused static compliance test to the main Windows check entry point

## Production impact

V1 gains a readable TMDB attribution block in its existing footer. Existing lookup, export, Worker, and Builder runtime behavior is unchanged. V2 receives documentation only.

## Validation

- `.\\scripts\\check.cmd` — passed (full suite)
- `npm run build --prefix builder` — passed
- `node scripts/prepare-pages-site.mjs` — passed, including combined Pages artifact validation
- `git diff --check` — passed
- browser verification at 1280px and mobile widths 360, 384, 393, 402, and 412px — exact notice visible, official logo loaded without distortion, no page-level horizontal overflow