### PR TITLE
Stabilize Linux mounted-browser teardown

### DIFF
--- a/.github/workflows/update-genre-counts.yml
+++ b/.github/workflows/update-genre-counts.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
   schedule:
-    - cron: "30 7 * * *"
+    - cron: "30 7 * * 0"
 
 permissions:
   contents: write

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Each Nuvio export modal includes a help button with current import steps for Nuv
 
 Cached company, TV network, and genre data is maintained automatically from TMDB data and API responses.
 
-The project runs daily checks for TMDB export changes, repairs small cache differences automatically, and refreshes genre title counts. Production company and TV network caches also run scheduled full-refresh passes at the start of each month so the local lookup data stays aligned with TMDB's exported ID lists.
+The project runs daily checks for TMDB export changes, repairs small cache differences automatically, and refreshes genre title counts weekly. Production company and TV network caches also run scheduled full-refresh passes at the start of each month so the local lookup data stays aligned with TMDB's exported ID lists.
 
 The site is deployed with GitHub Pages.
 
@@ -172,6 +172,8 @@ TMDB API requests from the live lookup tools go through the Cloudflare Worker pr
 Run `scripts\check.cmd` before pushing changes on Windows. This runs the shared validation sequence for frontend JavaScript syntax, cached JSON parsing, duplicate HTML IDs, duplicate cached IDs, Nuvio export preset references, genre artwork/count coverage, unsafe rendering patterns, and deterministic Nuvio contract fixtures.
 
 On any platform, the equivalent command is `node scripts/check-all.mjs`. To run only the Nuvio contract suite, use `node --test tests/nuvio-contracts.test.mjs`.
+
+Browser-owning test conventions and focused lifecycle checks are documented in [docs/TESTING.md](docs/TESTING.md).
 
 ## TMDB Collection Builder
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,27 @@
+# Repository Testing
+
+## Mounted browser lifecycle
+
+Mounted-browser suites register their tests during module loading and start one isolated browser in a `before` hook. Keep browser setup out of top-level module evaluation so launch or cleanup failures are attributed to the suite instead of aborting test discovery. One browser per suite is preferred when the callbacks only assert results collected from the same mounted fixture.
+
+Chrome owns DevTools port selection. Launch it with `--remote-debugging-port=0` and read the fresh profile's `DevToolsActivePort` file; do not reserve and release a port before launch. Browser and page WebSocket opens, fixture execution, cooperative shutdown, and forced shutdown must all remain bounded.
+
+The normal ownership path is:
+
+1. request `Browser.close` through the browser-level DevTools connection;
+2. await the direct Chrome child handle, its captured owned process tree, and browser socket closure;
+3. close local DevTools connections and Vite;
+4. remove the temporary Chrome profile and Vite cache.
+
+If no browser connection was established, or cooperative close fails, use the bounded process-tree fallback. The fallback waits for the child and test-owned processes, not a potentially wedged client WebSocket. Process-group signaling is a fallback only and must remain limited to the isolated browser launch's process group plus explicitly captured browser PIDs.
+
+Every asynchronous exit wait must be observed before cancellation can reject it. Check synchronous failure branches before creating waits, and wrap commands that may throw synchronously before combining them with other promises. Cleanup for one resource owner is idempotent: concurrent and repeated calls share one cleanup operation, while a failed cleanup may be retried.
+
+Focused checks:
+
+```powershell
+node --test tests/mounted-browser-lifecycle.test.mjs
+node --test tests/builder-source-edit-mounted.test.mjs
+$env:TMDB_MOUNTED_BROWSER_DIAGNOSTICS = "1"
+node --test tests/builder-source-edit-mounted.test.mjs
+```

--- a/tests/builder-source-edit-mounted.test.mjs
+++ b/tests/builder-source-edit-mounted.test.mjs
@@ -2,10 +2,9 @@ import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import fs from "node:fs";
 import fsPromises from "node:fs/promises";
-import net from "node:net";
 import os from "node:os";
 import path from "node:path";
-import test, { after } from "node:test";
+import test, { before } from "node:test";
 import { fileURLToPath } from "node:url";
 
 import react from "../builder/node_modules/@vitejs/plugin-react/dist/index.js";
@@ -15,6 +14,7 @@ import {
 	connectDevTools,
 	createBrowserProcessTree,
 	runWithLifecycleCleanup,
+	waitForDevToolsEndpoint,
 } from "./helpers/mounted-browser-lifecycle.mjs";
 
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -35,28 +35,24 @@ function chromeExecutable() {
 	return executable;
 }
 
-async function availablePort() {
-	const server = net.createServer();
-	await new Promise((resolve, reject) => {
-		server.once("error", reject);
-		server.listen(0, "127.0.0.1", resolve);
-	});
-	const { port } = server.address();
-	await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
-	return port;
-}
-
 async function waitForJson(url, timeoutMs = 10000) {
 	const deadline = Date.now() + timeoutMs;
 	let lastError = null;
 	while (Date.now() < deadline) {
 		try {
-			const response = await fetch(url);
+			const remainingMs = Math.max(1, deadline - Date.now());
+			const response = await fetch(url, {
+				signal: AbortSignal.timeout(Math.min(1000, remainingMs)),
+			});
 			if (response.ok) return response.json();
+			lastError = new Error(`HTTP ${response.status}`);
 		} catch (error) {
 			lastError = error;
 		}
-		await new Promise((resolve) => setTimeout(resolve, 50));
+		const remainingMs = deadline - Date.now();
+		if (remainingMs > 0) {
+			await new Promise((resolve) => setTimeout(resolve, Math.min(50, remainingMs)));
+		}
 	}
 	throw new Error(`Chrome DevTools did not become available: ${lastError?.message ?? "timeout"}`);
 }
@@ -66,6 +62,7 @@ async function runMountedPage() {
 		browserExecutable: null,
 		browserProcess: null,
 		browserConnection: null,
+		debugPort: null,
 		pageConnection: null,
 		processTree: null,
 		profileDir: null,
@@ -94,7 +91,6 @@ async function runMountedPage() {
 		});
 		await resources.vite.listen();
 
-		const debugPort = await availablePort();
 		resources.profileDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), "builder-source-edit-mounted-"));
 		resources.browserExecutable = chromeExecutable();
 		resources.browserProcess = spawn(resources.browserExecutable, [
@@ -104,7 +100,8 @@ async function runMountedPage() {
 			"--disable-gpu",
 			"--no-first-run",
 			"--no-sandbox",
-			`--remote-debugging-port=${debugPort}`,
+			"--remote-debugging-address=127.0.0.1",
+			"--remote-debugging-port=0",
 			`--user-data-dir=${resources.profileDir}`,
 			"about:blank",
 		], {
@@ -130,10 +127,13 @@ async function runMountedPage() {
 		});
 		resources.processTree = createBrowserProcessTree({ rootPid: resources.browserProcess.pid });
 
-		const version = await waitForJson(`http://127.0.0.1:${debugPort}/json/version`);
-		if (!version?.webSocketDebuggerUrl) throw new Error("Chrome browser target is unavailable.");
-		resources.browserConnection = await connectDevTools(version.webSocketDebuggerUrl);
-		const targets = await waitForJson(`http://127.0.0.1:${debugPort}/json/list`);
+		const endpoint = await waitForDevToolsEndpoint({
+			profileDir: resources.profileDir,
+			browserProcess: resources.browserProcess,
+		});
+		resources.debugPort = endpoint.port;
+		resources.browserConnection = await connectDevTools(endpoint.browserWebSocketUrl);
+		const targets = await waitForJson(`http://127.0.0.1:${endpoint.port}/json/list`);
 		const target = targets.find((entry) => entry.type === "page");
 		if (!target?.webSocketDebuggerUrl) throw new Error("Chrome page target is unavailable.");
 		resources.pageConnection = await connectDevTools(target.webSocketDebuggerUrl);
@@ -165,6 +165,7 @@ async function runMountedPage() {
 	if (process.env.TMDB_MOUNTED_BROWSER_DIAGNOSTICS === "1") {
 		console.log(`MOUNTED_BROWSER_DIAGNOSTICS ${JSON.stringify({
 			browserExecutable: execution.cleanupReport.browserExecutable,
+			debugPort: resources.debugPort,
 			rootPid: execution.cleanupReport.rootPid,
 			graceful: execution.cleanupReport.browser.graceful,
 			fallback: execution.cleanupReport.browser.fallback,
@@ -178,16 +179,8 @@ async function runMountedPage() {
 }
 
 let mountedResults;
-let mountedCleanupFailure = null;
-try {
+before(async () => {
 	mountedResults = await runMountedPage();
-} catch (error) {
-	if (!error?.operationCompleted) throw error;
-	mountedResults = error.operationValue;
-	mountedCleanupFailure = error;
-}
-after(() => {
-	if (mountedCleanupFailure) throw mountedCleanupFailure;
 });
 
 function assertRequiredNameFailure(result) {

--- a/tests/fixtures/mounted-browser-missing-connection.mjs
+++ b/tests/fixtures/mounted-browser-missing-connection.mjs
@@ -1,0 +1,83 @@
+import { EventEmitter } from "node:events";
+
+import {
+	cleanupMountedBrowser,
+	runWithLifecycleCleanup,
+	waitForDevToolsEndpoint,
+} from "../helpers/mounted-browser-lifecycle.mjs";
+
+const child = new EventEmitter();
+child.pid = 4242;
+child.exitCode = null;
+child.signalCode = null;
+child.finish = () => {
+	if (child.exitCode !== null) return;
+	child.exitCode = 0;
+	child.emit("exit", 0, null);
+};
+
+const processTree = {
+	capture: async () => [child.pid],
+	remainingPids: async () => child.exitCode === null ? [child.pid] : [],
+	terminate: async () => {
+		terminationCalls += 1;
+		child.finish();
+	},
+	waitForExit: async () => {
+		if (child.exitCode !== null) return;
+		await new Promise((resolve) => child.once("exit", resolve));
+	},
+};
+
+let terminationCalls = 0;
+let readinessError = null;
+let elapsedMs = 0;
+let observedError = null;
+try {
+	await runWithLifecycleCleanup(
+		async () => {
+			try {
+				await waitForDevToolsEndpoint({
+					profileDir: "missing-profile",
+					browserProcess: child,
+					timeoutMs: 10,
+					pollIntervalMs: 5,
+					fsApi: {
+						readFile: async () => {
+							const error = new Error("missing");
+							error.code = "ENOENT";
+							throw error;
+						},
+					},
+					delay: async (delayMs) => { elapsedMs += delayMs; },
+					now: () => elapsedMs,
+				});
+			} catch (error) {
+				readinessError = error;
+				throw error;
+			}
+		},
+		() => cleanupMountedBrowser({
+			browserExecutable: "test-chrome",
+			browserProcess: child,
+			browserConnection: null,
+			pageConnection: null,
+			processTree,
+			profileDir: null,
+			vite: null,
+			viteCacheDir: null,
+		}),
+	);
+} catch (error) {
+	observedError = error;
+}
+
+if (observedError !== readinessError || !/did not publish a valid DevTools endpoint/u.test(observedError.message)) {
+	throw new Error(`Cleanup masked the readiness error with: ${observedError?.stack ?? observedError}`);
+}
+if (terminationCalls !== 1 || child.exitCode !== 0) {
+	throw new Error(`Fallback ownership failed: terminations=${terminationCalls}, exitCode=${child.exitCode}`);
+}
+
+await new Promise((resolve) => setImmediate(resolve));
+console.log("MISSING_CONNECTION_CLEANUP_OK");

--- a/tests/helpers/mounted-browser-lifecycle.mjs
+++ b/tests/helpers/mounted-browser-lifecycle.mjs
@@ -1,5 +1,6 @@
 import { execFile as execFileCallback } from "node:child_process";
 import fs from "node:fs/promises";
+import path from "node:path";
 import { promisify } from "node:util";
 
 const execFile = promisify(execFileCallback);
@@ -13,6 +14,9 @@ export const TRANSIENT_REMOVE_CODES = Object.freeze([
 ]);
 
 export const DEFAULT_REMOVE_RETRY_DELAYS_MS = Object.freeze([25, 50, 100, 200]);
+export const DEFAULT_DEVTOOLS_STARTUP_MS = 10000;
+export const DEFAULT_DEVTOOLS_CONNECTION_MS = 5000;
+export const DEFAULT_DEVTOOLS_COMMAND_MS = 5000;
 export const DEFAULT_GRACEFUL_SHUTDOWN_MS = 5000;
 export const DEFAULT_FALLBACK_SHUTDOWN_MS = 3000;
 
@@ -29,6 +33,19 @@ function abortError() {
 
 function throwIfAborted(signal) {
 	if (signal?.aborted) throw abortError();
+}
+
+function browserProcessStatus(browserProcess) {
+	return [
+		`rootPid=${browserProcess?.pid ?? "unknown"}`,
+		`exitCode=${browserProcess?.exitCode ?? "running"}`,
+		`signalCode=${browserProcess?.signalCode ?? "none"}`,
+	].join(", ");
+}
+
+function browserProcessExited(browserProcess) {
+	return Boolean(browserProcess) &&
+		(browserProcess.exitCode !== null || browserProcess.signalCode !== null);
 }
 
 export function abortableDelay(
@@ -113,19 +130,109 @@ export async function withDeadline(
 	}
 }
 
+export async function waitForDevToolsEndpoint({
+	profileDir,
+	browserProcess,
+	timeoutMs = DEFAULT_DEVTOOLS_STARTUP_MS,
+	pollIntervalMs = 50,
+	fsApi = fs,
+	delay = abortableDelay,
+	now = Date.now,
+} = {}) {
+	if (!profileDir) throw new TypeError("A Chrome profile directory is required.");
+	if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+		throw new TypeError("A positive Chrome DevTools startup timeout is required.");
+	}
+	if (!Number.isFinite(pollIntervalMs) || pollIntervalMs <= 0) {
+		throw new TypeError("A positive Chrome DevTools polling interval is required.");
+	}
+
+	const activePortPath = path.join(profileDir, "DevToolsActivePort");
+	const deadlineAt = now() + timeoutMs;
+	let lastProblem = "DevToolsActivePort has not been created";
+
+	while (now() < deadlineAt) {
+		if (browserProcessExited(browserProcess)) {
+			throw new Error(
+				`Chrome exited before publishing its DevTools endpoint (${browserProcessStatus(browserProcess)}).`,
+			);
+		}
+
+		try {
+			const contents = await fsApi.readFile(activePortPath, "utf8");
+			const [portText = "", browserPath = ""] = contents.split(/\r?\n/u).map((line) => line.trim());
+			const port = Number(portText);
+			if (
+				Number.isInteger(port) &&
+				port >= 1 &&
+				port <= 65535 &&
+				browserPath.startsWith("/devtools/browser/")
+			) {
+				return {
+					port,
+					browserPath,
+					browserWebSocketUrl: `ws://127.0.0.1:${port}${browserPath}`,
+				};
+			}
+			lastProblem = "DevToolsActivePort was incomplete or invalid";
+		} catch (error) {
+			lastProblem = error?.code === "ENOENT"
+				? "DevToolsActivePort has not been created"
+				: `DevToolsActivePort could not be read: ${asError(error).message}`;
+		}
+
+		const remainingMs = deadlineAt - now();
+		if (remainingMs > 0) await delay(Math.min(pollIntervalMs, remainingMs));
+	}
+
+	if (browserProcessExited(browserProcess)) {
+		throw new Error(
+			`Chrome exited before publishing its DevTools endpoint (${browserProcessStatus(browserProcess)}).`,
+		);
+	}
+	throw new Error(
+		`Chrome did not publish a valid DevTools endpoint within ${timeoutMs} ms ` +
+		`(${browserProcessStatus(browserProcess)}; lastState=${lastProblem}).`,
+	);
+}
+
 export async function connectDevTools(
 	url,
-	{ WebSocketImpl = globalThis.WebSocket } = {},
+	{
+		WebSocketImpl = globalThis.WebSocket,
+		timeoutMs = DEFAULT_DEVTOOLS_CONNECTION_MS,
+		commandTimeoutMs = DEFAULT_DEVTOOLS_COMMAND_MS,
+		signal,
+		setTimeoutFn = setTimeout,
+		clearTimeoutFn = clearTimeout,
+	} = {},
 ) {
 	if (typeof WebSocketImpl !== "function") {
 		throw new Error("A WebSocket implementation is required for Chrome DevTools.");
 	}
+	if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+		throw new TypeError("A positive Chrome DevTools connection timeout is required.");
+	}
+	if (!Number.isFinite(commandTimeoutMs) || commandTimeoutMs <= 0) {
+		throw new TypeError("A positive Chrome DevTools command timeout is required.");
+	}
+	throwIfAborted(signal);
 
 	const socket = new WebSocketImpl(url);
 	await new Promise((resolve, reject) => {
+		let timer = null;
 		const cleanup = () => {
+			if (timer !== null) clearTimeoutFn(timer);
 			socket.removeEventListener("open", onOpen);
 			socket.removeEventListener("error", onError);
+			signal?.removeEventListener("abort", onAbort);
+		};
+		const closeOpeningSocket = () => {
+			try {
+				if (typeof socket.close === "function" && socket.readyState < 2) socket.close();
+			} catch {
+				// The opening error remains the useful failure.
+			}
 		};
 		const onOpen = () => {
 			cleanup();
@@ -133,10 +240,23 @@ export async function connectDevTools(
 		};
 		const onError = () => {
 			cleanup();
+			closeOpeningSocket();
 			reject(new Error("Chrome DevTools WebSocket failed to open."));
+		};
+		const onAbort = () => {
+			cleanup();
+			closeOpeningSocket();
+			reject(abortError());
 		};
 		socket.addEventListener("open", onOpen, { once: true });
 		socket.addEventListener("error", onError, { once: true });
+		signal?.addEventListener("abort", onAbort, { once: true });
+		timer = setTimeoutFn(() => {
+			timer = null;
+			cleanup();
+			closeOpeningSocket();
+			reject(new Error(`Chrome DevTools WebSocket did not open within ${timeoutMs} ms.`));
+		}, timeoutMs);
 	});
 
 	let nextId = 0;
@@ -145,9 +265,17 @@ export async function connectDevTools(
 	let resolveClosed;
 	const closedPromise = new Promise((resolve) => { resolveClosed = resolve; });
 
+	const settlePending = (id, outcome, value) => {
+		const operation = pending.get(id);
+		if (!operation) return;
+		pending.delete(id);
+		clearTimeoutFn(operation.timer);
+		operation[outcome](value);
+	};
 	const rejectPending = (message) => {
-		for (const { reject } of pending.values()) reject(new Error(message));
-		pending.clear();
+		for (const id of [...pending.keys()]) {
+			settlePending(id, "reject", new Error(message));
+		}
 	};
 
 	socket.addEventListener("message", (event) => {
@@ -159,10 +287,8 @@ export async function connectDevTools(
 			return;
 		}
 		if (!message.id || !pending.has(message.id)) return;
-		const operation = pending.get(message.id);
-		pending.delete(message.id);
-		if (message.error) operation.reject(new Error(message.error.message));
-		else operation.resolve(message.result);
+		if (message.error) settlePending(message.id, "reject", new Error(message.error.message));
+		else settlePending(message.id, "resolve", message.result);
 	});
 
 	socket.addEventListener("close", (event) => {
@@ -183,12 +309,19 @@ export async function connectDevTools(
 			}
 			const id = ++nextId;
 			return new Promise((resolve, reject) => {
-				pending.set(id, { resolve, reject });
+				const operation = { resolve, reject, timer: null };
+				pending.set(id, operation);
+				operation.timer = setTimeoutFn(() => {
+					settlePending(
+						id,
+						"reject",
+						new Error(`Chrome DevTools command ${method} exceeded ${commandTimeoutMs} ms.`),
+					);
+				}, commandTimeoutMs);
 				try {
 					socket.send(JSON.stringify({ id, method, params }));
 				} catch (error) {
-					pending.delete(id);
-					reject(error);
+					settlePending(id, "reject", error);
 				}
 			});
 		},
@@ -455,13 +588,24 @@ export async function shutdownBrowser({
 	try {
 		await deadline(async (signal) => {
 			ownedPids = await processTree.capture(signal);
-			const rootExited = waitForChildExit(browserProcess, signal);
-			const treeExited = processTree.waitForExit(ownedPids, signal);
-			if (!browserConnection) throw new Error("Browser-level Chrome DevTools connection is unavailable.");
-			const socketClosed = abortablePromise(browserConnection.closed, signal);
-			const closeRequested = browserConnection.command("Browser.close").catch((error) => {
-				if (!browserConnection.isClosed?.()) throw error;
-			});
+			if ((await processTree.remainingPids(ownedPids)).length === 0) return;
+			if (!browserConnection) {
+				throw new Error("Browser-level Chrome DevTools connection is unavailable.");
+			}
+			const connectionAlreadyClosed = browserConnection.isClosed?.() === true;
+			const rootExited = Promise.resolve()
+				.then(() => waitForChildExit(browserProcess, signal));
+			const treeExited = Promise.resolve()
+				.then(() => processTree.waitForExit(ownedPids, signal));
+			const socketClosed = Promise.resolve()
+				.then(() => abortablePromise(browserConnection.closed, signal));
+			const closeRequested = connectionAlreadyClosed
+				? Promise.resolve()
+				: Promise.resolve()
+					.then(() => browserConnection.command("Browser.close"))
+					.catch((error) => {
+						if (!browserConnection.isClosed?.()) throw error;
+					});
 			await Promise.all([closeRequested, socketClosed, rootExited, treeExited]);
 		}, gracefulTimeoutMs, {
 			label: "Graceful mounted browser shutdown",
@@ -480,12 +624,10 @@ export async function shutdownBrowser({
 	try {
 		await deadline(async (signal) => {
 			await processTree.terminate(ownedPids, signal);
-			const waits = [
-				waitForChildExit(browserProcess, signal),
-				processTree.waitForExit(ownedPids, signal),
-			];
-			if (browserConnection) waits.push(abortablePromise(browserConnection.closed, signal));
-			await Promise.all(waits);
+			await Promise.all([
+				Promise.resolve().then(() => waitForChildExit(browserProcess, signal)),
+				Promise.resolve().then(() => processTree.waitForExit(ownedPids, signal)),
+			]);
 		}, fallbackTimeoutMs, {
 			label: "Mounted browser process-tree fallback",
 			...deadlineOptions,
@@ -588,7 +730,9 @@ export class MountedBrowserCleanupError extends AggregateError {
 	}
 }
 
-export async function cleanupMountedBrowser(resources, {
+const cleanupOperations = new WeakMap();
+
+async function cleanupMountedBrowserOnce(resources, {
 	shutdownBrowserFn = shutdownBrowser,
 	removeDirectoryFn = removeDirectoryWithRetry,
 	directoryEntriesFn = directoryEntries,
@@ -620,6 +764,8 @@ export async function cleanupMountedBrowser(resources, {
 				...shutdownOptions,
 			});
 			browserOwnershipEnded = true;
+			resources.browserProcess = null;
+			resources.processTree = null;
 		} catch (error) {
 			errors.push(asError(error));
 			report.browser.graceful = "failed";
@@ -629,15 +775,17 @@ export async function cleanupMountedBrowser(resources, {
 		}
 	}
 
-	for (const connection of [resources.pageConnection, resources.browserConnection]) {
-		const closeError = closeConnection(connection);
+	for (const key of ["pageConnection", "browserConnection"]) {
+		const closeError = closeConnection(resources[key]);
 		if (closeError) errors.push(closeError);
+		else resources[key] = null;
 	}
 
 	if (!viteOwnershipEnded) {
 		try {
 			await resources.vite.close();
 			viteOwnershipEnded = true;
+			resources.vite = null;
 		} catch (error) {
 			errors.push(asError(error));
 		}
@@ -646,11 +794,13 @@ export async function cleanupMountedBrowser(resources, {
 	if (browserOwnershipEnded && viteOwnershipEnded) {
 		try {
 			report.profile = await removeDirectoryFn(resources.profileDir, removeOptions);
+			resources.profileDir = null;
 		} catch (error) {
 			errors.push(asError(error));
 		}
 		try {
 			report.viteCache = await removeDirectoryFn(resources.viteCacheDir, removeOptions);
+			resources.viteCacheDir = null;
 		} catch (error) {
 			errors.push(asError(error));
 		}
@@ -674,6 +824,21 @@ export async function cleanupMountedBrowser(resources, {
 	}
 
 	return report;
+}
+
+export function cleanupMountedBrowser(resources, options = {}) {
+	if (!resources || typeof resources !== "object") {
+		return Promise.reject(new TypeError("Mounted browser resources are required."));
+	}
+	const activeCleanup = cleanupOperations.get(resources);
+	if (activeCleanup) return activeCleanup;
+
+	const cleanup = cleanupMountedBrowserOnce(resources, options).catch((error) => {
+		cleanupOperations.delete(resources);
+		throw error;
+	});
+	cleanupOperations.set(resources, cleanup);
+	return cleanup;
 }
 
 export class MountedLifecycleError extends AggregateError {

--- a/tests/mounted-browser-lifecycle.test.mjs
+++ b/tests/mounted-browser-lifecycle.test.mjs
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
+import { execFile as execFileCallback } from "node:child_process";
 import { EventEmitter } from "node:events";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
 
 import {
 	BrowserShutdownError,
@@ -11,11 +14,17 @@ import {
 	TRANSIENT_REMOVE_CODES,
 	abortableDelay,
 	cleanupMountedBrowser,
+	connectDevTools,
 	createBrowserProcessTree,
 	removeDirectoryWithRetry,
 	runWithLifecycleCleanup,
 	shutdownBrowser,
+	waitForChildExit,
+	waitForDevToolsEndpoint,
+	withDeadline,
 } from "./helpers/mounted-browser-lifecycle.mjs";
+
+const execFile = promisify(execFileCallback);
 
 function deferred() {
 	let resolve;
@@ -66,7 +75,7 @@ function fakeShutdown({ events = [], ownedPids = [101, 102], autoFinish = true }
 	};
 	const processTree = {
 		capture: async () => [...ownedPids],
-		remainingPids: async () => [],
+		remainingPids: async () => child.exitCode === null ? [...ownedPids] : [],
 		terminate: async () => { throw new Error("Fallback should not run."); },
 		waitForExit: () => treeExited.promise,
 	};
@@ -89,6 +98,146 @@ function trackedTimers() {
 		},
 	};
 }
+
+test("DevToolsActivePort readiness tolerates absent and partial writes before returning Chrome's endpoint", async () => {
+	const child = fakeChild(321);
+	const reads = [
+		missingError(),
+		"45123\n",
+		"45123\n/devtools/browser/test-browser\n",
+	];
+	let elapsedMs = 0;
+	const endpoint = await waitForDevToolsEndpoint({
+		profileDir: "test-profile",
+		browserProcess: child,
+		timeoutMs: 100,
+		pollIntervalMs: 10,
+		fsApi: {
+			readFile: async () => {
+				const value = reads.shift();
+				if (value instanceof Error) throw value;
+				return value;
+			},
+		},
+		delay: async (delayMs) => { elapsedMs += delayMs; },
+		now: () => elapsedMs,
+	});
+
+	assert.deepEqual(endpoint, {
+		port: 45123,
+		browserPath: "/devtools/browser/test-browser",
+		browserWebSocketUrl: "ws://127.0.0.1:45123/devtools/browser/test-browser",
+	});
+	assert.equal(elapsedMs, 20);
+});
+
+test("DevTools readiness reports Chrome exit state instead of an opaque fetch error", async () => {
+	const child = fakeChild(654);
+	child.exitCode = 23;
+	await assert.rejects(waitForDevToolsEndpoint({
+		profileDir: "test-profile",
+		browserProcess: child,
+	}), /Chrome exited before publishing.*rootPid=654, exitCode=23, signalCode=none/u);
+});
+
+test("DevTools readiness timeout retains its lifecycle diagnostic", async () => {
+	const child = fakeChild(987);
+	let elapsedMs = 0;
+	await assert.rejects(waitForDevToolsEndpoint({
+		profileDir: "test-profile",
+		browserProcess: child,
+		timeoutMs: 40,
+		pollIntervalMs: 10,
+		fsApi: { readFile: async () => { throw missingError(); } },
+		delay: async (delayMs) => { elapsedMs += delayMs; },
+		now: () => elapsedMs,
+	}), /within 40 ms.*rootPid=987.*DevToolsActivePort has not been created/u);
+	assert.equal(elapsedMs, 40);
+});
+
+test("a DevTools WebSocket that never opens is closed at its bounded connection timeout", async () => {
+	let socket;
+	class NeverOpeningSocket extends EventTarget {
+		constructor() {
+			super();
+			this.readyState = 0;
+			this.wasClosed = false;
+			socket = this;
+		}
+		close() {
+			this.readyState = 3;
+			this.wasClosed = true;
+		}
+	}
+
+	await assert.rejects(connectDevTools("ws://127.0.0.1:1/devtools/browser/test", {
+		WebSocketImpl: NeverOpeningSocket,
+		timeoutMs: 25,
+		setTimeoutFn: (callback) => {
+			queueMicrotask(callback);
+			return 1;
+		},
+		clearTimeoutFn: () => {},
+	}), /did not open within 25 ms/u);
+	assert.equal(socket.wasClosed, true);
+});
+
+test("a DevTools command that never answers rejects within its own bound", async () => {
+	class SilentSocket extends EventTarget {
+		constructor() {
+			super();
+			this.readyState = 0;
+			queueMicrotask(() => {
+				this.readyState = 1;
+				this.dispatchEvent(new Event("open"));
+			});
+		}
+		send() {}
+		close() {
+			this.readyState = 3;
+			this.dispatchEvent(new Event("close"));
+		}
+	}
+
+	const connection = await connectDevTools("ws://127.0.0.1:1/devtools/browser/test", {
+		WebSocketImpl: SilentSocket,
+		timeoutMs: 100,
+		commandTimeoutMs: 5,
+	});
+	await assert.rejects(
+		connection.command("Runtime.evaluate"),
+		/command Runtime\.evaluate exceeded 5 ms/u,
+	);
+	connection.close();
+});
+
+test("deadline cancellation reports ShutdownDeadlineError rather than a late AbortError", async () => {
+	const child = fakeChild(741);
+	await assert.rejects(
+		withDeadline((signal) => waitForChildExit(child, signal), 5, { label: "Boundary probe" }),
+		(error) => {
+			assert.equal(error instanceof ShutdownDeadlineError, true);
+			assert.equal(error.code, "MOUNTED_BROWSER_SHUTDOWN_TIMEOUT");
+			assert.match(error.message, /Boundary probe exceeded/u);
+			return true;
+		},
+	);
+	assert.equal(child.listenerCount("exit"), 0);
+	assert.equal(child.listenerCount("error"), 0);
+});
+
+test("missing browser connection cleanup emits no unhandled rejection under strict Node handling", async () => {
+	const fixture = fileURLToPath(new URL(
+		"./fixtures/mounted-browser-missing-connection.mjs",
+		import.meta.url,
+	));
+	const { stdout, stderr } = await execFile(process.execPath, [
+		"--unhandled-rejections=strict",
+		fixture,
+	], { windowsHide: true });
+	assert.match(stdout, /MISSING_CONNECTION_CLEANUP_OK/u);
+	assert.doesNotMatch(stderr, /AbortError|ABORT_ERR/u);
+});
 
 test("POSIX cleanup captures and signals owned descendants when the detached group is unavailable", async () => {
 	const processRecords = new Map([
@@ -216,6 +365,134 @@ test("graceful shutdown waits for browser WebSocket closure", async () => {
 	assert.deepEqual(events, ["Browser.close"]);
 });
 
+test("graceful shutdown waits for both root and descendant completion in either exit order", async (t) => {
+	for (const order of ["root-first", "descendant-first"]) {
+		await t.test(order, async () => {
+			const child = fakeChild(101);
+			const socketClosed = deferred();
+			const treeExited = deferred();
+			let treeComplete = false;
+			let settled = false;
+			const connection = {
+				closed: socketClosed.promise,
+				isClosed: () => false,
+				command: async () => {},
+			};
+			const processTree = {
+				capture: async () => [101, 102],
+				remainingPids: async () => [
+					...(child.exitCode === null ? [101] : []),
+					...(!treeComplete ? [102] : []),
+				],
+				terminate: async () => { throw new Error("Fallback should not run."); },
+				waitForExit: () => treeExited.promise,
+			};
+
+			const shuttingDown = shutdownBrowser({
+				browserProcess: child,
+				browserConnection: connection,
+				processTree,
+			}).then(() => { settled = true; });
+			socketClosed.resolve();
+			await new Promise((resolve) => setImmediate(resolve));
+
+			if (order === "root-first") {
+				child.finish();
+			} else {
+				treeComplete = true;
+				treeExited.resolve();
+			}
+			await new Promise((resolve) => setImmediate(resolve));
+			assert.equal(settled, false);
+
+			if (order === "root-first") {
+				treeComplete = true;
+				treeExited.resolve();
+			} else {
+				child.finish();
+			}
+			await shuttingDown;
+			assert.equal(settled, true);
+		});
+	}
+});
+
+test("an already-exited browser with no remaining owned process needs no DevTools connection", async () => {
+	const child = fakeChild(101);
+	child.exitCode = 0;
+	const result = await shutdownBrowser({
+		browserProcess: child,
+		browserConnection: null,
+		processTree: {
+			capture: async () => [],
+			remainingPids: async () => [],
+			terminate: async () => { throw new Error("Fallback should not run."); },
+			waitForExit: async () => {},
+		},
+	});
+	assert.equal(result.graceful, "succeeded");
+	assert.equal(result.fallback, "not-used");
+});
+
+test("an already-closed DevTools connection allows natural browser and descendant exit", async () => {
+	const child = fakeChild(101);
+	const treeExited = deferred();
+	let commandCalls = 0;
+	let treeComplete = false;
+	const shuttingDown = shutdownBrowser({
+		browserProcess: child,
+		browserConnection: {
+			closed: Promise.resolve(),
+			isClosed: () => true,
+			command: () => { commandCalls += 1; },
+		},
+		processTree: {
+			capture: async () => [101, 102],
+			remainingPids: async () => [
+				...(child.exitCode === null ? [101] : []),
+				...(!treeComplete ? [102] : []),
+			],
+			terminate: async () => { throw new Error("Fallback should not run."); },
+			waitForExit: () => treeExited.promise,
+		},
+	});
+	queueMicrotask(() => {
+		child.finish();
+		treeComplete = true;
+		treeExited.resolve();
+	});
+	const result = await shuttingDown;
+	assert.equal(result.graceful, "succeeded");
+	assert.equal(result.fallback, "not-used");
+	assert.equal(commandCalls, 0);
+});
+
+test("a synchronous Browser.close failure is observed before bounded fallback", async () => {
+	const child = fakeChild(101);
+	const closed = deferred();
+	const treeExited = deferred();
+	const result = await shutdownBrowser({
+		browserProcess: child,
+		browserConnection: {
+			closed: closed.promise,
+			isClosed: () => false,
+			command: () => { throw new Error("Browser.close failed synchronously"); },
+		},
+		processTree: {
+			capture: async () => [101],
+			remainingPids: async () => child.exitCode === null ? [101] : [],
+			terminate: async () => {
+				child.finish();
+				treeExited.resolve();
+			},
+			waitForExit: () => treeExited.promise,
+		},
+	});
+	assert.equal(result.graceful, "failed");
+	assert.match(result.gracefulError.message, /failed synchronously/u);
+	assert.equal(result.fallback, "succeeded");
+});
+
 function timeoutThenRun() {
 	let invocation = 0;
 	return async (task, timeoutMs) => {
@@ -244,7 +521,7 @@ test("graceful timeout invokes bounded fallback for only captured test-owned PID
 	};
 	const processTree = {
 		capture: async () => [101, 102],
-		remainingPids: async () => [],
+		remainingPids: async () => child.exitCode === null ? [101, 102] : [],
 		terminate: async (pids) => {
 			terminationTargets.push(...pids);
 			child.finish();
@@ -386,6 +663,36 @@ test("successful lifecycle cleanup confirms both profile and Vite cache absence"
 	assert.deepEqual([...present], []);
 	assert.equal(report.profile.attempts, 1);
 	assert.equal(report.viteCache.attempts, 1);
+});
+
+test("concurrent and repeated cleanup calls share one idempotent ownership transition", async () => {
+	const events = [];
+	const resources = {
+		pageConnection: { close: () => events.push("page-close") },
+		profileDir: "profile",
+		vite: { close: async () => { events.push("vite-close"); } },
+		viteCacheDir: "cache",
+	};
+	const options = {
+		removeDirectoryFn: async (target) => {
+			events.push(`remove:${target}`);
+			return { attempts: 1, retries: 0, totalDelayMs: 0 };
+		},
+	};
+
+	const first = cleanupMountedBrowser(resources, options);
+	const concurrent = cleanupMountedBrowser(resources, options);
+	assert.equal(concurrent, first);
+	const report = await first;
+	const repeated = cleanupMountedBrowser(resources, options);
+	assert.equal(repeated, first);
+	assert.equal(await repeated, report);
+	assert.deepEqual(events, [
+		"page-close",
+		"vite-close",
+		"remove:profile",
+		"remove:cache",
+	]);
 });
 
 test("a primary fixture error remains primary when cleanup also fails", async () => {


### PR DESCRIPTION
## Summary

- remove the released-port handoff by letting Chrome select port 0 and reading its fresh `DevToolsActivePort` endpoint
- make startup, WebSocket, CDP command, cooperative shutdown, and forced shutdown operations bounded
- prevent the missing-browser-connection path from creating exit promises that reject unobserved when cleanup cancels
- make mounted cleanup idempotent, handle already-ended resources, and run browser setup in a `before` hook
- change TMDB Genre Count refresh from daily to Sunday 07:30 UTC while retaining manual dispatch

## Historical evidence

The workflow has 148 runs in the reviewed history: 140 successes and 8 failures. Four failures are materially related to mounted-browser lifecycle behavior; the other four are separately classified dependency/setup or retired Movie/TV cache/maintenance failures.

Since the mounted suite was introduced, 28 runs actually reached it: 24 passed and 4 had related cleanup failures (14.3%). Under the current lifecycle helper, 20/23 passed and 3 failed with the current AbortError family (13.0%). The three current failures were 10.323–10.365 seconds, matching the 10-second DevTools readiness bound rather than the 5+3-second shutdown bounds.

## Root cause

When Chrome did not expose `/json/version` within 10 seconds, no browser-level connection existed. Cleanup created child/tree exit promises and only then rejected for the missing connection. `withDeadline` cancelled its signal while unwinding, those unobserved waits rejected with `AbortError`, and Node 22 treated the rejection as fatal. That masked the real startup error and interrupted forced cleanup, explaining the observed Chrome/crashpad remnants.

The intermittent trigger was exposed by the reserve-release-bind debugging-port pattern. Using Chrome's documented port-0/DevToolsActivePort mechanism removes that non-atomic handoff.

## Regression coverage

- absent/partial/valid `DevToolsActivePort`
- early Chrome exit and useful readiness timeout diagnostics
- WebSocket-open and CDP-command bounds
- strict `--unhandled-rejections=strict` reproduction of readiness timeout + null connection + fallback, preserving the primary error
- normal, root-first, descendant-first, already-exited, and already-closed completion
- synchronous Browser.close failure and timeout escalation
- concurrent/repeated idempotent cleanup
- existing process-group-unavailable and unrelated-PID safety

## Local verification

- lifecycle baseline before changes: 25/25
- mounted baseline before changes: 5/5
- final lifecycle stress: 100/100
- final real-Chrome stress: 20/20 (1.60–2.67s)
- `node scripts/check-all.mjs`
- `.\scripts\check.cmd`
- Builder production build
- combined Pages artifact preparation/validation
- `git diff --check`

All passed.

## Final Linux evidence

Four Ubuntu executions passed on final SHA `d138048a6e1f4f29b26acf80e9bfa746f03fe641`:

- [push 31249336261](https://github.com/davecollections/tmdb-id-lookup/actions/runs/31249336261): mounted 3/3 in 9.640s
- [pull request 31249353800](https://github.com/davecollections/tmdb-id-lookup/actions/runs/31249353800): mounted 3/3 in 7.569s
- [manual 31249391559](https://github.com/davecollections/tmdb-id-lookup/actions/runs/31249391559): mounted 3/3 in 9.520s
- [manual 31249433503](https://github.com/davecollections/tmdb-id-lookup/actions/runs/31249433503): mounted 3/3 in 10.138s

Each run passed all 29 lifecycle results and the complete workflow. None logged a fallback warning, runtime AbortError/unhandled rejection, Chrome/crashpad warning, or orphan PID termination.

## Scope

No Studio, People, Franchise, Network, Builder foundation, Worker, v1 behavior, catalogue content, dependency, secret, count logic, output-format, or commit-behavior changes.

Closes #94
