### PR TITLE
Harden mounted-browser Chrome startup in CI

### DIFF
--- a/.github/workflows/nuvio-contract-validation.yml
+++ b/.github/workflows/nuvio-contract-validation.yml
@@ -27,6 +27,8 @@ jobs:
         run: npm ci --prefix builder
 
       - name: Run frontend and Nuvio contract checks
+        env:
+          DEVTOOLS_STARTUP_MS: "30000"
         run: node scripts/check-all.mjs
 
       - name: Build builder

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -16,6 +16,8 @@ Mounted-browser suites register their tests during module loading and start one 
 
 Chrome owns DevTools port selection. Launch it with `--remote-debugging-port=0` and read the fresh profile's `DevToolsActivePort` file; do not reserve and release a port before launch. Browser and page WebSocket opens, fixture execution, cooperative shutdown, and forced shutdown must all remain bounded.
 
+Mounted Chrome startup allows 10,000 ms by default. `DEVTOOLS_STARTUP_MS` may provide a positive integer millisecond override; an unset or blank value keeps the default, surrounding whitespace is ignored, and zero, negative, fractional, malformed, or unsafe integer values fail clearly. Nuvio Contract Validation sets the override to 30,000 ms for GitHub-hosted CI. Exceeding the allowance remains a test failure with bounded process, profile-directory, and Chrome-stderr diagnostics; mounted browser checks are not skipped or converted to success when Chrome starts slowly or cannot become ready.
+
 The normal ownership path is:
 
 1. request `Browser.close` through the browser-level DevTools connection;

--- a/tests/builder-folder-card-artwork-mounted.test.mjs
+++ b/tests/builder-folder-card-artwork-mounted.test.mjs
@@ -14,7 +14,9 @@ import { extractTmdbProxyBaseUrl } from "../builder/build-config.js";
 import {
 	cleanupMountedBrowser,
 	connectDevTools,
+	createBoundedStderrCapture,
 	createBrowserProcessTree,
+	resolveDevToolsStartupTimeout,
 	runWithLifecycleCleanup,
 	waitForDevToolsEndpoint,
 } from "./helpers/mounted-browser-lifecycle.mjs";
@@ -68,11 +70,13 @@ async function evaluate(connection, expression) {
 }
 
 async function runMountedPage() {
+	const devToolsStartupMs = resolveDevToolsStartupTimeout(process.env.DEVTOOLS_STARTUP_MS);
 	const resources = {
 		artworkRequests: [],
 		artworkServer: null,
 		browserExecutable: null,
 		browserProcess: null,
+		browserStderrCapture: null,
 		browserConnection: null,
 		debugPort: null,
 		pageConnection: null,
@@ -177,6 +181,7 @@ async function runMountedPage() {
 			"--headless=new",
 			"--disable-background-networking",
 			"--disable-component-update",
+			"--disable-dev-shm-usage",
 			"--disable-gpu",
 			"--hide-scrollbars",
 			"--no-first-run",
@@ -187,19 +192,35 @@ async function runMountedPage() {
 			"about:blank",
 		], {
 			detached: process.platform !== "win32",
-			stdio: "ignore",
+			stdio: ["ignore", "ignore", "pipe"],
 			windowsHide: true,
 		});
-		await new Promise((resolve, reject) => {
-			resources.browserProcess.once("spawn", resolve);
-			resources.browserProcess.once("error", reject);
-		});
+		resources.browserStderrCapture = createBoundedStderrCapture(resources.browserProcess.stderr);
+		try {
+			await new Promise((resolve, reject) => {
+				resources.browserProcess.once("spawn", resolve);
+				resources.browserProcess.once("error", reject);
+			});
+		} catch (error) {
+			resources.browserStderrCapture.stop();
+			resources.browserStderrCapture = null;
+			throw error;
+		}
 		resources.processTree = createBrowserProcessTree({ rootPid: resources.browserProcess.pid });
 
-		const endpoint = await waitForDevToolsEndpoint({
-			profileDir: resources.profileDir,
-			browserProcess: resources.browserProcess,
-		});
+		let endpoint;
+		try {
+			endpoint = await waitForDevToolsEndpoint({
+				profileDir: resources.profileDir,
+				browserProcess: resources.browserProcess,
+				browserExecutable: resources.browserExecutable,
+				stderrCapture: resources.browserStderrCapture,
+				timeoutMs: devToolsStartupMs,
+			});
+		} finally {
+			resources.browserStderrCapture.stop();
+			resources.browserStderrCapture = null;
+		}
 		resources.debugPort = endpoint.port;
 		resources.browserConnection = await connectDevTools(endpoint.browserWebSocketUrl);
 		const targets = await waitForJson(`http://127.0.0.1:${endpoint.port}/json/list`);

--- a/tests/builder-source-edit-mounted.test.mjs
+++ b/tests/builder-source-edit-mounted.test.mjs
@@ -13,7 +13,9 @@ import { extractTmdbProxyBaseUrl } from "../builder/build-config.js";
 import {
 	cleanupMountedBrowser,
 	connectDevTools,
+	createBoundedStderrCapture,
 	createBrowserProcessTree,
+	resolveDevToolsStartupTimeout,
 	runWithLifecycleCleanup,
 	waitForDevToolsEndpoint,
 } from "./helpers/mounted-browser-lifecycle.mjs";
@@ -60,9 +62,11 @@ async function waitForJson(url, timeoutMs = 10000) {
 }
 
 async function runMountedPage() {
+	const devToolsStartupMs = resolveDevToolsStartupTimeout(process.env.DEVTOOLS_STARTUP_MS);
 	const resources = {
 		browserExecutable: null,
 		browserProcess: null,
+		browserStderrCapture: null,
 		browserConnection: null,
 		debugPort: null,
 		pageConnection: null,
@@ -104,6 +108,7 @@ async function runMountedPage() {
 			"--headless=new",
 			"--disable-background-networking",
 			"--disable-component-update",
+			"--disable-dev-shm-usage",
 			"--disable-gpu",
 			"--no-first-run",
 			"--no-sandbox",
@@ -113,31 +118,47 @@ async function runMountedPage() {
 			"about:blank",
 		], {
 			detached: process.platform !== "win32",
-			stdio: "ignore",
+			stdio: ["ignore", "ignore", "pipe"],
 			windowsHide: true,
 		});
-		await new Promise((resolve, reject) => {
-			const cleanup = () => {
-				resources.browserProcess.removeListener("spawn", onSpawn);
-				resources.browserProcess.removeListener("error", onError);
-			};
-			const onSpawn = () => {
-				cleanup();
-				resolve();
-			};
-			const onError = (error) => {
-				cleanup();
-				reject(error);
-			};
-			resources.browserProcess.once("spawn", onSpawn);
-			resources.browserProcess.once("error", onError);
-		});
+		resources.browserStderrCapture = createBoundedStderrCapture(resources.browserProcess.stderr);
+		try {
+			await new Promise((resolve, reject) => {
+				const cleanup = () => {
+					resources.browserProcess.removeListener("spawn", onSpawn);
+					resources.browserProcess.removeListener("error", onError);
+				};
+				const onSpawn = () => {
+					cleanup();
+					resolve();
+				};
+				const onError = (error) => {
+					cleanup();
+					reject(error);
+				};
+				resources.browserProcess.once("spawn", onSpawn);
+				resources.browserProcess.once("error", onError);
+			});
+		} catch (error) {
+			resources.browserStderrCapture.stop();
+			resources.browserStderrCapture = null;
+			throw error;
+		}
 		resources.processTree = createBrowserProcessTree({ rootPid: resources.browserProcess.pid });
 
-		const endpoint = await waitForDevToolsEndpoint({
-			profileDir: resources.profileDir,
-			browserProcess: resources.browserProcess,
-		});
+		let endpoint;
+		try {
+			endpoint = await waitForDevToolsEndpoint({
+				profileDir: resources.profileDir,
+				browserProcess: resources.browserProcess,
+				browserExecutable: resources.browserExecutable,
+				stderrCapture: resources.browserStderrCapture,
+				timeoutMs: devToolsStartupMs,
+			});
+		} finally {
+			resources.browserStderrCapture.stop();
+			resources.browserStderrCapture = null;
+		}
 		resources.debugPort = endpoint.port;
 		resources.browserConnection = await connectDevTools(endpoint.browserWebSocketUrl);
 		const targets = await waitForJson(`http://127.0.0.1:${endpoint.port}/json/list`);

--- a/tests/fixtures/builder-source-edit-mounted.jsx
+++ b/tests/fixtures/builder-source-edit-mounted.jsx
@@ -182,14 +182,16 @@ async function waitForReadyPosterGrid({
 	preview,
 	gridSelector,
 	expectedVisibleCount,
+	expectedSelectedTab = null,
 	label,
 	timeoutMs = 20_000,
 }) {
-	let diagnostic = { preview: false, grid: false, expectedVisibleCount, images: [] };
+	let diagnostic = { preview: false, grid: false, expectedVisibleCount, expectedSelectedTab, images: [] };
 	try {
 		return await waitForMountedCondition(() => {
 			const previewElement = typeof preview === "string" ? document.querySelector(preview) : preview;
 			const grid = previewElement?.querySelector(gridSelector) ?? null;
+			const selectedTab = previewElement?.querySelector('[role="tab"][aria-selected="true"]') ?? null;
 			const images = grid ? [...grid.querySelectorAll(":scope > img")] : [];
 			const visibleImages = images.filter(visibleElement);
 			diagnostic = {
@@ -197,6 +199,8 @@ async function waitForReadyPosterGrid({
 				previewStatus: previewElement?.dataset.previewStatus ?? "not-exposed",
 				grid: Boolean(grid),
 				expectedVisibleCount,
+				expectedSelectedTab,
+				selectedTab: selectedTab?.textContent.trim() ?? null,
 				visibleCount: visibleImages.length,
 				images: images.map((image) => {
 					const rect = image.getBoundingClientRect();
@@ -214,8 +218,9 @@ async function waitForReadyPosterGrid({
 			const previewReady = previewElement?.dataset.previewStatus === undefined
 				|| previewElement.dataset.previewStatus === "ready";
 			if (!previewReady || !grid || visibleImages.length !== expectedVisibleCount) return null;
+			if (expectedSelectedTab !== null && selectedTab?.textContent.trim() !== expectedSelectedTab) return null;
 			if (visibleImages.some((image) => !image.complete || image.naturalWidth <= 0 || image.naturalHeight <= 0)) return null;
-			return { grid, images, visibleImages };
+			return { preview: previewElement, grid, images, visibleImages };
 		}, { label, timeoutMs });
 	} catch (error) {
 		throw new Error(`${error.message} Poster readiness: ${JSON.stringify(diagnostic)}`);
@@ -3283,15 +3288,16 @@ async function runPeopleConfigureLayoutScenario() {
 		const previewTrigger = firstRow.querySelector(".people-bulk-actions button:first-child");
 		const requestsBeforePreview = requests.length;
 		await clickAndSettle(required(previewTrigger, "first Preview titles action"));
-		let preview = document.querySelector(".people-title-preview");
-		let previewGrid = preview.querySelector(".people-title-preview-grid");
 		const expectedPosterCount = window.innerWidth <= 520 ? 5 : 10;
 		const readyMoviePosters = await waitForReadyPosterGrid({
-			preview,
+			preview: ".people-title-preview",
 			gridSelector: ".people-title-preview-grid",
 			expectedVisibleCount: expectedPosterCount,
+			expectedSelectedTab: "Movies",
 			label: `Live People Movies Preview at ${window.innerWidth}px`,
 		});
+		let preview = readyMoviePosters.preview;
+		let previewGrid = readyMoviePosters.grid;
 		const previewBackdrop = preview.closest(".nested-modal-backdrop");
 		const creationPortal = document.querySelector(".add-source-portal");
 		const previewTabs = required(preview.querySelector(".people-preview-tabs"), "People Preview media tabs");
@@ -3300,18 +3306,22 @@ async function runPeopleConfigureLayoutScenario() {
 		const moviesInitiallyActive = movieTab.getAttribute("aria-selected") === "true" && seriesTab.getAttribute("aria-selected") === "false";
 		const moviePosterCount = readyMoviePosters.visibleImages.length;
 		await clickAndSettle(seriesTab);
-		preview = document.querySelector(".people-title-preview");
-		previewGrid = preview.querySelector(".people-title-preview-grid");
 		const readySeriesPosters = await waitForReadyPosterGrid({
-			preview,
+			preview: ".people-title-preview",
 			gridSelector: ".people-title-preview-grid",
 			expectedVisibleCount: expectedPosterCount,
+			expectedSelectedTab: "Series",
 			label: `Live People Series Preview at ${window.innerWidth}px`,
 		});
+		preview = readySeriesPosters.preview;
+		previewGrid = readySeriesPosters.grid;
+		const seriesPreviewTabs = required(preview.querySelector(".people-preview-tabs"), "current People Preview media tabs");
+		const seriesMovieTab = required(buttonContaining(seriesPreviewTabs, "Movies"), "current People Movies Preview tab");
+		const currentSeriesTab = required(buttonContaining(seriesPreviewTabs, "Series"), "current People Series Preview tab");
 		const mediaSeparation = {
-			tabCount: previewTabs.querySelectorAll('[role="tab"]').length,
+			tabCount: seriesPreviewTabs.querySelectorAll('[role="tab"]').length,
 			moviesInitiallyActive,
-			seriesActive: movieTab.getAttribute("aria-selected") === "false" && seriesTab.getAttribute("aria-selected") === "true",
+			seriesActive: seriesMovieTab.getAttribute("aria-selected") === "false" && currentSeriesTab.getAttribute("aria-selected") === "true",
 			moviePosterCount,
 			seriesPosterCount: readySeriesPosters.visibleImages.length,
 			seriesCount: /Series · [\d,]+/.test(preview.textContent),
@@ -3320,15 +3330,16 @@ async function runPeopleConfigureLayoutScenario() {
 			noCombinedTotal: !preview.textContent.includes("Movies + Series") && !preview.textContent.includes("Combined"),
 			noAdditionalRequests: requests.length === requestsBeforePreview,
 		};
-		await clickAndSettle(movieTab);
-		preview = document.querySelector(".people-title-preview");
-		previewGrid = preview.querySelector(".people-title-preview-grid");
+		await clickAndSettle(seriesMovieTab);
 		const restoredMoviePosters = await waitForReadyPosterGrid({
-			preview,
+			preview: ".people-title-preview",
 			gridSelector: ".people-title-preview-grid",
 			expectedVisibleCount: expectedPosterCount,
+			expectedSelectedTab: "Movies",
 			label: `Restored live People Movies Preview at ${window.innerWidth}px`,
 		});
+		preview = restoredMoviePosters.preview;
+		previewGrid = restoredMoviePosters.grid;
 		const previewState = {
 			modalSurface: preview.dataset.previewSurface === "modal" && preview.getAttribute("role") === "dialog" && preview.getAttribute("aria-modal") === "true",
 			outsidePeopleRow: preview.closest(".people-bulk-row") === null,
@@ -3350,7 +3361,11 @@ async function runPeopleConfigureLayoutScenario() {
 		previewState.escapeClosed = document.querySelector(".people-title-preview") === null;
 		previewState.escapeRestoredFocus = document.activeElement === previewTrigger;
 		await clickAndSettle(required(previewTrigger, "reopened Preview titles action"));
-		preview = document.querySelector(".people-title-preview");
+		preview = await waitForMountedCondition(() => {
+			const candidate = document.querySelector(".people-title-preview");
+			if (!candidate) return null;
+			return buttonContaining(candidate, "Close") ? candidate : null;
+		}, { label: `Reopened People Preview at ${window.innerWidth}px`, timeoutMs: 20_000 });
 		await clickAndSettle(required(buttonContaining(preview, "Close"), "preview Close action"));
 		previewState.closeRestoredFocus = document.activeElement === previewTrigger;
 

--- a/tests/helpers/mounted-browser-lifecycle.mjs
+++ b/tests/helpers/mounted-browser-lifecycle.mjs
@@ -15,6 +15,8 @@ export const TRANSIENT_REMOVE_CODES = Object.freeze([
 
 export const DEFAULT_REMOVE_RETRY_DELAYS_MS = Object.freeze([25, 50, 100, 200]);
 export const DEFAULT_DEVTOOLS_STARTUP_MS = 10000;
+export const DEFAULT_CHROME_STDERR_MAX_BYTES = 8 * 1024;
+export const DEFAULT_PROFILE_DIAGNOSTIC_ENTRY_LIMIT = 50;
 export const DEFAULT_DEVTOOLS_CONNECTION_MS = 5000;
 export const DEFAULT_DEVTOOLS_COMMAND_MS = 5000;
 export const DEFAULT_GRACEFUL_SHUTDOWN_MS = 5000;
@@ -22,6 +24,106 @@ export const DEFAULT_FALLBACK_SHUTDOWN_MS = 3000;
 
 function asError(value) {
 	return value instanceof Error ? value : new Error(String(value));
+}
+
+function boundedDiagnosticText(value, maxLength = 300) {
+	const text = String(value);
+	return text.length <= maxLength ? text : `${text.slice(0, maxLength - 1)}…`;
+}
+
+export function resolveDevToolsStartupTimeout(value) {
+	if (value === undefined || value === null) return DEFAULT_DEVTOOLS_STARTUP_MS;
+	if (typeof value !== "string") {
+		throw new TypeError("DEVTOOLS_STARTUP_MS must be a positive integer in milliseconds.");
+	}
+	const normalized = value.trim();
+	if (normalized === "") return DEFAULT_DEVTOOLS_STARTUP_MS;
+	if (!/^\d+$/u.test(normalized)) {
+		throw new TypeError(
+			`DEVTOOLS_STARTUP_MS must be a positive integer in milliseconds; received ${JSON.stringify(value)}.`,
+		);
+	}
+	const timeoutMs = Number(normalized);
+	if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0) {
+		throw new TypeError(
+			`DEVTOOLS_STARTUP_MS must be a positive integer in milliseconds; received ${JSON.stringify(value)}.`,
+		);
+	}
+	return timeoutMs;
+}
+
+export function createBoundedStderrCapture(
+	stream,
+	{ maxBytes = DEFAULT_CHROME_STDERR_MAX_BYTES } = {},
+) {
+	if (!Number.isInteger(maxBytes) || maxBytes <= 0) {
+		throw new TypeError("A positive integer Chrome stderr byte limit is required.");
+	}
+
+	let tail = Buffer.alloc(0);
+	let captureError = null;
+	let attached = false;
+	let capturing = false;
+	const onData = (chunk) => {
+		try {
+			const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk));
+			const boundedChunk = buffer.length > maxBytes
+				? buffer.subarray(buffer.length - maxBytes)
+				: buffer;
+			const keepFromTail = Math.max(0, maxBytes - boundedChunk.length);
+			const retainedTail = tail.length > keepFromTail
+				? tail.subarray(tail.length - keepFromTail)
+				: tail;
+			tail = Buffer.concat([retainedTail, boundedChunk]);
+		} catch (error) {
+			captureError = asError(error);
+			stop();
+		}
+	};
+	const onError = (error) => {
+		captureError = asError(error);
+	};
+
+	function stop() {
+		if (!capturing) return;
+		capturing = false;
+		stream.removeListener("data", onData);
+	}
+
+	function detach() {
+		stop();
+		if (!attached) return;
+		attached = false;
+		stream.removeListener("error", onError);
+		stream.removeListener("end", detach);
+		stream.removeListener("close", detach);
+	}
+
+	if (
+		stream &&
+		typeof stream.on === "function" &&
+		typeof stream.once === "function" &&
+		typeof stream.removeListener === "function"
+	) {
+		attached = true;
+		capturing = true;
+		stream.on("data", onData);
+		stream.on("error", onError);
+		stream.once("end", detach);
+		stream.once("close", detach);
+		try {
+			stream.unref?.();
+		} catch {
+			// Capturing remains bounded even when the stream cannot be unreferenced.
+		}
+	}
+
+	return Object.freeze({
+		byteLength: () => tail.length,
+		error: () => captureError,
+		text: () => tail.toString("utf8"),
+		stop,
+	});
 }
 
 function abortError() {
@@ -46,6 +148,51 @@ function browserProcessStatus(browserProcess) {
 function browserProcessExited(browserProcess) {
 	return Boolean(browserProcess) &&
 		(browserProcess.exitCode !== null || browserProcess.signalCode !== null);
+}
+
+function chromeStderrDiagnostic(stderrCapture) {
+	try {
+		const captureError = stderrCapture?.error?.();
+		if (captureError) {
+			return `chromeStderr=<capture unavailable: ${boundedDiagnosticText(asError(captureError).message)}>`;
+		}
+		const stderrText = stderrCapture?.text?.() ?? "";
+		return `chromeStderr=${JSON.stringify(stderrText || "<none captured>")}`;
+	} catch (error) {
+		return `chromeStderr=<capture unavailable: ${boundedDiagnosticText(asError(error).message)}>`;
+	}
+}
+
+function chromeLaunchDiagnostic(browserExecutable, stderrCapture) {
+	return [
+		`executable=${JSON.stringify(browserExecutable ?? "unknown")}`,
+		chromeStderrDiagnostic(stderrCapture),
+	].join("; ");
+}
+
+function profileEntryName(entry) {
+	const name = typeof entry === "string" ? entry : entry?.name;
+	if (typeof name !== "string") return "<unnamed entry>";
+	const suffix = typeof entry?.isDirectory === "function" && entry.isDirectory() ? "/" : "";
+	return boundedDiagnosticText(`${name}${suffix}`, 120);
+}
+
+async function chromeProfileDiagnostic(profileDir, fsApi) {
+	try {
+		const entries = (await fsApi.readdir(profileDir, { withFileTypes: true }))
+			.map(profileEntryName)
+			.sort();
+		const visibleEntries = entries.slice(0, DEFAULT_PROFILE_DIAGNOSTIC_ENTRY_LIMIT);
+		const omittedCount = entries.length - visibleEntries.length;
+		return [
+			`profileEntries=${JSON.stringify(visibleEntries)}`,
+			omittedCount > 0 ? `profileEntriesOmitted=${omittedCount}` : null,
+		].filter(Boolean).join("; ");
+	} catch (error) {
+		if (error?.code === "ENOENT") return "profileEntries=<profile directory absent>";
+		const code = typeof error?.code === "string" ? `${error.code}: ` : "";
+		return `profileEntries=<unavailable: ${code}${boundedDiagnosticText(asError(error).message)}>`;
+	}
 }
 
 export function abortableDelay(
@@ -133,6 +280,8 @@ export async function withDeadline(
 export async function waitForDevToolsEndpoint({
 	profileDir,
 	browserProcess,
+	browserExecutable,
+	stderrCapture,
 	timeoutMs = DEFAULT_DEVTOOLS_STARTUP_MS,
 	pollIntervalMs = 50,
 	fsApi = fs,
@@ -154,7 +303,8 @@ export async function waitForDevToolsEndpoint({
 	while (now() < deadlineAt) {
 		if (browserProcessExited(browserProcess)) {
 			throw new Error(
-				`Chrome exited before publishing its DevTools endpoint (${browserProcessStatus(browserProcess)}).`,
+				`Chrome exited before publishing its DevTools endpoint ` +
+				`(${browserProcessStatus(browserProcess)}; ${chromeLaunchDiagnostic(browserExecutable, stderrCapture)}).`,
 			);
 		}
 
@@ -187,12 +337,15 @@ export async function waitForDevToolsEndpoint({
 
 	if (browserProcessExited(browserProcess)) {
 		throw new Error(
-			`Chrome exited before publishing its DevTools endpoint (${browserProcessStatus(browserProcess)}).`,
+			`Chrome exited before publishing its DevTools endpoint ` +
+			`(${browserProcessStatus(browserProcess)}; ${chromeLaunchDiagnostic(browserExecutable, stderrCapture)}).`,
 		);
 	}
+	const profileDiagnostic = await chromeProfileDiagnostic(profileDir, fsApi);
 	throw new Error(
 		`Chrome did not publish a valid DevTools endpoint within ${timeoutMs} ms ` +
-		`(${browserProcessStatus(browserProcess)}; lastState=${lastProblem}).`,
+		`(${browserProcessStatus(browserProcess)}; lastState=${lastProblem}; ` +
+		`${chromeLaunchDiagnostic(browserExecutable, stderrCapture)}; ${profileDiagnostic}).`,
 	);
 }
 

--- a/tests/mounted-browser-lifecycle.test.mjs
+++ b/tests/mounted-browser-lifecycle.test.mjs
@@ -7,6 +7,8 @@ import { promisify } from "node:util";
 
 import {
 	BrowserShutdownError,
+	DEFAULT_CHROME_STDERR_MAX_BYTES,
+	DEFAULT_DEVTOOLS_STARTUP_MS,
 	DEFAULT_REMOVE_RETRY_DELAYS_MS,
 	MountedCleanupAfterSuccessError,
 	MountedLifecycleError,
@@ -15,8 +17,10 @@ import {
 	abortableDelay,
 	cleanupMountedBrowser,
 	connectDevTools,
+	createBoundedStderrCapture,
 	createBrowserProcessTree,
 	removeDirectoryWithRetry,
+	resolveDevToolsStartupTimeout,
 	runWithLifecycleCleanup,
 	shutdownBrowser,
 	waitForChildExit,
@@ -99,6 +103,89 @@ function trackedTimers() {
 	};
 }
 
+test("DevTools startup timeout defaults for unset or blank configuration", () => {
+	assert.equal(resolveDevToolsStartupTimeout(undefined), DEFAULT_DEVTOOLS_STARTUP_MS);
+	assert.equal(resolveDevToolsStartupTimeout(null), DEFAULT_DEVTOOLS_STARTUP_MS);
+	assert.equal(resolveDevToolsStartupTimeout(""), DEFAULT_DEVTOOLS_STARTUP_MS);
+	assert.equal(resolveDevToolsStartupTimeout(" \t "), DEFAULT_DEVTOOLS_STARTUP_MS);
+});
+
+test("DevTools startup timeout accepts validated positive integer overrides", () => {
+	assert.equal(resolveDevToolsStartupTimeout("30000"), 30000);
+	assert.equal(resolveDevToolsStartupTimeout("2500"), 2500);
+	assert.equal(resolveDevToolsStartupTimeout("030000"), 30000);
+	assert.equal(resolveDevToolsStartupTimeout(" 30000 "), 30000);
+});
+
+test("DevTools startup timeout rejects ambiguous or invalid configuration", () => {
+	for (const value of ["0", "-1", "1.5", "NaN", "30000oops", "1e3", "9007199254740992"]) {
+		assert.throws(
+			() => resolveDevToolsStartupTimeout(value),
+			/DEVTOOLS_STARTUP_MS must be a .*positive integer in milliseconds/u,
+		);
+	}
+	assert.throws(
+		() => resolveDevToolsStartupTimeout(30000),
+		/DEVTOOLS_STARTUP_MS must be a positive integer in milliseconds/u,
+	);
+});
+
+test("bounded Chrome stderr capture is quiet when no stderr is available", () => {
+	const capture = createBoundedStderrCapture(null);
+	assert.equal(capture.byteLength(), 0);
+	assert.equal(capture.text(), "");
+	capture.stop();
+});
+
+test("bounded Chrome stderr capture retains small string and Buffer chunks", () => {
+	const stream = new EventEmitter();
+	const capture = createBoundedStderrCapture(stream);
+	stream.emit("data", "first line\n");
+	stream.emit("data", Buffer.from("second line\n"));
+	assert.equal(capture.text(), "first line\nsecond line\n");
+	assert.equal(capture.byteLength(), Buffer.byteLength(capture.text()));
+	capture.stop();
+});
+
+test("bounded Chrome stderr capture retains only the configured tail across many chunks", () => {
+	const stream = new EventEmitter();
+	const capture = createBoundedStderrCapture(stream, { maxBytes: 8 });
+	for (const chunk of ["abc", Buffer.from("defg"), "hijklmnop", "qrst"]) stream.emit("data", chunk);
+	assert.equal(capture.text(), "mnopqrst");
+	assert.equal(capture.byteLength(), 8);
+	assert.ok(capture.byteLength() <= DEFAULT_CHROME_STDERR_MAX_BYTES);
+	capture.stop();
+});
+
+test("bounded Chrome stderr capture releases listeners when the stream ends", () => {
+	const stream = new EventEmitter();
+	let unrefCalls = 0;
+	stream.unref = () => { unrefCalls += 1; };
+	const capture = createBoundedStderrCapture(stream);
+	assert.equal(unrefCalls, 1);
+	stream.emit("end");
+	for (const event of ["data", "error", "end", "close"]) assert.equal(stream.listenerCount(event), 0);
+	capture.stop();
+});
+
+test("successful DevTools readiness does not inspect or emit captured stderr", async () => {
+	let stderrReads = 0;
+	const endpoint = await waitForDevToolsEndpoint({
+		profileDir: "test-profile",
+		browserProcess: fakeChild(320),
+		fsApi: { readFile: async () => "45123\n/devtools/browser/test-browser\n" },
+		stderrCapture: {
+			error: () => null,
+			text: () => {
+				stderrReads += 1;
+				return "successful startup warning";
+			},
+		},
+	});
+	assert.equal(endpoint.port, 45123);
+	assert.equal(stderrReads, 0);
+});
+
 test("DevToolsActivePort readiness tolerates absent and partial writes before returning Chrome's endpoint", async () => {
 	const child = fakeChild(321);
 	const reads = [
@@ -131,13 +218,25 @@ test("DevToolsActivePort readiness tolerates absent and partial writes before re
 	assert.equal(elapsedMs, 20);
 });
 
-test("DevTools readiness reports Chrome exit state instead of an opaque fetch error", async () => {
+test("DevTools readiness reports Chrome exit state and bounded stderr instead of a timeout", async () => {
 	const child = fakeChild(654);
 	child.exitCode = 23;
+	const stream = new EventEmitter();
+	const stderrCapture = createBoundedStderrCapture(stream, { maxBytes: 64 });
+	stream.emit("data", "zygote initialization failed");
 	await assert.rejects(waitForDevToolsEndpoint({
 		profileDir: "test-profile",
 		browserProcess: child,
-	}), /Chrome exited before publishing.*rootPid=654, exitCode=23, signalCode=none/u);
+		browserExecutable: "/usr/bin/google-chrome",
+		stderrCapture,
+	}), (error) => {
+		assert.match(error.message, /Chrome exited before publishing.*rootPid=654, exitCode=23, signalCode=none/u);
+		assert.match(error.message, /executable="\/usr\/bin\/google-chrome"/u);
+		assert.match(error.message, /chromeStderr="zygote initialization failed"/u);
+		assert.doesNotMatch(error.message, /within \d+ ms/u);
+		return true;
+	});
+	stderrCapture.stop();
 });
 
 test("DevTools readiness timeout retains its lifecycle diagnostic", async () => {
@@ -153,6 +252,93 @@ test("DevTools readiness timeout retains its lifecycle diagnostic", async () => 
 		now: () => elapsedMs,
 	}), /within 40 ms.*rootPid=987.*DevToolsActivePort has not been created/u);
 	assert.equal(elapsedMs, 40);
+});
+
+test("DevTools timeout includes a deterministic bounded Chrome profile inventory", async () => {
+	const child = fakeChild(988);
+	let elapsedMs = 0;
+	const entries = Array.from({ length: 55 }, (_, index) => `entry-${String(54 - index).padStart(2, "0")}`);
+	await assert.rejects(waitForDevToolsEndpoint({
+		profileDir: "test-profile",
+		browserProcess: child,
+		browserExecutable: "/usr/bin/google-chrome",
+		timeoutMs: 20,
+		pollIntervalMs: 10,
+		fsApi: {
+			readFile: async () => { throw missingError(); },
+			readdir: async () => entries,
+		},
+		delay: async (delayMs) => { elapsedMs += delayMs; },
+		now: () => elapsedMs,
+	}), (error) => {
+		assert.match(error.message, /within 20 ms.*rootPid=988.*lastState=DevToolsActivePort has not been created/u);
+		assert.match(error.message, /executable="\/usr\/bin\/google-chrome"/u);
+		assert.match(error.message, /chromeStderr="<none captured>"/u);
+		assert.match(error.message, /profileEntries=\["entry-00","entry-01"/u);
+		assert.match(error.message, /"entry-49"\]; profileEntriesOmitted=5/u);
+		assert.doesNotMatch(error.message, /entry-50/u);
+		return true;
+	});
+});
+
+test("DevTools timeout distinguishes an incomplete ActivePort file", async () => {
+	const child = fakeChild(989);
+	let elapsedMs = 0;
+	await assert.rejects(waitForDevToolsEndpoint({
+		profileDir: "test-profile",
+		browserProcess: child,
+		timeoutMs: 10,
+		pollIntervalMs: 5,
+		fsApi: {
+			readFile: async () => "45123\n",
+			readdir: async () => ["DevToolsActivePort", "Local State"],
+		},
+		delay: async (delayMs) => { elapsedMs += delayMs; },
+		now: () => elapsedMs,
+	}), /lastState=DevToolsActivePort was incomplete or invalid.*profileEntries=\["DevToolsActivePort","Local State"\]/u);
+});
+
+test("DevTools timeout distinguishes an unreadable ActivePort file", async () => {
+	const child = fakeChild(990);
+	let elapsedMs = 0;
+	const unreadable = new Error("permission denied");
+	unreadable.code = "EACCES";
+	await assert.rejects(waitForDevToolsEndpoint({
+		profileDir: "test-profile",
+		browserProcess: child,
+		timeoutMs: 10,
+		pollIntervalMs: 5,
+		fsApi: {
+			readFile: async () => { throw unreadable; },
+			readdir: async () => ["DevToolsActivePort"],
+		},
+		delay: async (delayMs) => { elapsedMs += delayMs; },
+		now: () => elapsedMs,
+	}), /lastState=DevToolsActivePort could not be read: permission denied/u);
+});
+
+test("profile-directory diagnostic failure never masks the Chrome startup timeout", async () => {
+	const child = fakeChild(991);
+	let elapsedMs = 0;
+	const denied = new Error("profile access denied");
+	denied.code = "EACCES";
+	await assert.rejects(waitForDevToolsEndpoint({
+		profileDir: "test-profile",
+		browserProcess: child,
+		timeoutMs: 10,
+		pollIntervalMs: 5,
+		fsApi: {
+			readFile: async () => { throw missingError(); },
+			readdir: async () => { throw denied; },
+		},
+		delay: async (delayMs) => { elapsedMs += delayMs; },
+		now: () => elapsedMs,
+	}), (error) => {
+		assert.match(error.message, /^Chrome did not publish a valid DevTools endpoint within 10 ms/u);
+		assert.match(error.message, /lastState=DevToolsActivePort has not been created/u);
+		assert.match(error.message, /profileEntries=<unavailable: EACCES: profile access denied>/u);
+		return true;
+	});
 });
 
 test("a DevTools WebSocket that never opens is closed at its bounded connection timeout", async () => {


### PR DESCRIPTION
## Problem

Historical push run 32603031065 failed on both attempts before mounted-browser assertions because Chrome did not create `DevToolsActivePort` within the previous fixed 10-second startup window. The same approved feature SHA later passed pull-request CI, and the resulting merge SHA passed main CI, supporting hosted Chrome startup variability rather than a deterministic application failure.

## Changes

- Preserve the ordinary 10-second local startup default while adding an explicitly validated `DEVTOOLS_STARTUP_MS` override.
- Set hosted Nuvio Contract Validation to 30 seconds for the frontend/contract-check step.
- Add bounded startup diagnostics for process state, executable resolution, `DevToolsActivePort`, and sorted Chrome-profile entries.
- Capture an 8 KiB Chrome stderr tail only for relevant startup-failure diagnostics.
- Add `--disable-dev-shm-usage` consistently to both real mounted-browser launchers.
- Preserve existing browser discovery and shutdown/cleanup behavior.

## Safety

This PR does not skip mounted tests, reduce assertions, add browser or suite retries, install Chromium, change the runner or Node version, add `--no-zygote` or `--disable-setuid-sandbox`, replace real integration with mocks, change Builder runtime/UI behavior, or change Worker or V1 behavior.

## Validation

- Lifecycle: 41/41
- Folder mounted, default timeout: 25/25
- Source Edit mounted, default timeout: 29/29
- Folder mounted, 30-second override: 25/25
- Source Edit mounted, 30-second override: 29/29
- Full `scripts/check.cmd`: passed
- Builder production build: passed
- Owner review: approved
- Push-triggered hosted CI [32609125137](https://github.com/davecollections/tmdb-id-lookup/actions/runs/32609125137): passed on the first attempt at `80bbd174b09122bc80bb8b9ede4f58edb9f085fb`, including Folder 25/25, Source Edit 29/29, live integration, Builder build, and Pages artifact validation

Closes #144