### PR TITLE
Allow service-token automation on approved Watch Provider routes

### DIFF
--- a/cloudflare-worker/README.md
+++ b/cloudflare-worker/README.md
@@ -22,8 +22,8 @@ NUVIO_PEOPLE_SERVICE_TOKEN
 
 `TMDB_BEARER_TOKEN` is the TMDB API read access token. `NUVIO_PEOPLE_SERVICE_TOKEN`
 is a separate server-to-server credential for the `nuvio-people-assets` generator
-and must contain at least 32 characters. Never reuse, expose, log, or commit either
-value.
+and controlled Watch Provider automation. It must contain at least 32 characters.
+Never reuse, expose, log, or commit either value.
 
 Production was manually updated with the People service-token behavior on
 2026-08-06 before the matching repository change. Once the synchronizing change
@@ -52,10 +52,11 @@ https://davecollections.github.io
 It also allows local development from any `localhost` or `127.0.0.1` port.
 
 Browser requests remain controlled by this CORS allowlist and do not need the
-People service token. The service-token header is intentionally absent from the
-CORS allowed-header list because browser clients do not use it.
+service token. This behavior is unchanged by the origin-free service access. The
+service-token header is intentionally absent from the CORS allowed-header list
+because browser clients do not use it.
 
-## People Service Access
+## People And Watch Provider Service Access
 
 An origin-free server-to-server request is accepted only when all of these are
 true:
@@ -64,7 +65,8 @@ true:
 * `X-Nuvio-Service-Token` exactly matches the configured
   `NUVIO_PEOPLE_SERVICE_TOKEN` secret;
 * the configured secret is a string containing at least 32 characters; and
-* the pathname exactly matches `/3/person/{numeric ID}`.
+* the pathname exactly matches `/3/person/{numeric ID}` or one of the three
+  approved Watch Provider paths below.
 
 The People generator uses this single request shape:
 
@@ -75,9 +77,22 @@ GET /3/person/31?append_to_response=combined_credits,images
 The query string is forwarded to TMDB, so the response can include Person
 details, combined movie/TV credits, and official profile images. The pathname is
 still `/3/person/31`; the separate `/3/person/31/combined_credits` route is
-intentionally not service-token enabled. Search, Collection, Movie, TV, Keyword,
-and every other route continue to require an allowed browser Origin even when a
-valid service token is supplied.
+intentionally not service-token enabled.
+
+Controlled automation may also use these exact origin-free request shapes:
+
+```text
+GET /3/watch/providers/regions?language=en-US
+GET /3/watch/providers/movie?language=en-US
+GET /3/watch/providers/tv?language=en-US
+```
+
+Each Watch Provider route still requires exactly one `language=en-US` parameter.
+Missing, changed, duplicate, or additional parameters, including `api_key`, are
+rejected by the existing TMDB request validator. Token access does not broaden
+the TMDB path or query allowlist. Search, Collection, Movie, TV, Keyword,
+Discover, unsupported Watch Provider paths, and every other route continue to
+require an allowed browser Origin even when a valid service token is supplied.
 
 The service-token header is used only for the Worker's access decision. It is not
 forwarded to TMDB, returned in responses, or deliberately logged.
@@ -87,10 +102,10 @@ allowed` when no allowed browser Origin is present. Missing TMDB configuration
 receives `500 TMDB token not configured`; upstream network failure receives `502
 TMDB request failed`. Error responses remain `Cache-Control: no-store`.
 
-To rotate the People credential, generate a new high-entropy value of at least 32
-characters, update the Cloudflare Worker secret and the authorized generator's
-secret through their protected operator interfaces, verify the exact Person
-request, then retire the old value. Do not place either value in commands, logs,
+To rotate the service credential, generate a new high-entropy value of at least
+32 characters, update the Cloudflare Worker secret and each authorized service's
+secret through their protected operator interfaces, verify the exact approved
+requests, then retire the old value. Do not place either value in commands, logs,
 issues, pull requests, documentation, or repository files.
 
 ## Allowed TMDB Paths

--- a/cloudflare-worker/tmdb-proxy.js
+++ b/cloudflare-worker/tmdb-proxy.js
@@ -121,8 +121,9 @@ export default {
     const suppliedServiceToken =
       request.headers.get("X-Nuvio-Service-Token") || "";
 
-    const hasPeopleServiceAccess =
-      PEOPLE_SERVICE_PATH.test(url.pathname) &&
+    const hasServiceAccess =
+      (PEOPLE_SERVICE_PATH.test(url.pathname) ||
+        WATCH_PROVIDER_PATHS.has(url.pathname)) &&
       typeof env.NUVIO_PEOPLE_SERVICE_TOKEN === "string" &&
       env.NUVIO_PEOPLE_SERVICE_TOKEN.length >= 32 &&
       suppliedServiceToken === env.NUVIO_PEOPLE_SERVICE_TOKEN;
@@ -140,7 +141,7 @@ export default {
       });
     }
 
-    if (!isAllowedOrigin(origin) && !hasPeopleServiceAccess) {
+    if (!isAllowedOrigin(origin) && !hasServiceAccess) {
       return textResponse("Origin not allowed", 403, origin);
     }
 

--- a/tests/cloudflare-worker.test.mjs
+++ b/tests/cloudflare-worker.test.mjs
@@ -64,12 +64,14 @@ test("approved browser origins retain access without a service token", async () 
 
 test("disallowed or missing origins fail without valid service access", async () => {
 	await withMockFetch(async (calls) => {
-		for (const options of [
-			{ origin: "https://example.com" },
-			{},
-			{ token: "incorrect-service-token-at-least-32" },
+		for (const [pathname, options] of [
+			["/3/person/31", { origin: "https://example.com" }],
+			["/3/person/31", {}],
+			["/3/person/31", { token: "incorrect-service-token-at-least-32" }],
+			["/3/watch/providers/movie?language=en-US", {}],
+			["/3/watch/providers/movie?language=en-US", { token: "incorrect-service-token-at-least-32" }],
 		]) {
-			const response = await fetchWorker("/3/person/31", options);
+			const response = await fetchWorker(pathname, options);
 			assert.equal(response.status, 403);
 			assert.equal(await response.text(), "Origin not allowed");
 			assert.equal(response.headers.get("Access-Control-Allow-Origin"), null);
@@ -123,6 +125,30 @@ test("valid origin-free People service requests forward append_to_response and s
 		assert.equal(upstreamUrl.searchParams.has("api_key"), false);
 		assert.equal(upstreamInit.headers.Authorization, "Bearer mock-tmdb-token");
 		assert.equal(Object.keys(upstreamInit.headers).some((name) => name.toLowerCase() === "x-nuvio-service-token"), false);
+	});
+});
+
+test("valid origin-free Watch Provider service requests use the fixed TMDB host without forwarding the service token", async () => {
+	await withMockFetch(async (calls) => {
+		for (const pathname of [
+			"/3/watch/providers/regions?language=en-US",
+			"/3/watch/providers/movie?language=en-US",
+			"/3/watch/providers/tv?language=en-US",
+		]) {
+			const response = await fetchWorker(pathname, { token: serviceToken });
+			assert.equal(response.status, 200, pathname);
+			assert.equal(response.headers.get("Access-Control-Allow-Origin"), null);
+		}
+
+		assert.deepEqual(calls.map(([url]) => url.toString()), [
+			"https://api.themoviedb.org/3/watch/providers/regions?language=en-US",
+			"https://api.themoviedb.org/3/watch/providers/movie?language=en-US",
+			"https://api.themoviedb.org/3/watch/providers/tv?language=en-US",
+		]);
+		for (const [, init] of calls) {
+			assert.equal(init.headers.Authorization, "Bearer mock-tmdb-token");
+			assert.equal(Object.keys(init.headers).some((name) => name.toLowerCase() === "x-nuvio-service-token"), false);
+		}
 	});
 });
 
@@ -235,20 +261,21 @@ test("Streaming provider catalogue routes forward only exact language requests t
 	});
 });
 
-test("Streaming provider catalogue routes reject missing, duplicate, changed, and extra parameters", async () => {
+test("Watch Provider service access keeps exact query validation authoritative", async () => {
 	await withMockFetch(async (calls) => {
-		for (const pathname of [
-			"/3/watch/providers/regions",
-			"/3/watch/providers/movie?language=en-us",
-			"/3/watch/providers/tv?language=en-US&language=en-US",
-			"/3/watch/providers/tv?language=en-US&page=1",
-			"/3/watch/providers/tv?language=en-US&api_key=browser-secret",
-			"/3/watch/providers/person?language=en-US",
-			"/3/watch/providers/tv/?language=en-US",
+		for (const [pathname, expectedMessage] of [
+			["/3/watch/providers/regions", "TMDB path not allowed"],
+			["/3/watch/providers/movie?language=en-us", "TMDB path not allowed"],
+			["/3/watch/providers/movie?language=en-GB", "TMDB path not allowed"],
+			["/3/watch/providers/tv?language=en-US&language=en-US", "TMDB path not allowed"],
+			["/3/watch/providers/tv?language=en-US&page=1", "TMDB path not allowed"],
+			["/3/watch/providers/tv?language=en-US&api_key=browser-secret", "TMDB path not allowed"],
+			["/3/watch/providers/person?language=en-US", "Origin not allowed"],
+			["/3/watch/providers/tv/?language=en-US", "Origin not allowed"],
 		]) {
-			const response = await fetchWorker(pathname, { origin: allowedOrigin });
+			const response = await fetchWorker(pathname, { token: serviceToken });
 			assert.equal(response.status, 403, pathname);
-			assert.equal(await response.text(), "TMDB path not allowed", pathname);
+			assert.equal(await response.text(), expectedMessage, pathname);
 		}
 		assert.equal(calls.length, 0);
 	});
@@ -287,7 +314,7 @@ test("missing, incorrect, short, and empty configured service tokens fail closed
 	});
 });
 
-test("valid service token is limited to the exact Person details pathname", async () => {
+test("valid service token is limited to People details and exact Watch Provider pathnames", async () => {
 	await withMockFetch(async (calls) => {
 		for (const pathname of [
 			"/3/person/31/combined_credits",
@@ -296,6 +323,8 @@ test("valid service token is limited to the exact Person details pathname", asyn
 			"/3/movie/550",
 			"/3/tv/1399",
 			"/3/search/keyword",
+			"/3/discover/movie?with_companies=3",
+			"/3/watch/providers/person?language=en-US",
 			"/3/person/not-a-number",
 			"/3/person/31/",
 		]) {


### PR DESCRIPTION
### Summary

* extends the existing origin-free service-token boundary to the three already-approved Watch Provider catalogue paths;
* preserves existing People service-token access;
* keeps the existing exact Watch Provider request validator authoritative, including the mandatory `language=en-US` query;
* preserves browser CORS, fixed TMDB upstream host, server-side bearer authentication, cache/error behavior, and service-token secrecy;
* adds focused regression coverage and updates Worker documentation.

### Production scope

Only:

* `cloudflare-worker/tmdb-proxy.js`

Tests/docs:

* `tests/cloudflare-worker.test.mjs`
* `cloudflare-worker/README.md`

No new routes, secrets, auth framework, storage, cache, Builder changes, assets work, or dependencies.

### Validation

* Worker tests: 16/16
* `.\scripts\check.cmd` — passed
* `git diff --check` — passed

### Deployment boundary

This PR does **not** deploy the Cloudflare Worker.

Live Worker deployment remains a separate owner-authorized action after merge.

The future `nuvio-assets` provider registry must not begin until the merged Worker change is separately deployed and origin-free access to all three routes is live-verified.

### Deliberate boundaries

* no Worker deployment;
* no new service token or secret rotation;
* no generic service authorization framework;
* no provider registry;
* no `nuvio-assets` changes;
* no artwork;
* no additional TMDB calls;
* no KV, D1, database, or provider cache;
* no Builder/V1/DISCOVER changes.

Closes #108