### PR TITLE
Show assigned Folder artwork in Builder

### DIFF
--- a/builder/src/styles.css
+++ b/builder/src/styles.css
@@ -3245,6 +3245,8 @@ button:disabled {
 .hierarchy-card-row,
 .hierarchy-card-main,
 .node-button-content,
+.folder-card-content,
+.folder-card-copy,
 .source-content,
 .source-heading {
 	min-width: 0;
@@ -3535,6 +3537,90 @@ body.hierarchy-pointer-dragging .builder-shell {
 	gap: 5px;
 }
 
+.folder-card-content {
+	display: grid;
+	width: 100%;
+	grid-template-columns: auto minmax(0, 1fr);
+	align-items: center;
+	gap: 9px;
+}
+
+.folder-card-copy {
+	display: grid;
+	gap: 5px;
+}
+
+.folder-card-copy .node-meta {
+	flex-wrap: nowrap;
+}
+
+.folder-card-copy .node-meta > span {
+	white-space: nowrap;
+}
+
+.folder-card-copy .node-meta > span:last-child {
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.folder-card-thumbnail-frame {
+	display: grid;
+	overflow: hidden;
+	place-items: center;
+	background: rgb(2 13 20 / 64%);
+	border: 1px solid rgb(137 190 215 / 20%);
+	border-radius: 7px;
+}
+
+.folder-card-thumbnail-frame[data-folder-artwork-shape="poster"] {
+	width: 34px;
+	height: 50px;
+}
+
+.folder-card-thumbnail-frame[data-folder-artwork-shape="landscape"] {
+	width: 60px;
+	height: 34px;
+}
+
+.folder-card-thumbnail-frame[data-folder-artwork-shape="unknown"] {
+	width: 44px;
+	height: 44px;
+	padding: 2px;
+}
+
+.folder-card-thumbnail {
+	display: block;
+	width: 100%;
+	height: 100%;
+	pointer-events: none;
+	object-fit: cover;
+}
+
+.folder-card-thumbnail-frame[data-folder-artwork-shape="unknown"] .folder-card-thumbnail {
+	object-fit: contain;
+}
+
+@media (max-width: 1239px) {
+	.folder-card-content {
+		gap: 7px;
+	}
+
+	.folder-card-thumbnail-frame[data-folder-artwork-shape="poster"] {
+		width: 30px;
+		height: 44px;
+	}
+
+	.folder-card-thumbnail-frame[data-folder-artwork-shape="landscape"] {
+		width: 50px;
+		height: 28px;
+	}
+
+	.folder-card-thumbnail-frame[data-folder-artwork-shape="unknown"] {
+		width: 36px;
+		height: 36px;
+	}
+}
+
 .node-title {
 	display: -webkit-box;
 	overflow: hidden;
@@ -3573,13 +3659,6 @@ body.hierarchy-pointer-dragging .builder-shell {
 	margin-right: 8px;
 	color: var(--quiet);
 	content: "·";
-}
-
-.node-chevron {
-	flex: 0 0 auto;
-	color: var(--quiet);
-	font-size: 1.4rem;
-	line-height: 1;
 }
 
 .source-button {
@@ -4006,7 +4085,7 @@ body.hierarchy-pointer-dragging .builder-shell {
 	}
 
 	.workspace {
-		grid-template-columns: minmax(265px, 0.8fr) minmax(265px, 0.8fr) minmax(270px, 1.35fr);
+		grid-template-columns: minmax(250px, 0.9fr) minmax(310px, 1.1fr) minmax(240px, 0.95fr);
 		gap: 0;
 	}
 
@@ -4085,7 +4164,7 @@ body.hierarchy-pointer-dragging .builder-shell {
 	}
 
 	.workspace {
-		grid-template-columns: minmax(260px, 0.82fr) minmax(260px, 0.82fr) minmax(440px, 1.45fr);
+		grid-template-columns: minmax(285px, 1.05fr) minmax(330px, 1.2fr) minmax(330px, 0.95fr);
 	}
 
 }

--- a/builder/src/ui/BuilderWorkspace.jsx
+++ b/builder/src/ui/BuilderWorkspace.jsx
@@ -386,7 +386,6 @@ function NodeButton({
 			}}
 		>
 			<span className="node-button-content">{children}</span>
-			<span className="node-chevron" aria-hidden="true">›</span>
 			{node.selected ? <span className="visually-hidden">Selected</span> : null}
 		</button>
 	);
@@ -437,16 +436,67 @@ function FolderList({ folders, actionProps, createdCardTarget, createdCardRef })
 						: undefined}
 				>
 					<HierarchyCard node={folder} noun="folder" siblings={folders} {...actionProps}>
-						<span className="node-title">{folder.title}</span>
-						{folder.titleHidden ? <span className="hidden-title-badge">Invisible in Nuvio</span> : null}
-						<span className="node-meta">
-							<span>{folder.sourceCountLabel}</span>
-							{folder.tileShape !== null ? <span>{folder.tileShape}</span> : null}
-						</span>
+						<FolderCardContent folder={folder} />
 					</HierarchyCard>
 				</li>
 			))}
 		</ul>
+	);
+}
+
+const folderThumbnailDimensions = Object.freeze({
+	poster: Object.freeze({ width: 34, height: 50 }),
+	landscape: Object.freeze({ width: 60, height: 34 }),
+	unknown: Object.freeze({ width: 44, height: 44 }),
+});
+
+function FolderCardText({ folder }) {
+	return (
+		<>
+			<span className="node-title">{folder.title}</span>
+			{folder.titleHidden ? <span className="hidden-title-badge">Invisible in Nuvio</span> : null}
+			<span className="node-meta">
+				<span>{folder.sourceCountLabel}</span>
+				{folder.tileShape !== null ? <span>{folder.tileShape}</span> : null}
+			</span>
+		</>
+	);
+}
+
+function FolderCardContent({ folder }) {
+	const [failedArtworkUrl, setFailedArtworkUrl] = useState(null);
+	useEffect(() => {
+		setFailedArtworkUrl(null);
+	}, [folder.tileArtworkUrl]);
+	const artworkVisible = folder.tileArtworkUrl !== null && failedArtworkUrl !== folder.tileArtworkUrl;
+
+	if (!artworkVisible) return <FolderCardText folder={folder} />;
+
+	const shape = folder.tileArtworkShape ?? "unknown";
+	const dimensions = folderThumbnailDimensions[shape] ?? folderThumbnailDimensions.unknown;
+	return (
+		<span className="folder-card-content" data-folder-card-artwork={shape}>
+			<span className="folder-card-thumbnail-frame" data-folder-artwork-shape={shape} aria-hidden="true">
+				<img
+					className="folder-card-thumbnail"
+					src={folder.tileArtworkUrl}
+					alt=""
+					width={dimensions.width}
+					height={dimensions.height}
+					loading="lazy"
+					decoding="async"
+					referrerPolicy="no-referrer"
+					draggable="false"
+					onError={(event) => {
+						event.currentTarget.hidden = true;
+						setFailedArtworkUrl(folder.tileArtworkUrl);
+					}}
+				/>
+			</span>
+			<span className="folder-card-copy">
+				<FolderCardText folder={folder} />
+			</span>
+		</span>
 	);
 }
 

--- a/builder/src/ui/view-model.js
+++ b/builder/src/ui/view-model.js
@@ -77,6 +77,18 @@ function supportedBoolean(value) {
 	return typeof value === "boolean" ? value : null;
 }
 
+function assignedTileArtworkUrl(value) {
+	return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function tileArtworkShape(value) {
+	if (typeof value !== "string") return "unknown";
+	const normalized = value.toUpperCase();
+	if (normalized === "POSTER") return "poster";
+	if (normalized === "LANDSCAPE") return "landscape";
+	return "unknown";
+}
+
 function buildCollection(collection, selectedInternalId) {
 	const folderCount = collection.folders.length;
 	const sourceCount = collection.folders.reduce((total, folder) => total + folder.sources.length, 0);
@@ -115,6 +127,7 @@ function buildFolder(folder, selectedInternalId) {
 	const sourceCount = folder.sources.length;
 	const artworkCount = folderArtworkFields.filter((field) => presentValue(folder.editable[field]) !== null).length;
 	const title = nodeTitle(folder.editable.title, "folder");
+	const tileArtworkUrl = assignedTileArtworkUrl(folder.editable.coverImageUrl);
 	const tileShape = friendlyChoice(folder.editable.tileShape, {
 		POSTER: "Poster",
 		LANDSCAPE: "Landscape",
@@ -136,6 +149,8 @@ function buildFolder(folder, selectedInternalId) {
 		sourceCount,
 		sourceCountLabel: countLabel(sourceCount, "source"),
 		tileShape,
+		tileArtworkUrl,
+		tileArtworkShape: tileArtworkUrl === null ? null : tileArtworkShape(folder.editable.tileShape),
 		selected: folder.internalId === selectedInternalId,
 		details: compactDetails([
 			detail("Title", title.text),

--- a/docs/v2/ARTWORK_RUNTIME.md
+++ b/docs/v2/ARTWORK_RUNTIME.md
@@ -2,7 +2,7 @@
 
 Status: shared `nuvio-assets` runtime is active for V1 Company/Network and V2 Studio/Network hierarchy; active V2 People resolution moved to `nuvio-people-assets` in issue #118
 
-Last reviewed: 2026-08-20
+Last reviewed: 2026-08-22
 
 ## Evidence and scope
 
@@ -20,6 +20,14 @@ Issue [#45](https://github.com/davecollections/tmdb-id-lookup/issues/45) added t
 Active V2 People creation now loads [`nuvio-people-assets/manifests/people.json`](https://raw.githubusercontent.com/davecollections/nuvio-people-assets/main/manifests/people.json) once per workspace and indexes records by numeric TMDB Person ID. The manifest supplies registered canonical name, actor/director membership, stable asset URLs, and per-asset SHA-256 values. Poster or compatibility Landscape maps to `coverImageUrl`; Hero and Title Logo remain separate; optional focus Poster/Landscape are accepted only as a complete pair. People Review exposes only a shared Poster/Landscape choice. Orientation changes recompute every generated folder's canonical manifest/fallback values; there are no per-person artwork URL, focus, or reset controls in hierarchy creation. The extracted known-field group remains available in the ordinary manual Folder editor for later individual customisation with preservation-first minimal patches. Missing IDs use the existing TMDB profile/emoji fallback and never construct the legacy paths listed later in this document. The historical `focusGifUrl` name is treated as a generic optional string by import/overlay/serialization, so the manifest's static WebP focus counterpart round-trips; no current-client rendering claim is made.
 
 The `nuvio-assets` People paths and tests below remain valid historical/publication and V1 compatibility documentation. They are not an active V2 Builder fallback. Company and Network behavior in this runtime is unchanged. The Builder migration is merged, but no legacy asset may be deleted until generated JSON is accepted in Nuvio, remaining consumers are migrated or retired, and Dave separately approves deletion.
+
+## Assigned Folder artwork in the Builder workspace
+
+Issue [#134](https://github.com/davecollections/tmdb-id-lookup/issues/134) is a presentation-only consumer of the Folder's existing persisted `coverImageUrl`. A nonblank string is displayed exactly as assigned on its Folder card, regardless of whether it came from a curated runtime, TMDB, import, or a custom URL. Poster and Landscape values receive compact orientation-aware thumbnails; an unsupported or legacy `tileShape` receives a neutral contained treatment without rewriting the stored shape.
+
+Blank, absent, null, and non-string values retain the original text-only Folder card. An image load failure also falls back to that text-only presentation for the current render while preserving the exact URL, raw import evidence, revision, and serialized output. Failure state is scoped to the exact attempted URL and resets when the assignment changes, so a failed old URL cannot suppress its replacement. Workspace display performs no artwork-runtime lookup, manifest lookup, TMDB request, URL replacement, migration, or cache refresh. Images are decorative, natively lazy-loaded, asynchronously decoded, requested without sending the Builder page as a referrer, and excluded from drag behavior; this host-agnostic request policy permits arbitrary valid artwork origins without an allowlist, while the existing card remains the sole selection and reorder interaction.
+
+This does not add artwork discovery to import or Folder Settings. A later separately approved Folder Settings issue may preview the currently assigned URLs and offer an explicit suggestion only when authoritative exact identity evidence exists. It must keep imported/custom values visible and unchanged until the user deliberately accepts a replacement; no preview or suggestion UI is part of issue #134.
 
 ## Published location
 

--- a/docs/v2/BUILDER_KNOWLEDGE.md
+++ b/docs/v2/BUILDER_KNOWLEDGE.md
@@ -2,7 +2,7 @@
 
 Status: Active isolated builder and contract groundwork
 
-Last reviewed: 2026-08-20
+Last reviewed: 2026-08-22
 
 This is a living record of confirmed v2/Nuvio findings, current decisions, unsupported behaviour, and open questions. GitHub issues remain the source of truth for implementation scope. See [`BUILDER_PRODUCT_PLAN.md`](./BUILDER_PRODUCT_PLAN.md) for durable product direction, [`BUILDER_HIERARCHY_CREATION.md`](./BUILDER_HIERARCHY_CREATION.md) for the shared hierarchy-family standard, and [`PROJECT_WORKFLOW.md`](./PROJECT_WORKFLOW.md) for the Dave/ChatGPT/Codex process.
 
@@ -825,6 +825,8 @@ Quick Setup, Dave's 1-Click Setup, templates/recipes, the Kaptain comparison, pr
 | 2026-08-21 | Genre hierarchy issue #130 final owner-acceptance checkpoint: one shared Structure-card grid correction replaced bottom alignment of the preview area with stretched, space-between description/preview allocation. This removes the longer third title's excess empty space without a card-specific override, preserves card dimensions, diagrams, selected treatment, and bottom count alignment, and measures a consistent 12-pixel description-to-diagram gap at 360, 393, 412, 899, 900, 901, and 1280 pixels with no clipping, horizontal overflow, awkward wrapping, diagram compression, or count drift. Dave accepted the final desktop and physical-phone result. Worker deployment/live validation remain complete and unchanged; implementation and durable evidence remain unstaged/uncommitted with no push or PR pending explicit commit authorization. | [Issue #130](https://github.com/davecollections/tmdb-id-lookup/issues/130) and [`BUILDER_GENRES.md`](./BUILDER_GENRES.md) |
 
 ## Decision history
+
+- **2026-08-22 — Assigned Folder artwork workspace contract:** display every exact nonblank string `coverImageUrl` already assigned to a Folder as a compact decorative card thumbnail, regardless of curated-runtime, TMDB, imported, or custom origin. Use Poster/Landscape proportions and a neutral contained fallback for unsupported shapes without rewriting them. Keep blank, absent, null, non-string, and load-failed images on the original text-only card; image failure is presentation-only and preserves URL, raw data, revision, and serialization. Request the native image without disclosing the Builder page as a referrer so referrer-sensitive arbitrary origins are not rejected, without host allowlists or URL rewriting. Scope failure state to the exact attempted URL and reset it when the assignment changes so an old failure cannot poison a replacement or later reassignment. Use native lazy loading and async decoding, make the image non-draggable, preserve the card's existing selection/accessibility/reorder semantics, and perform no resolver, manifest, TMDB, migration, or replacement request. Keep Folder Settings current-URL previews and exact-authority opt-in suggestions deferred to a separate approved issue. See [issue #134](https://github.com/davecollections/tmdb-id-lookup/issues/134) and [`ARTWORK_RUNTIME.md`](./ARTWORK_RUNTIME.md).
 
 - **2026-08-21 — People entry and browse-first cleanup:** remove the temporary Folders-header People shortcut and its dedicated session path. Keep `New Collection → People` and `New Folder → People` as the hierarchy routes, keep `Selected Folder → Add Source → People` as the physical-source route, focus the stable People browse heading for guided hierarchy, and retain typing-first Search focus for direct Add Source.
 

--- a/docs/v2/BUILDER_PRODUCT_PLAN.md
+++ b/docs/v2/BUILDER_PRODUCT_PLAN.md
@@ -2,7 +2,7 @@
 
 Status: Durable product direction for the isolated v2 Builder
 
-Last reviewed: 2026-08-20
+Last reviewed: 2026-08-22
 
 This document records the current product direction recovered from the owner-supplied V1 and V2 project histories and reconciled with the repository, tests, manual Nuvio evidence, current GitHub history, and official Nuvio documentation. It is not a release claim or an implementation specification.
 
@@ -340,6 +340,10 @@ Artwork should normally feel automatic rather than technical:
 3. otherwise retain a visible title and emoji fallback.
 
 Imported or custom nonblank artwork must be preserved unless the user changes it. Runtime-owned automatic artwork may refresh under a later approved policy. Builder-only ownership metadata must never leak into Nuvio JSON. Missing artwork must not prevent collection creation.
+
+Issue [#134](https://github.com/davecollections/tmdb-id-lookup/issues/134) makes the workspace reflect the Folder Tile artwork that is already assigned: every nonblank string `coverImageUrl` is shown directly on the Folder card with compact Poster/Landscape treatment, regardless of origin. Native image requests omit the Builder referrer without using a host allowlist, and exact-URL failure state resets when the assignment changes. Blank, absent, null, invalid, or genuinely failed images use the established text-only card. This display is presentation-only and performs no resolution, discovery, normalization, migration, mutation, or serialization change; unsupported shapes remain preserved and receive a neutral thumbnail treatment.
+
+Current-URL previews and exact-identity artwork suggestions inside ordinary Folder Settings remain a separate future issue. Any suggestion must be clearly optional and accepted explicitly, and imported/custom artwork must remain visible and byte-preserved until the user chooses replacement. Issue #134 adds no Settings preview, suggestion, or automatic replacement behavior.
 
 The separate `nuvio-assets` project owns artwork production, replacement, review, publication, runtime schema, and asset-contract decisions. TMDB ID Lookup consumes its published runtime. Questions owned by that project must be taken there instead of guessed in V2.
 

--- a/scripts/check-all.mjs
+++ b/scripts/check-all.mjs
@@ -52,6 +52,7 @@ runNode(["--test", path.join("tests", "builder-migration.test.mjs")]);
 runNode(["--test", path.join("tests", "builder-controller.test.mjs")]);
 runNode(["--test", path.join("tests", "builder-welcome-import.test.mjs")]);
 runNode(["--test", path.join("tests", "builder-ui.test.mjs")]);
+runNode(["--test", path.join("tests", "builder-folder-card-artwork.test.mjs")]);
 runNode(["--test", path.join("tests", "builder-about-credits-ui.test.mjs")]);
 runNode(["--test", path.join("tests", "builder-reordering.test.mjs")]);
 runNode(["--test", path.join("tests", "builder-hierarchy-menu-placement.test.mjs")]);
@@ -89,6 +90,7 @@ runNode(["--test", path.join("tests", "v1-company-search-compatibility.test.mjs"
 runNode(["--test", path.join("tests", "builder-source-edit-foundation.test.mjs")]);
 runNode(["--test", path.join("tests", "builder-source-edit-ui.test.mjs")]);
 runNode(["--test", path.join("tests", "mounted-browser-lifecycle.test.mjs")]);
+runNode(["--test", path.join("tests", "builder-folder-card-artwork-mounted.test.mjs")]);
 runNode(["--test", path.join("tests", "builder-source-edit-mounted.test.mjs")]);
 runNode(["--test", path.join("tests", "fixture-line-endings.test.mjs")]);
 runNode(["--test", path.join("tests", "windows-validation.test.mjs")]);

--- a/tests/builder-folder-card-artwork-mounted.test.mjs
+++ b/tests/builder-folder-card-artwork-mounted.test.mjs
@@ -1,0 +1,417 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import fsPromises from "node:fs/promises";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import test, { before } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import react from "../builder/node_modules/@vitejs/plugin-react/dist/index.js";
+import { createServer } from "../builder/node_modules/vite/dist/node/index.js";
+import { extractTmdbProxyBaseUrl } from "../builder/build-config.js";
+import {
+	cleanupMountedBrowser,
+	connectDevTools,
+	createBrowserProcessTree,
+	runWithLifecycleCleanup,
+	waitForDevToolsEndpoint,
+} from "./helpers/mounted-browser-lifecycle.mjs";
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const builderModules = path.join(rootDir, "builder", "node_modules");
+const tmdbProxyBaseUrl = extractTmdbProxyBaseUrl(fs.readFileSync(path.join(rootDir, "js", "config.js"), "utf8"));
+
+function chromeExecutable() {
+	const candidates = [
+		process.env.CHROME_PATH,
+		"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
+		"C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
+		"/usr/bin/google-chrome",
+		"/usr/bin/chromium",
+		"/usr/bin/chromium-browser",
+		"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+	].filter(Boolean);
+	const executable = candidates.find((candidate) => fs.existsSync(candidate));
+	if (!executable) throw new Error("Chrome or Chromium is required for mounted Folder artwork regressions.");
+	return executable;
+}
+
+async function waitForJson(url, timeoutMs = 10000) {
+	const deadline = Date.now() + timeoutMs;
+	let lastError = null;
+	while (Date.now() < deadline) {
+		try {
+			const remainingMs = Math.max(1, deadline - Date.now());
+			const response = await fetch(url, { signal: AbortSignal.timeout(Math.min(1000, remainingMs)) });
+			if (response.ok) return response.json();
+			lastError = new Error(`HTTP ${response.status}`);
+		} catch (error) {
+			lastError = error;
+		}
+		await new Promise((resolve) => setTimeout(resolve, 50));
+	}
+	throw new Error(`Chrome DevTools did not become available: ${lastError?.message ?? "timeout"}`);
+}
+
+async function evaluate(connection, expression) {
+	const response = await connection.command("Runtime.evaluate", {
+		expression,
+		awaitPromise: true,
+		returnByValue: true,
+	});
+	if (response.exceptionDetails) {
+		throw new Error(response.exceptionDetails.exception?.description ?? response.exceptionDetails.text);
+	}
+	return response.result?.value;
+}
+
+async function runMountedPage() {
+	const resources = {
+		artworkRequests: [],
+		artworkServer: null,
+		browserExecutable: null,
+		browserProcess: null,
+		browserConnection: null,
+		debugPort: null,
+		pageConnection: null,
+		processTree: null,
+		profileDir: null,
+		vite: null,
+		viteCacheDir: null,
+	};
+	const execution = await runWithLifecycleCleanup(async () => {
+		const artworkBytes = Buffer.from("R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==", "base64");
+		resources.artworkServer = http.createServer((request, response) => {
+			const requestUrl = new URL(request.url, "http://127.0.0.1");
+			resources.artworkRequests.push({
+				path: requestUrl.pathname,
+				referer: request.headers.referer ?? null,
+			});
+			response.setHeader("Cache-Control", "no-store");
+
+			const recoveringRequestCount = resources.artworkRequests.filter(({ path: requestPath }) => requestPath === "/recovering.gif").length;
+			if (requestUrl.pathname === "/recovering.gif" && recoveringRequestCount === 1) {
+				response.writeHead(404).end();
+				return;
+			}
+			if (requestUrl.pathname === "/hotlink-sensitive.gif" && request.headers.referer) {
+				response.writeHead(403).end();
+				return;
+			}
+			if (["/hotlink-sensitive.gif", "/replacement.gif", "/recovering.gif"].includes(requestUrl.pathname)) {
+				response.writeHead(200, { "Content-Type": "image/gif", "Content-Length": artworkBytes.length });
+				response.end(artworkBytes);
+				return;
+			}
+			response.writeHead(404).end();
+		});
+		await new Promise((resolve, reject) => {
+			resources.artworkServer.once("error", reject);
+			resources.artworkServer.listen(0, "127.0.0.1", resolve);
+		});
+		const artworkAddress = resources.artworkServer.address();
+		const artworkBaseUrl = `http://127.0.0.1:${artworkAddress.port}`;
+
+		resources.viteCacheDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), "builder-folder-artwork-vite-"));
+		resources.vite = await createServer({
+			root: rootDir,
+			cacheDir: resources.viteCacheDir,
+			configFile: false,
+			appType: "spa",
+			logLevel: "silent",
+			plugins: [react()],
+			define: {
+				__TMDB_PROXY_BASE_URL__: JSON.stringify(tmdbProxyBaseUrl),
+				__TMDB_STUDIO_MOCK_COUNTS__: "false",
+				__TMDB_NETWORK_MOCK_COUNTS__: "false",
+			},
+			resolve: {
+				alias: [
+					{ find: /^react$/, replacement: path.join(builderModules, "react", "index.js") },
+					{ find: /^react\/jsx-runtime$/, replacement: path.join(builderModules, "react", "jsx-runtime.js") },
+					{ find: /^react-dom$/, replacement: path.join(builderModules, "react-dom", "index.js") },
+					{ find: /^react-dom\/client$/, replacement: path.join(builderModules, "react-dom", "client.js") },
+				],
+			},
+			server: { host: "127.0.0.1", port: 0 },
+		});
+		await resources.vite.listen();
+
+		resources.profileDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), "builder-folder-artwork-mounted-"));
+		resources.browserExecutable = chromeExecutable();
+		resources.browserProcess = spawn(resources.browserExecutable, [
+			"--headless=new",
+			"--disable-background-networking",
+			"--disable-component-update",
+			"--disable-gpu",
+			"--hide-scrollbars",
+			"--no-first-run",
+			"--no-sandbox",
+			"--remote-debugging-address=127.0.0.1",
+			"--remote-debugging-port=0",
+			`--user-data-dir=${resources.profileDir}`,
+			"about:blank",
+		], {
+			detached: process.platform !== "win32",
+			stdio: "ignore",
+			windowsHide: true,
+		});
+		await new Promise((resolve, reject) => {
+			resources.browserProcess.once("spawn", resolve);
+			resources.browserProcess.once("error", reject);
+		});
+		resources.processTree = createBrowserProcessTree({ rootPid: resources.browserProcess.pid });
+
+		const endpoint = await waitForDevToolsEndpoint({
+			profileDir: resources.profileDir,
+			browserProcess: resources.browserProcess,
+		});
+		resources.debugPort = endpoint.port;
+		resources.browserConnection = await connectDevTools(endpoint.browserWebSocketUrl);
+		const targets = await waitForJson(`http://127.0.0.1:${endpoint.port}/json/list`);
+		const target = targets.find((entry) => entry.type === "page");
+		if (!target?.webSocketDebuggerUrl) throw new Error("Chrome page target is unavailable.");
+		resources.pageConnection = await connectDevTools(target.webSocketDebuggerUrl, { commandTimeoutMs: 30000 });
+		await resources.pageConnection.command("Page.enable");
+		await resources.pageConnection.command("Runtime.enable");
+		const address = resources.vite.httpServer.address();
+		await resources.pageConnection.command("Page.navigate", {
+			url: `http://127.0.0.1:${address.port}/tests/fixtures/builder-folder-card-artwork-mounted.html?artworkBaseUrl=${encodeURIComponent(artworkBaseUrl)}`,
+		});
+
+		const deadline = Date.now() + 30000;
+		while (Date.now() < deadline) {
+			const status = await evaluate(resources.pageConnection, "window.__builderFolderArtworkMounted ?? null");
+			if (status?.status === "error") throw new Error(status.message);
+			if (status?.status === "complete") break;
+			await new Promise((resolve) => setTimeout(resolve, 50));
+		}
+		const ready = await evaluate(resources.pageConnection, "window.__builderFolderArtworkMounted ?? null");
+		if (ready?.status !== "complete") throw new Error("Mounted Folder artwork regressions timed out.");
+
+		const widths = [];
+		for (const width of [360, 384, 393, 402, 412, 899, 900, 901, 1280]) {
+			await resources.pageConnection.command("Emulation.setDeviceMetricsOverride", {
+				width,
+				height: width <= 412 ? 852 : 900,
+				deviceScaleFactor: 1,
+				mobile: width <= 412,
+			});
+			await new Promise((resolve) => setTimeout(resolve, 40));
+			widths.push(await evaluate(resources.pageConnection, "window.__measureFolderArtworkLayout()"));
+		}
+
+		await resources.pageConnection.command("Emulation.setDeviceMetricsOverride", {
+			width: 1280,
+			height: 900,
+			deviceScaleFactor: 1,
+			mobile: false,
+		});
+		await evaluate(resources.pageConnection, "window.__measureFolderArtworkLayout()");
+		const handle = await evaluate(resources.pageConnection, `(() => {
+			const card = [...document.querySelectorAll('[data-hierarchy-card="folder"]')]
+				.find((entry) => entry.querySelector('.node-title')?.textContent.trim() === 'Poster artwork');
+			const rect = card.querySelector('[data-action="reorder-folder"]').getBoundingClientRect();
+			return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+		})()`);
+		await resources.pageConnection.command("Input.dispatchMouseEvent", {
+			type: "mousePressed", x: handle.x, y: handle.y, button: "left", buttons: 1, clickCount: 1,
+		});
+		await resources.pageConnection.command("Input.dispatchMouseEvent", {
+			type: "mouseMoved", x: handle.x, y: handle.y + 12, button: "left", buttons: 1,
+		});
+		await new Promise((resolve) => setTimeout(resolve, 60));
+		const dragOverlay = await evaluate(resources.pageConnection, `(() => {
+			const overlay = document.querySelector('[data-reorder-drag-overlay="true"]');
+			const source = [...document.querySelectorAll('[data-hierarchy-card="folder"]')]
+				.find((entry) => entry.querySelector('.node-title')?.textContent.trim() === 'Poster artwork');
+			if (!overlay) return { present: false };
+			const sourceRect = source.getBoundingClientRect();
+			return {
+				present: true,
+				ariaHidden: overlay.getAttribute('aria-hidden'),
+				inert: overlay.inert,
+				thumbnailPresent: overlay.querySelector('.folder-card-thumbnail') !== null,
+				widthMatches: Math.abs(Number.parseFloat(overlay.style.width) - sourceRect.width) < 1,
+				heightMatches: Math.abs(Number.parseFloat(overlay.style.height) - sourceRect.height) < 1,
+				buttonsOutOfTabOrder: [...overlay.querySelectorAll('button')].every((button) => button.tabIndex === -1),
+			};
+		})()`);
+		await resources.pageConnection.command("Input.dispatchKeyEvent", { type: "keyDown", key: "Escape", code: "Escape" });
+		await resources.pageConnection.command("Input.dispatchKeyEvent", { type: "keyUp", key: "Escape", code: "Escape" });
+		await resources.pageConnection.command("Input.dispatchMouseEvent", {
+			type: "mouseReleased", x: handle.x, y: handle.y + 12, button: "left", buttons: 0, clickCount: 1,
+		});
+		await new Promise((resolve) => setTimeout(resolve, 240));
+		const dragAfter = await evaluate(resources.pageConnection, `({
+			overlayRemoved: document.querySelector('[data-reorder-drag-overlay="true"]') === null,
+			...window.__folderArtworkPreservationState(),
+		})`);
+
+		await evaluate(resources.pageConnection, `(() => {
+			const card = [...document.querySelectorAll('[data-hierarchy-card="folder"]')]
+				.find((entry) => entry.querySelector('.node-title')?.textContent.trim() === 'Poster artwork');
+			card.querySelector('[data-action="reorder-folder"]').focus();
+		})()`);
+		await resources.pageConnection.command("Input.dispatchKeyEvent", { type: "keyDown", key: "Enter", code: "Enter" });
+		await resources.pageConnection.command("Input.dispatchKeyEvent", { type: "keyUp", key: "Enter", code: "Enter" });
+		await new Promise((resolve) => setTimeout(resolve, 30));
+		const keyboardActive = await evaluate(resources.pageConnection, `(() => {
+			const card = [...document.querySelectorAll('[data-hierarchy-card="folder"]')]
+				.find((entry) => entry.querySelector('.node-title')?.textContent.trim() === 'Poster artwork');
+			const handle = card.querySelector('[data-action="reorder-folder"]');
+			return { pressed: handle.getAttribute('aria-pressed'), thumbnailPresent: card.querySelector('.folder-card-thumbnail') !== null };
+		})()`);
+		await resources.pageConnection.command("Input.dispatchKeyEvent", { type: "keyDown", key: "Escape", code: "Escape" });
+		await resources.pageConnection.command("Input.dispatchKeyEvent", { type: "keyUp", key: "Escape", code: "Escape" });
+		await new Promise((resolve) => setTimeout(resolve, 30));
+		const keyboardAfter = await evaluate(resources.pageConnection, `(() => {
+			const card = [...document.querySelectorAll('[data-hierarchy-card="folder"]')]
+				.find((entry) => entry.querySelector('.node-title')?.textContent.trim() === 'Poster artwork');
+			return {
+				pressed: card.querySelector('[data-action="reorder-folder"]').getAttribute('aria-pressed'),
+				...window.__folderArtworkPreservationState(),
+			};
+		})()`);
+
+		const failureReplacement = await evaluate(resources.pageConnection, "window.__exerciseFolderArtworkFailureReplacement()");
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		const artworkRequests = resources.artworkRequests.map((request) => ({ ...request }));
+
+		return { widths, dragOverlay, dragAfter, keyboardActive, keyboardAfter, failureReplacement, artworkRequests };
+	}, async () => {
+		const cleanupReport = await cleanupMountedBrowser(resources);
+		if (resources.artworkServer?.listening) {
+			await new Promise((resolve, reject) => resources.artworkServer.close((error) => (error ? reject(error) : resolve())));
+		}
+		return cleanupReport;
+	});
+
+	if (execution.cleanupReport.browser.fallback === "succeeded") {
+		console.warn(`Mounted Folder artwork browser required process-tree fallback: ${execution.cleanupReport.browser.gracefulError?.message ?? "unknown error"}`);
+	}
+	return execution.value;
+}
+
+let mountedResults;
+before(async () => {
+	mountedResults = await runMountedPage();
+});
+
+test("mounted assigned artwork remains compact, decorative, lazy, and overflow-free at every required width", () => {
+	assert.deepEqual(mountedResults.widths.map((result) => result.width), [360, 384, 393, 402, 412, 899, 900, 901, 1280]);
+	for (const result of mountedResults.widths) {
+		const compact = result.width < 1240;
+		assert.equal(result.folderPanelVisible, true, `${result.width}px Folder panel`);
+		assert.deepEqual(result.poster.attributes, { alt: "", loading: "lazy", decoding: "async", referrerPolicy: "no-referrer", draggable: "false" }, `${result.width}px browser image behavior`);
+		assert.equal(result.poster.frame.width, compact ? 30 : 34, `${result.width}px Poster width`);
+		assert.equal(result.poster.frame.height, compact ? 44 : 50, `${result.width}px Poster height`);
+		assert.equal(result.landscape.frame.width, compact ? 50 : 60, `${result.width}px Landscape width`);
+		assert.equal(result.landscape.frame.height, compact ? 28 : 34, `${result.width}px Landscape height`);
+		assert.equal(result.unknown.frame.width, compact ? 36 : 44, `${result.width}px unknown width`);
+		assert.equal(result.unknown.frame.height, compact ? 36 : 44, `${result.width}px unknown height`);
+		assert.equal(result.unknown.objectFit, "contain", `${result.width}px unknown shape treatment`);
+		assert.equal(result.cardHeightGrowth <= 10, true, `${result.width}px compact card height (${JSON.stringify(result.cardHeights)})`);
+		assert.equal(result.longTitleHeight <= 90, true, `${result.width}px long-title card height`);
+		assert.equal(result.longTitleWidth >= 60, true, `${result.width}px title width`);
+		assert.equal(result.noHorizontalOverflow, true, `${result.width}px overflow`);
+		assert.equal(result.fetchCallCount, 0, `${result.width}px no artwork resolver or TMDB fetch`);
+		if (result.width >= 1240) {
+			assert.equal(result.panelWidths.collections > result.panelWidths.sources, true, `${result.width}px Collection width`);
+			assert.equal(result.panelWidths.folders > result.panelWidths.sources, true, `${result.width}px Folder width`);
+		}
+	}
+});
+
+test("mounted blank, absent, and broken artwork use the exact text-only card without mutating preserved state", () => {
+	for (const result of mountedResults.widths) {
+		assert.deepEqual(result.textFallbacks, {
+			noArtworkHasFrame: false,
+			blankHasFrame: false,
+			brokenHasFrame: false,
+			brokenTextDirect: true,
+		}, `${result.width}px text-only fallback`);
+		assert.equal(result.projectUnchanged, true, `${result.width}px project`);
+		assert.equal(result.serializedUnchanged, true, `${result.width}px serialization`);
+		assert.equal(result.revisionUnchanged, true, `${result.width}px revision`);
+	}
+	assert.deepEqual(mountedResults.dragAfter, {
+		overlayRemoved: true,
+		brokenUrl: "/tests/fixtures/missing-folder-card-artwork.webp",
+		blankUrl: "   ",
+		absentHasField: false,
+		unsupportedShape: "SQUARE",
+		projectUnchanged: true,
+		serializedUnchanged: true,
+		revisionUnchanged: true,
+	});
+});
+
+test("mounted selected and hidden-title Folder cards retain accessible non-colour state with artwork", () => {
+	for (const result of mountedResults.widths) {
+		assert.deepEqual(result.selectedState, { cardSelected: true, buttonPressed: "true" }, `${result.width}px selection`);
+		assert.equal(result.hiddenAccessibleName, "Folder with hidden Nuvio title", `${result.width}px hidden-title name`);
+	}
+});
+
+test("mounted 100-plus Folder list uses native lazy/async images without workspace fetches", () => {
+	for (const result of mountedResults.widths) {
+		assert.equal(result.imageCount, 106, `${result.width}px image count`);
+		assert.equal(result.allImagesLazy, true, `${result.width}px lazy`);
+		assert.equal(result.allImagesAsync, true, `${result.width}px async`);
+		assert.equal(result.allImagesDecorative, true, `${result.width}px decorative`);
+		assert.equal(result.allImagesNonDraggable, true, `${result.width}px non-draggable`);
+	}
+});
+
+test("mounted pointer overlay and keyboard reorder mode retain the assigned thumbnail without data mutation", () => {
+	assert.deepEqual(mountedResults.dragOverlay, {
+		present: true,
+		ariaHidden: "true",
+		inert: true,
+		thumbnailPresent: true,
+		widthMatches: true,
+		heightMatches: true,
+		buttonsOutOfTabOrder: true,
+	});
+	assert.deepEqual(mountedResults.keyboardActive, { pressed: "true", thumbnailPresent: true });
+	assert.equal(mountedResults.keyboardAfter.pressed, "false");
+	assert.equal(mountedResults.keyboardAfter.projectUnchanged, true);
+	assert.equal(mountedResults.keyboardAfter.serializedUnchanged, true);
+	assert.equal(mountedResults.keyboardAfter.revisionUnchanged, true);
+});
+
+test("mounted arbitrary-origin artwork omits the Builder referrer and a failed URL cannot poison its replacement", () => {
+	assert.deepEqual(mountedResults.failureReplacement, {
+		initialUrl: mountedResults.failureReplacement.initialUrl,
+		initialFailureUsedTextFallback: true,
+		failureDidNotMutateProject: true,
+		failureDidNotMutateSerialization: true,
+		failureDidNotChangeRevision: true,
+		updateAccepted: true,
+		replacementUrl: mountedResults.failureReplacement.replacementUrl,
+		replacementAttempted: true,
+		replacementRendered: true,
+		replacementReferrerPolicy: "no-referrer",
+		reassignedOriginalUrl: mountedResults.failureReplacement.reassignedOriginalUrl,
+		reassignedOriginalAttempted: true,
+		reassignedOriginalRendered: true,
+		reassignedOriginalReferrerPolicy: "no-referrer",
+		folderCardRemainedMounted: true,
+	});
+	assert.match(mountedResults.failureReplacement.initialUrl, /^http:\/\/127\.0\.0\.1:\d+\/recovering\.gif$/);
+	assert.match(mountedResults.failureReplacement.replacementUrl, /^http:\/\/127\.0\.0\.1:\d+\/replacement\.gif$/);
+	assert.equal(mountedResults.failureReplacement.reassignedOriginalUrl, mountedResults.failureReplacement.initialUrl);
+
+	const hotlinkRequest = mountedResults.artworkRequests.find((request) => request.path === "/hotlink-sensitive.gif");
+	const replacementRequest = mountedResults.artworkRequests.find((request) => request.path === "/replacement.gif");
+	const recoveringRequests = mountedResults.artworkRequests.filter((request) => request.path === "/recovering.gif");
+	assert.deepEqual(hotlinkRequest, { path: "/hotlink-sensitive.gif", referer: null });
+	assert.deepEqual(replacementRequest, { path: "/replacement.gif", referer: null });
+	assert.deepEqual(recoveringRequests, [
+		{ path: "/recovering.gif", referer: null },
+		{ path: "/recovering.gif", referer: null },
+	]);
+});

--- a/tests/builder-folder-card-artwork.test.mjs
+++ b/tests/builder-folder-card-artwork.test.mjs
@@ -1,0 +1,190 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test, { after } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { createElement } from "../builder/node_modules/react/index.js";
+import { renderToStaticMarkup } from "../builder/node_modules/react-dom/server.js";
+import { createServer } from "../builder/node_modules/vite/dist/node/index.js";
+import { createBuilderController } from "../builder/src/application/index.js";
+import { buildBuilderViewModel } from "../builder/src/ui/view-model.js";
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const vite = await createServer({
+	root: path.join(rootDir, "builder"),
+	appType: "custom",
+	logLevel: "silent",
+	server: { middlewareMode: true },
+});
+const { BuilderWorkspace } = await vite.ssrLoadModule("/src/ui/BuilderWorkspace.jsx");
+after(() => vite.close());
+
+function countingIdFactory(prefix = "builder") {
+	let count = 0;
+	return () => `${prefix}-${++count}`;
+}
+
+function createController() {
+	return createBuilderController({
+		idFactory: countingIdFactory(),
+		nuvioIdFactory: countingIdFactory("nuvio"),
+		initialProjectTitle: "Folder artwork test",
+	});
+}
+
+function importArtworkFolders(controller) {
+	const result = controller.importValue([{
+		id: "collection",
+		title: "Artwork collection",
+		folders: [
+			{
+				id: "poster",
+				title: "Custom Poster",
+				tileShape: "POSTER",
+				coverImageUrl: "https://example.test/custom.webp",
+				sources: [],
+			},
+			{
+				id: "landscape",
+				title: "TMDB Landscape",
+				tileShape: "landscape",
+				coverImageUrl: "https://image.tmdb.org/t/p/w500/example.jpg",
+				sources: [],
+			},
+			{
+				id: "blank",
+				title: "Blank artwork",
+				tileShape: "POSTER",
+				coverImageUrl: "   ",
+				sources: [],
+			},
+			{
+				id: "absent",
+				title: "Absent artwork",
+				tileShape: "POSTER",
+				sources: [],
+			},
+			{
+				id: "null",
+				title: "Null artwork",
+				tileShape: "POSTER",
+				coverImageUrl: null,
+				sources: [],
+			},
+			{
+				id: "unsupported-shape",
+				title: "Unsupported shape",
+				tileShape: "SQUARE",
+				coverImageUrl: "https://example.test/unknown-shape.webp",
+				sources: [],
+			},
+			{
+				id: "hidden-title",
+				title: "\u200E",
+				tileShape: "POSTER",
+				coverImageUrl: "https://example.test/hidden.webp",
+				sources: [],
+			},
+		],
+	}]);
+	assert.equal(result.ok, true);
+	const collection = controller.getState().project.collections[0];
+	controller.selectNode(collection.internalId);
+	return collection;
+}
+
+function renderWorkspace(controller) {
+	return renderToStaticMarkup(createElement(BuilderWorkspace, {
+		controller,
+		state: controller.getState(),
+	}));
+}
+
+test("view model exposes only assigned Tile artwork and uses a neutral shape for preserved unsupported values", () => {
+	const controller = createController();
+	importArtworkFolders(controller);
+	const folders = buildBuilderViewModel(controller.getState()).folders;
+
+	assert.deepEqual(folders.map(({ title, tileArtworkUrl, tileArtworkShape }) => ({
+		title,
+		tileArtworkUrl,
+		tileArtworkShape,
+	})), [
+		{ title: "Custom Poster", tileArtworkUrl: "https://example.test/custom.webp", tileArtworkShape: "poster" },
+		{ title: "TMDB Landscape", tileArtworkUrl: "https://image.tmdb.org/t/p/w500/example.jpg", tileArtworkShape: "landscape" },
+		{ title: "Blank artwork", tileArtworkUrl: null, tileArtworkShape: null },
+		{ title: "Absent artwork", tileArtworkUrl: null, tileArtworkShape: null },
+		{ title: "Null artwork", tileArtworkUrl: null, tileArtworkShape: null },
+		{ title: "Unsupported shape", tileArtworkUrl: "https://example.test/unknown-shape.webp", tileArtworkShape: "unknown" },
+		{ title: "Hidden title", tileArtworkUrl: "https://example.test/hidden.webp", tileArtworkShape: "poster" },
+	]);
+});
+
+test("Folder cards render assigned custom and TMDB artwork without adding frames for missing artwork", () => {
+	const controller = createController();
+	const collection = importArtworkFolders(controller);
+	const stateBefore = JSON.stringify(controller.getState().project);
+	const revisionBefore = controller.getState().revision;
+	const markup = renderWorkspace(controller);
+
+	assert.equal((markup.match(/class="folder-card-thumbnail"/g) ?? []).length, 4);
+	assert.match(markup, /data-folder-card-artwork="poster"/);
+	assert.match(markup, /data-folder-card-artwork="landscape"/);
+	assert.match(markup, /data-folder-card-artwork="unknown"/);
+	assert.match(markup, /src="https:\/\/example\.test\/custom\.webp" alt="" width="34" height="50" loading="lazy" decoding="async" referrerPolicy="no-referrer" draggable="false"/);
+	assert.match(markup, /src="https:\/\/image\.tmdb\.org\/t\/p\/w500\/example\.jpg" alt="" width="60" height="34" loading="lazy" decoding="async" referrerPolicy="no-referrer" draggable="false"/);
+	assert.equal(markup.includes('src="   "'), false);
+	assert.equal(markup.includes("placeholder poster"), false);
+	assert.match(markup, /aria-label="Folder with hidden Nuvio title"/);
+	assert.match(markup, /data-card-layout="folder"><div class="hierarchy-card-main[^>]*>[\s\S]*?data-action="reorder-folder"[\s\S]*?<button class="node-button[\s\S]*?folder-card-thumbnail[\s\S]*?<div class="hierarchy-actions"/);
+
+	assert.equal(JSON.stringify(controller.getState().project), stateBefore);
+	assert.equal(controller.getState().revision, revisionBefore);
+	assert.equal(collection.folders[0].editable.coverImageUrl, "https://example.test/custom.webp");
+});
+
+test("import and workspace rendering preserve custom, TMDB, blank, absent, and null artwork states exactly", () => {
+	const controller = createController();
+	const collection = importArtworkFolders(controller);
+	const revisionBefore = controller.getState().revision;
+	const serializedBefore = controller.serializeProject().value;
+
+	renderWorkspace(controller);
+
+	const folders = collection.folders;
+	assert.equal(folders[0].editable.coverImageUrl, "https://example.test/custom.webp");
+	assert.equal(folders[1].editable.coverImageUrl, "https://image.tmdb.org/t/p/w500/example.jpg");
+	assert.equal(folders[2].editable.coverImageUrl, "   ");
+	assert.equal(Object.hasOwn(folders[3].editable, "coverImageUrl"), false);
+	assert.equal(folders[4].editable.coverImageUrl, null);
+	assert.deepEqual(controller.serializeProject().value, serializedBefore);
+	assert.equal(controller.getState().revision, revisionBefore);
+});
+
+test("selected and hidden-title Folder cards retain non-colour selection and accessible naming with artwork", () => {
+	const controller = createController();
+	const collection = importArtworkFolders(controller);
+	const hiddenFolder = collection.folders.at(-1);
+	controller.selectNode(hiddenFolder.internalId);
+	const markup = renderWorkspace(controller);
+
+	assert.match(markup, /class="hierarchy-card is-selected" data-hierarchy-card="folder"/);
+	assert.match(markup, /class="node-button is-selected"[^>]*data-node-type="folder" aria-pressed="true" aria-label="Folder with hidden Nuvio title"/);
+	assert.match(markup, /<img class="folder-card-thumbnail"[^>]*alt=""/);
+	assert.equal(markup.includes("\u200E"), false);
+});
+
+test("Folder thumbnail CSS reserves compact shape-aware dimensions and rebalances responsive workspace columns", () => {
+	const styles = fs.readFileSync(path.join(rootDir, "builder", "src", "styles.css"), "utf8");
+
+	assert.match(styles, /\.folder-card-thumbnail-frame\[data-folder-artwork-shape="poster"\]\s*\{[\s\S]*?width:\s*34px;[\s\S]*?height:\s*50px;/);
+	assert.match(styles, /\.folder-card-thumbnail-frame\[data-folder-artwork-shape="landscape"\]\s*\{[\s\S]*?width:\s*60px;[\s\S]*?height:\s*34px;/);
+	assert.match(styles, /\.folder-card-thumbnail-frame\[data-folder-artwork-shape="unknown"\][\s\S]*?width:\s*44px;[\s\S]*?height:\s*44px;/);
+	assert.match(styles, /\.folder-card-thumbnail\s*\{[\s\S]*?pointer-events:\s*none;[\s\S]*?object-fit:\s*cover;/);
+	assert.match(styles, /data-folder-artwork-shape="unknown"[^\{]*\.folder-card-thumbnail\s*\{[\s\S]*?object-fit:\s*contain;/);
+	assert.match(styles, /@media \(max-width: 1239px\)[\s\S]*?data-folder-artwork-shape="poster"[\s\S]*?width:\s*30px;[\s\S]*?height:\s*44px;[\s\S]*?data-folder-artwork-shape="landscape"[\s\S]*?width:\s*50px;[\s\S]*?height:\s*28px;/);
+	assert.match(styles, /@media \(min-width: 900px\)[\s\S]*?grid-template-columns:\s*minmax\(250px, 0\.9fr\) minmax\(310px, 1\.1fr\) minmax\(240px, 0\.95fr\)/);
+	assert.match(styles, /@media \(min-width: 1240px\)[\s\S]*?grid-template-columns:\s*minmax\(285px, 1\.05fr\) minmax\(330px, 1\.2fr\) minmax\(330px, 0\.95fr\)/);
+	assert.equal(styles.includes(".node-chevron"), false);
+});

--- a/tests/builder-hierarchy-deletion.test.mjs
+++ b/tests/builder-hierarchy-deletion.test.mjs
@@ -737,7 +737,7 @@ test("styles keep Add, actions menus, dialog, and responsive layouts touch-safe 
 	assert.match(styles, /@media \(max-width: 619px\)[\s\S]*\.delete-confirmation\s*\{[\s\S]*max-height:\s*calc\(100dvh - 24px\)/);
 	assert.match(
 		styles,
-		/@media \(min-width: 900px\)[\s\S]*\.workspace\s*\{[\s\S]*minmax\(265px,\s*0\.8fr\)[\s\S]*minmax\(270px,\s*1\.35fr\)[\s\S]*\.panel-header,[\s\S]*\.panel-body\s*\{[\s\S]*padding-right:\s*12px[\s\S]*padding-left:\s*12px/,
+		/@media \(min-width: 900px\)[\s\S]*\.workspace\s*\{[\s\S]*minmax\(250px,\s*0\.9fr\)[\s\S]*minmax\(310px,\s*1\.1fr\)[\s\S]*minmax\(240px,\s*0\.95fr\)[\s\S]*\.panel-header,[\s\S]*\.panel-body\s*\{[\s\S]*padding-right:\s*12px[\s\S]*padding-left:\s*12px/,
 	);
 	assert.match(
 		styles,

--- a/tests/builder-node-editing.test.mjs
+++ b/tests/builder-node-editing.test.mjs
@@ -2331,7 +2331,7 @@ test("styles keep card actions touch-safe and responsive while the modal stays b
 		/@media \(min-width: 620px\)[\s\S]*\.editor-compact-radio-grid\s*\{[\s\S]*grid-template-columns:\s*repeat\(3,\s*minmax\(0,\s*1fr\)\)/,
 	);
 	assert.match(styles, /@media \(min-width: 760px\)[\s\S]*\.node-editor-form\s*\{[\s\S]*max-width:\s*760px/);
-	assert.match(styles, /@media \(min-width: 900px\)[\s\S]*grid-template-columns:\s*minmax\(265px/);
+	assert.match(styles, /@media \(min-width: 900px\)[\s\S]*grid-template-columns:\s*minmax\(250px/);
 	assert.match(styles, /focus-visible/);
 	assert.match(styles, /@media \(prefers-reduced-motion: reduce\)/);
 	for (const mobileWidth of [360, 384, 393, 402, 412]) {

--- a/tests/builder-ui.test.mjs
+++ b/tests/builder-ui.test.mjs
@@ -676,7 +676,7 @@ test("styles provide mobile protection, touch sizing, focus, desktop panels, and
 	assert.match(styles, /min-height:\s*(?:46|48)px/);
 	assert.match(styles, /@media \(max-width: 430px\)/);
 	assert.match(styles, /@media \(min-width: 900px\)/);
-	assert.match(styles, /grid-template-columns:\s*minmax\(265px/);
+	assert.match(styles, /grid-template-columns:\s*minmax\(250px/);
 	assert.match(styles, /@media \(prefers-reduced-motion: reduce\)/);
 	assert.equal(BUILDER_DESKTOP_BREAKPOINT_PX, 900);
 	assert.equal(BUILDER_DESKTOP_MEDIA_QUERY, "(min-width: 900px)");

--- a/tests/fixtures/builder-folder-card-artwork-mounted.html
+++ b/tests/fixtures/builder-folder-card-artwork-mounted.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+	<title>Mounted Folder card artwork regression</title>
+</head>
+<body>
+	<div id="root"></div>
+	<script type="module" src="/tests/fixtures/builder-folder-card-artwork-mounted.jsx"></script>
+</body>
+</html>

--- a/tests/fixtures/builder-folder-card-artwork-mounted.jsx
+++ b/tests/fixtures/builder-folder-card-artwork-mounted.jsx
@@ -1,0 +1,273 @@
+import { act, createElement, useSyncExternalStore } from "react";
+import { createRoot } from "react-dom/client";
+import { createBuilderController } from "../../builder/src/application/index.js";
+import { BuilderWorkspace } from "../../builder/src/ui/BuilderWorkspace.jsx";
+import "../../builder/src/styles.css";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const DATA_ARTWORK = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==";
+const BROKEN_ARTWORK = "/tests/fixtures/missing-folder-card-artwork.webp";
+const ARTWORK_BASE_URL = new URL(window.location.href).searchParams.get("artworkBaseUrl");
+if (!ARTWORK_BASE_URL) throw new Error("Mounted Folder artwork fixture requires artworkBaseUrl.");
+const fetchCalls = [];
+const originalFetch = globalThis.fetch.bind(globalThis);
+globalThis.fetch = (...args) => {
+	fetchCalls.push(String(args[0]));
+	return originalFetch(...args);
+};
+
+function countingIdFactory(prefix = "mounted") {
+	let count = 0;
+	return () => `${prefix}-${++count}`;
+}
+
+const controller = createBuilderController({
+	idFactory: countingIdFactory(),
+	nuvioIdFactory: countingIdFactory("nuvio"),
+	initialProjectTitle: "Mounted Folder artwork",
+});
+
+const scaleFolders = Array.from({ length: 100 }, (_, index) => ({
+	id: `scale-${index + 1}`,
+	title: `Scale folder ${String(index + 1).padStart(3, "0")}`,
+	tileShape: index % 2 === 0 ? "POSTER" : "LANDSCAPE",
+	coverImageUrl: DATA_ARTWORK,
+	sources: [],
+}));
+
+const imported = controller.importValue([{
+	id: "collection",
+	title: "Artwork collection",
+	folders: [
+		{ id: "poster", title: "Poster artwork", tileShape: "POSTER", coverImageUrl: DATA_ARTWORK, sources: [] },
+		{ id: "landscape", title: "Landscape artwork", tileShape: "LANDSCAPE", coverImageUrl: DATA_ARTWORK, sources: [] },
+		{ id: "none", title: "No artwork", tileShape: "POSTER", sources: [] },
+		{ id: "blank", title: "Blank artwork", tileShape: "POSTER", coverImageUrl: "   ", sources: [] },
+		{ id: "broken", title: "Broken artwork", tileShape: "POSTER", coverImageUrl: BROKEN_ARTWORK, sources: [] },
+		{ id: "unknown", title: "Unsupported shape", tileShape: "SQUARE", coverImageUrl: DATA_ARTWORK, sources: [] },
+		{ id: "hidden", title: "\u200E", tileShape: "POSTER", coverImageUrl: DATA_ARTWORK, sources: [] },
+		{ id: "long", title: "A deliberately long Folder title that must remain readable beside assigned Landscape artwork", tileShape: "LANDSCAPE", coverImageUrl: DATA_ARTWORK, sources: [] },
+		{ id: "arbitrary-origin", title: "Arbitrary origin artwork", tileShape: "LANDSCAPE", coverImageUrl: `${ARTWORK_BASE_URL}/hotlink-sensitive.gif`, sources: [] },
+		{ id: "failure-replacement", title: "Failed artwork replacement", tileShape: "POSTER", coverImageUrl: `${ARTWORK_BASE_URL}/recovering.gif`, sources: [] },
+		...scaleFolders,
+	],
+}]);
+if (!imported.ok) throw new Error("Mounted Folder artwork fixture import failed.");
+
+const collection = controller.getState().project.collections[0];
+const foldersById = Object.fromEntries(collection.folders.map((folder) => [folder.editable.id, folder]));
+controller.selectNode(collection.internalId);
+const projectBefore = JSON.stringify(controller.getState().project);
+const serializedBefore = JSON.stringify(controller.serializeProject().value);
+const revisionBefore = controller.getState().revision;
+
+function MountedWorkspace() {
+	const state = useSyncExternalStore(
+		controller.subscribe,
+		controller.getState,
+		controller.getState,
+	);
+	return createElement(BuilderWorkspace, { controller, state });
+}
+
+function afterCommittedEffects() {
+	return new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+}
+
+async function waitForCondition(resolveCondition, timeoutMs = 3000) {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (resolveCondition()) return;
+		await new Promise((resolve) => setTimeout(resolve, 25));
+	}
+	throw new Error("Mounted Folder artwork condition timed out.");
+}
+
+function folderCard(title) {
+	return [...document.querySelectorAll('[data-hierarchy-card="folder"]')].find((card) => (
+		card.querySelector(".node-title")?.textContent.trim() === title
+	)) ?? null;
+}
+
+function roundedRect(element) {
+	const rect = element.getBoundingClientRect();
+	return {
+		width: Math.round(rect.width * 100) / 100,
+		height: Math.round(rect.height * 100) / 100,
+		left: Math.round(rect.left * 100) / 100,
+		right: Math.round(rect.right * 100) / 100,
+	};
+}
+
+async function selectCollection() {
+	controller.selectNode(collection.internalId);
+	await afterCommittedEffects();
+}
+
+async function measureLayout() {
+	await selectCollection();
+	const poster = folderCard("Poster artwork");
+	const landscape = folderCard("Landscape artwork");
+	const noArtwork = folderCard("No artwork");
+	const blank = folderCard("Blank artwork");
+	const broken = folderCard("Broken artwork");
+	const unknown = folderCard("Unsupported shape");
+	const hidden = folderCard("Hidden title");
+	const longTitle = folderCard("A deliberately long Folder title that must remain readable beside assigned Landscape artwork");
+	const posterImage = poster.querySelector("img");
+	const landscapeImage = landscape.querySelector("img");
+	const unknownImage = unknown.querySelector("img");
+	const allImages = [...document.querySelectorAll('[data-hierarchy-card="folder"] img.folder-card-thumbnail')];
+
+	controller.selectNode(foldersById.poster.internalId);
+	await afterCommittedEffects();
+	const selectedState = {
+		cardSelected: folderCard("Poster artwork").classList.contains("is-selected"),
+		buttonPressed: folderCard("Poster artwork").querySelector(".node-button")?.getAttribute("aria-pressed"),
+	};
+	await selectCollection();
+
+	const panelWidths = Object.fromEntries(["collections", "folders", "sources"].map((panel) => [
+		panel,
+		roundedRect(document.querySelector(`[data-panel="${panel}"]`)).width,
+	]));
+	const noArtworkHeight = roundedRect(noArtwork).height;
+	const artworkHeights = [poster, landscape, unknown].map((card) => roundedRect(card).height);
+	const folderPanel = document.querySelector('[data-panel="folders"]');
+
+	return {
+		width: window.innerWidth,
+		folderPanelVisible: getComputedStyle(folderPanel).display !== "none",
+		panelWidths,
+		poster: {
+			frame: roundedRect(poster.querySelector(".folder-card-thumbnail-frame")),
+			attributes: {
+				alt: posterImage.getAttribute("alt"),
+				loading: posterImage.getAttribute("loading"),
+				decoding: posterImage.getAttribute("decoding"),
+				referrerPolicy: posterImage.getAttribute("referrerpolicy"),
+				draggable: posterImage.getAttribute("draggable"),
+			},
+		},
+		landscape: { frame: roundedRect(landscape.querySelector(".folder-card-thumbnail-frame")) },
+		unknown: {
+			frame: roundedRect(unknown.querySelector(".folder-card-thumbnail-frame")),
+			objectFit: getComputedStyle(unknownImage).objectFit,
+		},
+		textFallbacks: {
+			noArtworkHasFrame: noArtwork.querySelector(".folder-card-thumbnail-frame") !== null,
+			blankHasFrame: blank.querySelector(".folder-card-thumbnail-frame") !== null,
+			brokenHasFrame: broken.querySelector(".folder-card-thumbnail-frame") !== null,
+			brokenTextDirect: broken.querySelector(":scope .node-button-content > .node-title")?.textContent.trim() === "Broken artwork",
+		},
+		selectedState,
+		hiddenAccessibleName: hidden.querySelector(".node-button")?.getAttribute("aria-label"),
+		imageCount: allImages.length,
+		allImagesLazy: allImages.every((image) => image.getAttribute("loading") === "lazy"),
+		allImagesAsync: allImages.every((image) => image.getAttribute("decoding") === "async"),
+		allImagesDecorative: allImages.every((image) => image.getAttribute("alt") === ""),
+		allImagesNonDraggable: allImages.every((image) => image.getAttribute("draggable") === "false"),
+		cardHeights: {
+			noArtwork: noArtworkHeight,
+			poster: roundedRect(poster).height,
+			landscape: roundedRect(landscape).height,
+			unknown: roundedRect(unknown).height,
+		},
+		cardHeightGrowth: Math.max(...artworkHeights) - noArtworkHeight,
+		longTitleHeight: roundedRect(longTitle).height,
+		longTitleWidth: roundedRect(longTitle.querySelector(".folder-card-copy")).width,
+		noHorizontalOverflow: document.documentElement.scrollWidth <= document.documentElement.clientWidth + 1,
+		projectUnchanged: JSON.stringify(controller.getState().project) === projectBefore,
+		serializedUnchanged: JSON.stringify(controller.serializeProject().value) === serializedBefore,
+		revisionUnchanged: controller.getState().revision === revisionBefore,
+		fetchCallCount: fetchCalls.length,
+	};
+}
+
+function preservationState() {
+	return {
+		brokenUrl: foldersById.broken.editable.coverImageUrl,
+		blankUrl: foldersById.blank.editable.coverImageUrl,
+		absentHasField: Object.hasOwn(foldersById.none.editable, "coverImageUrl"),
+		unsupportedShape: foldersById.unknown.editable.tileShape,
+		projectUnchanged: JSON.stringify(controller.getState().project) === projectBefore,
+		serializedUnchanged: JSON.stringify(controller.serializeProject().value) === serializedBefore,
+		revisionUnchanged: controller.getState().revision === revisionBefore,
+	};
+}
+
+async function exerciseFailureReplacement() {
+	await selectCollection();
+	const folder = foldersById["failure-replacement"];
+	const cardBefore = folderCard("Failed artwork replacement");
+	const initialProject = JSON.stringify(controller.getState().project);
+	const initialSerialized = JSON.stringify(controller.serializeProject().value);
+	const initialRevision = controller.getState().revision;
+	const initialUrl = folder.editable.coverImageUrl;
+	const initialFailureUsedTextFallback = cardBefore.querySelector(".folder-card-thumbnail-frame") === null;
+	const updateResult = controller.updateNode(folder.internalId, {
+		coverImageUrl: `${ARTWORK_BASE_URL}/replacement.gif`,
+	});
+	await afterCommittedEffects();
+	await waitForCondition(() => {
+		const image = folderCard("Failed artwork replacement")?.querySelector("img.folder-card-thumbnail");
+		return image?.complete === true && image.naturalWidth > 0;
+	});
+	const cardAfter = folderCard("Failed artwork replacement");
+	const replacementImage = cardAfter.querySelector("img.folder-card-thumbnail");
+	const replacementUrl = replacementImage.getAttribute("src");
+	const replacementAttempted = replacementImage.complete;
+	const replacementRendered = replacementImage.naturalWidth > 0;
+	const replacementReferrerPolicy = replacementImage.getAttribute("referrerpolicy");
+	const restoreResult = controller.updateNode(folder.internalId, { coverImageUrl: initialUrl });
+	await afterCommittedEffects();
+	await waitForCondition(() => {
+		const image = folderCard("Failed artwork replacement")?.querySelector("img.folder-card-thumbnail");
+		return image?.complete === true && image.naturalWidth > 0;
+	});
+	const restoredCard = folderCard("Failed artwork replacement");
+	const restoredImage = restoredCard.querySelector("img.folder-card-thumbnail");
+
+	return {
+		initialUrl,
+		initialFailureUsedTextFallback,
+		failureDidNotMutateProject: initialProject === projectBefore,
+		failureDidNotMutateSerialization: initialSerialized === serializedBefore,
+		failureDidNotChangeRevision: initialRevision === revisionBefore,
+		updateAccepted: updateResult.ok === true,
+		replacementUrl,
+		replacementAttempted,
+		replacementRendered,
+		replacementReferrerPolicy,
+		reassignedOriginalUrl: restoredImage.getAttribute("src"),
+		reassignedOriginalAttempted: restoreResult.ok === true && restoredImage.complete,
+		reassignedOriginalRendered: restoredImage.naturalWidth > 0,
+		reassignedOriginalReferrerPolicy: restoredImage.getAttribute("referrerpolicy"),
+		folderCardRemainedMounted: cardAfter === cardBefore && restoredCard === cardBefore,
+	};
+}
+
+const root = createRoot(document.getElementById("root"));
+window.__builderFolderArtworkMounted = { status: "running" };
+act(() => root.render(createElement(MountedWorkspace)));
+
+afterCommittedEffects().then(async () => {
+	await waitForCondition(() => (
+		document.querySelectorAll('[data-hierarchy-card="folder"]').length === 110
+		&& folderCard("Poster artwork")?.querySelector("img")?.complete === true
+		&& folderCard("Landscape artwork")?.querySelector("img")?.complete === true
+		&& folderCard("Arbitrary origin artwork")?.querySelector("img")?.naturalWidth > 0
+		&& folderCard("Broken artwork")?.querySelector("img") === null
+		&& folderCard("Failed artwork replacement")?.querySelector("img") === null
+	));
+	window.__measureFolderArtworkLayout = measureLayout;
+	window.__folderArtworkPreservationState = preservationState;
+	window.__exerciseFolderArtworkFailureReplacement = exerciseFailureReplacement;
+	window.__builderFolderArtworkMounted = { status: "complete" };
+}).catch((error) => {
+	window.__builderFolderArtworkMounted = {
+		status: "error",
+		message: error instanceof Error ? `${error.message}\n${error.stack ?? ""}` : String(error),
+	};
+});


### PR DESCRIPTION
## Summary

- Displays each Folder's actually assigned `coverImageUrl` in the Builder workspace.
- Supports compact Poster, Landscape, and legacy/unknown thumbnail presentation.
- Preserves text-only cards when no artwork is assigned.
- Gracefully falls back when assigned artwork fails to render without mutating project data.
- Uses no-referrer image requests to support arbitrary assigned artwork origins.
- Widens Collections/Folders, narrows Sources, and removes redundant card chevrons as owner-approved workspace adjustments.

## Preservation

- Import preserves exact assigned artwork.
- Missing imported artwork remains missing.
- Workspace rendering performs no artwork discovery or assignment.
- Assigned TMDB, custom, and curated URLs are treated equally because they are already part of the project.

## Validation

- Owner review and final scope audit passed.
- Focused #134 Folder-card tests passed (11/11).
- Import/migration/preservation tests passed (96/96).
- Affected hierarchy, reorder, and node-edit tests passed (140/140).
- Mounted production-path suite passed (29/29), including all six focused mounted Folder-artwork cases.
- Production Builder build passed.
- `./scripts/check.cmd` and `git diff --check` passed locally.
- Push-triggered Nuvio Contract Validation passed for `8893267e26b91c36b31b43655e88b32065435642`: https://github.com/davecollections/tmdb-id-lookup/actions/runs/32541191016
- Generic no-referrer behavior corrected hosts that reject Builder referrers, including the reviewed DreamWorks/Imgur case; no hostname-specific workaround was introduced.

## Deferred

This PR does not include:

- Folder Settings previews.
- Curated artwork suggestions.
- Collection backdrop support.
- Bulk editing.
- Source Edit artwork cleanup.
- Artwork-assignment redesign.
- Worker or V1 work.

Closes #134