### PR TITLE
Standardise guided hierarchy selection summaries

### DIFF
--- a/builder/src/ui/GenreHierarchyFlow.jsx
+++ b/builder/src/ui/GenreHierarchyFlow.jsx
@@ -39,7 +39,6 @@ import { SemanticSortChoices } from "./SemanticSortChoices.jsx";
 import { SourceElsewhereNotice } from "./SourceElsewhereNotice.jsx";
 
 const usePrePaintLayoutEffect = typeof window === "undefined" ? useEffect : useLayoutEffect;
-const COMPACT_GENRE_THRESHOLD = 6;
 
 function scopeLabel(scope) {
 	return scope === "new-folder" ? "New Folder" : "New Collection";
@@ -55,7 +54,7 @@ function SelectStep({ query, selection, genres, headingRef, onQueryChange, onCle
 		<section className="genre-hierarchy-select genre-browse-step" aria-labelledby="genre-hierarchy-select-title">
 			<div className="add-source-section-heading genre-browse-heading"><div><p className="panel-kicker">Step 1</p><h3 id="genre-hierarchy-select-title" ref={headingRef} tabIndex={-1}>Select Genres</h3></div></div>
 			<p className="studio-configure-helper">Choose official TMDB Genres in the folder order you want.</p>
-			{genres.length ? <section className="people-selected-tray genre-hierarchy-selected-tray"><div className="people-selected-summary"><strong>{genres.length} Genre{genres.length === 1 ? "" : "s"} selected</strong><RemovableSelectionSummary items={selectionItems(genres)} onRemove={onRemove} ariaLabel="Selected Genres" disclosureLabel="View selected Genres" compactThreshold={COMPACT_GENRE_THRESHOLD} /></div></section> : null}
+			{genres.length ? <section className="people-selected-tray genre-hierarchy-selected-tray"><div className="people-selected-summary"><strong>{genres.length} Genre{genres.length === 1 ? "" : "s"} selected</strong><RemovableSelectionSummary items={selectionItems(genres)} onRemove={onRemove} ariaLabel="Selected Genres" disclosureLabel="View selected Genres" alwaysDisclose showDisclosureCount={false} /></div></section> : null}
 			<GenreSelectionToolbar selectionCount={selection.length} totalCount={GENRE_CONCEPTS.length} onSelectAll={onSelectAll} onClearAll={onClearAll} />
 			<div className="editor-field add-source-query-field genre-search-field">
 				<label htmlFor="genre-hierarchy-query">Search Genres</label>

--- a/tests/builder-genre-hierarchy-ui.test.mjs
+++ b/tests/builder-genre-hierarchy-ui.test.mjs
@@ -70,6 +70,14 @@ test("Genre hierarchy opens on an accessible local Select stage without Search a
 	assert.doesNotMatch(markup, /autofocus|large-selection-notice|there is no selection cap/i);
 });
 
+test("Genre hierarchy configures the shared selected-items component as an always-compact disclosure", () => {
+	const selectStep = flowSource.slice(flowSource.indexOf("function SelectStep"), flowSource.indexOf("function placementLabel"));
+	assert.match(selectStep, /<RemovableSelectionSummary[^>]*alwaysDisclose[^>]*showDisclosureCount=\{false\}/);
+	assert.doesNotMatch(selectStep, /compactThreshold/);
+	assert.doesNotMatch(flowSource, /COMPACT_GENRE_THRESHOLD/);
+	assert.match(selectStep, /disclosureLabel="View selected Genres"/);
+});
+
 test("checkbox catalogue mode preserves the existing Add Source button mode", () => {
 	const concepts = GENRE_CONCEPTS.slice(0, 2);
 	const checkbox = renderToStaticMarkup(createElement(GenreCatalogueList, { concepts, selection: [concepts[0].name], selectionControl: "checkbox", onChoose() {} }));

--- a/tests/builder-source-edit-mounted.test.mjs
+++ b/tests/builder-source-edit-mounted.test.mjs
@@ -190,6 +190,7 @@ async function runMountedPage() {
 				const studioHierarchyWidths = [];
 				const networkHierarchyWidths = [];
 				const genreHierarchyWidths = [];
+				const genreNewFolderSummaryWidths = [];
 				const networkLivePreviewWidths = [];
 				const genreLivePreviewWidths = [];
 				for (const width of [360, 384, 393, 402, 412, 899, 900, 901, 1280]) {
@@ -236,6 +237,13 @@ async function runMountedPage() {
 					});
 					if (genreHierarchyEvaluation.exceptionDetails) throw new Error(genreHierarchyEvaluation.exceptionDetails.exception?.description ?? genreHierarchyEvaluation.exceptionDetails.text);
 					genreHierarchyWidths.push(genreHierarchyEvaluation.result?.value);
+					const genreNewFolderSummaryEvaluation = await resources.pageConnection.command("Runtime.evaluate", {
+						expression: "window.__runGenreNewFolderSummaryScenario()",
+						awaitPromise: true,
+						returnByValue: true,
+					});
+					if (genreNewFolderSummaryEvaluation.exceptionDetails) throw new Error(genreNewFolderSummaryEvaluation.exceptionDetails.exception?.description ?? genreNewFolderSummaryEvaluation.exceptionDetails.text);
+					genreNewFolderSummaryWidths.push(genreNewFolderSummaryEvaluation.result?.value);
 				}
 				const networkDeferredArtworkEvaluation = await resources.pageConnection.command("Runtime.evaluate", {
 					expression: "window.__runNetworkDeferredArtworkScenario()",
@@ -318,7 +326,7 @@ async function runMountedPage() {
 					returnByValue: true,
 				});
 				if (studioScaleEvaluation.exceptionDetails) throw new Error(studioScaleEvaluation.exceptionDetails.exception?.description ?? studioScaleEvaluation.exceptionDetails.text);
-				return { ...result.results, peopleConfigureWidths, peoplePillStabilityWidths, peopleSelectionScrollWidths, franchiseReviewWidths, studioHierarchyWidths, networkHierarchyWidths, genreHierarchyWidths, networkLivePreviewWidths, genreLivePreviewWidths, networkDeferredArtwork, studioScale: studioScaleEvaluation.result?.value, genreToolbarWidths, decadesActionWidths, decadesGenreDesktop, decadesGenreWidths, decadesExclusionDesktop, decadesExclusionWidths };
+				return { ...result.results, peopleConfigureWidths, peoplePillStabilityWidths, peopleSelectionScrollWidths, franchiseReviewWidths, studioHierarchyWidths, networkHierarchyWidths, genreHierarchyWidths, genreNewFolderSummaryWidths, networkLivePreviewWidths, genreLivePreviewWidths, networkDeferredArtwork, studioScale: studioScaleEvaluation.result?.value, genreToolbarWidths, decadesActionWidths, decadesGenreDesktop, decadesGenreWidths, decadesExclusionDesktop, decadesExclusionWidths };
 			}
 			if (result?.status === "error") throw new Error(result.message);
 			await new Promise((resolve) => setTimeout(resolve, 50));
@@ -478,6 +486,50 @@ test("mounted Genre hierarchy preserves browse-first focus, configuration state,
 			cardCount: 27,
 			nativeCheckboxes: true,
 		}, `${width}px browse-first selection`);
+		assert.deepEqual(result.selectionCountStates.map((state) => state.count), [0, 1, 2, 3, 4, 5, 6, 7, 27], `${width}px selected-summary counts`);
+		const zeroSummary = result.selectionCountStates[0];
+		assert.equal(zeroSummary.trayPresent, false, `${width}px zero selected tray`);
+		assert.equal(zeroSummary.disclosurePresent, false, `${width}px zero selected disclosure`);
+		assert.equal(zeroSummary.inlinePillsPresent, false, `${width}px zero selected pills`);
+		for (const state of result.selectionCountStates.slice(1)) {
+			assert.equal(state.trayPresent, true, `${width}px ${state.count} selected tray`);
+			assert.equal(state.countText, `${state.count} Genre${state.count === 1 ? "" : "s"} selected`, `${width}px ${state.count} selected count`);
+			assert.equal(state.disclosurePresent, true, `${width}px ${state.count} selected disclosure`);
+			assert.equal(state.disclosureLabel, "View selected Genres", `${width}px ${state.count} disclosure label`);
+			assert.equal(state.disclosureCollapsed, true, `${width}px ${state.count} collapsed by default`);
+			assert.equal(state.inlinePillsPresent, false, `${width}px ${state.count} no inline pills`);
+			assert.equal(state.countDisclosureOverlap, false, `${width}px ${state.count} count/disclosure separation`);
+			assert.equal(state.removeControlCount, state.count, `${width}px ${state.count} named removal controls`);
+			assert.equal(state.noHorizontalOverflow, true, `${width}px ${state.count} selected-summary overflow`);
+		}
+		assert.deepEqual(result.summaryInteraction.openDisclosureState, {
+			opened: true,
+			removeControlCount: 7,
+			bounded: true,
+			scrollableWhenNeeded: true,
+			closed: true,
+			outerStable: true,
+			documentStable: true,
+			actionStable: true,
+		}, `${width}px selected disclosure interaction`);
+		assert.equal(result.summaryInteraction.filteredSelectedCardAbsent, true, `${width}px filtered selected card absent`);
+		assert.equal(result.summaryInteraction.filteredRemoveAvailable, true, `${width}px filtered selected removal available`);
+		assert.equal(result.summaryInteraction.removedWhileFiltered, true, `${width}px filtered selected removal`);
+		assert.equal(result.summaryInteraction.reselectedCount, "7 Genres selected", `${width}px reselected count`);
+		assert.deepEqual(result.summaryInteraction.selectedOrder, ["Science Fiction", "Sci-Fi & Fantasy", "War & Politics", "Action", "Adventure", "Animation", "Action & Adventure"], `${width}px selected order`);
+		assert.equal(result.summaryInteraction.reselectedAtEnd, true, `${width}px reselect at end`);
+		assert.equal(result.summaryInteraction.namedRemoveControls, true, `${width}px named removal controls`);
+		assert.equal(result.summaryInteraction.zeroRestored.trayPresent, false, `${width}px clear all restores no summary`);
+		assert.deepEqual(result.largeDisclosure, {
+			opened: true,
+			removeControlCount: 27,
+			bounded: true,
+			scrollable: true,
+			closed: true,
+			outerStable: true,
+			documentStable: true,
+			actionStable: true,
+		}, `${width}px 27-Genre disclosure`);
 		assert.equal(result.explicitSearchFocused, true, `${width}px explicit Search focus`);
 		assert.equal(result.selectedAll, true, `${width}px Select all`);
 		assert.deepEqual({ state: result.selectionState, tick: result.selectionTick }, {
@@ -592,6 +644,27 @@ test("mounted Genre hierarchy preserves browse-first focus, configuration state,
 		}, `${width}px contextual hierarchy source titles`);
 		assert.equal(result.oneScrollOwner, true, `${width}px one scroll owner`);
 		assert.equal(result.noHorizontalOverflow, true, `${width}px horizontal overflow`);
+	}
+});
+
+test("mounted Genre New Folder uses the same compact selected-items disclosure at every required width", () => {
+	assert.deepEqual(mountedResults.genreNewFolderSummaryWidths.map((result) => result.width), [360, 384, 393, 402, 412, 899, 900, 901, 1280]);
+	for (const result of mountedResults.genreNewFolderSummaryWidths) {
+		const width = result.width;
+		assert.equal(result.scope, "new-folder", `${width}px New Folder scope`);
+		assert.equal(result.stage, "select", `${width}px New Folder Select stage`);
+		assert.equal(result.zero.trayPresent, false, `${width}px New Folder zero summary`);
+		assert.equal(result.four.countText, "4 Genres selected", `${width}px New Folder selected count`);
+		assert.equal(result.four.disclosurePresent, true, `${width}px New Folder disclosure`);
+		assert.equal(result.four.disclosureLabel, "View selected Genres", `${width}px New Folder disclosure label`);
+		assert.equal(result.four.disclosureCollapsed, true, `${width}px New Folder disclosure collapsed`);
+		assert.equal(result.four.inlinePillsPresent, false, `${width}px New Folder no inline pills`);
+		assert.equal(result.four.countDisclosureOverlap, false, `${width}px New Folder count/disclosure separation`);
+		assert.equal(result.four.removeControlCount, 4, `${width}px New Folder named removal controls`);
+		assert.equal(result.four.noHorizontalOverflow, true, `${width}px New Folder horizontal overflow`);
+		assert.equal(result.opened, true, `${width}px New Folder disclosure opens`);
+		assert.equal(result.closed, true, `${width}px New Folder disclosure closes`);
+		assert.equal(result.oneScrollOwner, true, `${width}px New Folder scroll owner`);
 	}
 });
 

--- a/tests/fixtures/builder-source-edit-mounted.jsx
+++ b/tests/fixtures/builder-source-edit-mounted.jsx
@@ -700,6 +700,45 @@ function setSelectValue(select, value) {
 	select.dispatchEvent(new Event("change", { bubbles: true }));
 }
 
+const GENRE_SUMMARY_TEST_NAMES = Object.freeze([
+	"Action & Adventure",
+	"Science Fiction",
+	"Sci-Fi & Fantasy",
+	"War & Politics",
+	"Action",
+	"Adventure",
+	"Animation",
+]);
+
+function genreCardByName(dialog, name) {
+	return [...dialog.querySelectorAll(".genre-catalogue-choice")].find((card) => card.dataset.genreName === name) ?? null;
+}
+
+function genreSummaryState(dialog, expectedCount) {
+	const tray = dialog.querySelector(".genre-hierarchy-selected-tray");
+	const count = tray?.querySelector(".people-selected-summary > strong") ?? null;
+	const disclosure = tray?.querySelector(".removable-selection-disclosure") ?? null;
+	const countRect = count?.getBoundingClientRect() ?? null;
+	const disclosureRect = disclosure?.getBoundingClientRect() ?? null;
+	const overlaps = Boolean(countRect && disclosureRect
+		&& countRect.left < disclosureRect.right - 0.5
+		&& countRect.right > disclosureRect.left + 0.5
+		&& countRect.top < disclosureRect.bottom - 0.5
+		&& countRect.bottom > disclosureRect.top + 0.5);
+	return {
+		count: expectedCount,
+		trayPresent: Boolean(tray),
+		countText: count?.textContent ?? null,
+		disclosurePresent: Boolean(disclosure),
+		disclosureLabel: disclosure?.querySelector("summary")?.textContent ?? null,
+		disclosureCollapsed: disclosure ? !disclosure.open : null,
+		inlinePillsPresent: Boolean(tray?.querySelector(".removable-selection-pills")),
+		countDisclosureOverlap: overlaps,
+		removeControlCount: disclosure?.querySelectorAll('[aria-label^="Remove "]').length ?? 0,
+		noHorizontalOverflow: document.documentElement.scrollWidth <= window.innerWidth + 1 && dialog.scrollWidth <= dialog.clientWidth + 1,
+	};
+}
+
 async function runGenreHierarchyScenario() {
 	const controller = createController();
 	const revisionBefore = controller.getState().revision;
@@ -738,7 +777,68 @@ async function runGenreHierarchyScenario() {
 			cardCount: cards.length,
 			nativeCheckboxes: cards.every((card) => card.querySelector('input[type="checkbox"]')),
 		};
-		const target = cards[12];
+		const selectionCountStates = [genreSummaryState(dialog, 0)];
+		for (const name of GENRE_SUMMARY_TEST_NAMES) {
+			await clickAndSettle(genreCardByName(dialog, name));
+			selectionCountStates.push(genreSummaryState(dialog, selectionCountStates.length));
+		}
+		let selectedDisclosure = dialog.querySelector(".genre-hierarchy-selected-tray .removable-selection-disclosure");
+		const selectedDisclosureSummary = selectedDisclosure.querySelector("summary");
+		const dialogRectBeforeDisclosure = dialog.getBoundingClientRect();
+		const actionRectBeforeDisclosure = action.getBoundingClientRect();
+		const documentScrollBeforeDisclosure = window.scrollY;
+		await clickAndSettle(selectedDisclosureSummary);
+		const selectedDisclosureList = selectedDisclosure.querySelector("ul");
+		const selectedDisclosureListStyle = getComputedStyle(selectedDisclosureList);
+		const openDisclosureState = {
+			opened: selectedDisclosure.open,
+			removeControlCount: selectedDisclosure.querySelectorAll('[aria-label^="Remove "]').length,
+			bounded: selectedDisclosureList.clientHeight <= Math.min(window.innerHeight * 0.36, 340) + 2,
+			scrollableWhenNeeded: selectedDisclosureListStyle.overflowY === "auto",
+		};
+		await clickAndSettle(selectedDisclosureSummary);
+		openDisclosureState.closed = !selectedDisclosure.open;
+		openDisclosureState.outerStable = Math.abs(dialog.getBoundingClientRect().top - dialogRectBeforeDisclosure.top) <= 1
+			&& Math.abs(dialog.getBoundingClientRect().bottom - dialogRectBeforeDisclosure.bottom) <= 1;
+		openDisclosureState.documentStable = window.scrollY === documentScrollBeforeDisclosure;
+		openDisclosureState.actionStable = Math.abs(action.getBoundingClientRect().top - actionRectBeforeDisclosure.top) <= 1
+			&& Math.abs(action.getBoundingClientRect().bottom - actionRectBeforeDisclosure.bottom) <= 1;
+
+		await clickAndSettle(selectedDisclosureSummary);
+		await act(async () => {
+			setInputValue(search, "Western");
+			await afterCommittedEffects();
+		});
+		const filteredSelectedCardAbsent = genreCardByName(dialog, GENRE_SUMMARY_TEST_NAMES[0]) === null;
+		const filteredRemoveAction = dialog.querySelector(`[aria-label="Remove ${GENRE_SUMMARY_TEST_NAMES[0]}"]`);
+		await clickAndSettle(filteredRemoveAction);
+		const removedWhileFiltered = dialog.querySelector(".people-selected-summary > strong")?.textContent === "6 Genres selected"
+			&& dialog.querySelector(`[aria-label="Remove ${GENRE_SUMMARY_TEST_NAMES[0]}"]`) === null;
+		await act(async () => {
+			setInputValue(search, "");
+			await afterCommittedEffects();
+		});
+		await clickAndSettle(genreCardByName(dialog, GENRE_SUMMARY_TEST_NAMES[0]));
+		selectedDisclosure = dialog.querySelector(".genre-hierarchy-selected-tray .removable-selection-disclosure");
+		if (!selectedDisclosure.open) await clickAndSettle(selectedDisclosure.querySelector("summary"));
+		const selectedOrder = [...selectedDisclosure.querySelectorAll('[aria-label^="Remove "]')].map((button) => button.getAttribute("aria-label").replace(/^Remove /, ""));
+		const expectedReselectedOrder = [...GENRE_SUMMARY_TEST_NAMES.slice(1), GENRE_SUMMARY_TEST_NAMES[0]];
+		const summaryInteraction = {
+			openDisclosureState,
+			filteredSelectedCardAbsent,
+			filteredRemoveAvailable: Boolean(filteredRemoveAction),
+			removedWhileFiltered,
+			reselectedCount: dialog.querySelector(".people-selected-summary > strong")?.textContent ?? null,
+			selectedOrder,
+			reselectedAtEnd: JSON.stringify(selectedOrder) === JSON.stringify(expectedReselectedOrder),
+			namedRemoveControls: selectedOrder.length === GENRE_SUMMARY_TEST_NAMES.length,
+		};
+		await clickAndSettle(selectedDisclosure.querySelector("summary"));
+		await clickAndSettle(buttonContaining(dialog.querySelector(".genre-selection-actions"), "Clear all"));
+		summaryInteraction.zeroRestored = genreSummaryState(dialog, 0);
+
+		const focusCards = [...dialog.querySelectorAll(".genre-catalogue-choice")];
+		const target = focusCards[12];
 		const scrollRect = scrollOwner.getBoundingClientRect();
 		const cardRect = target.getBoundingClientRect();
 		const visibleHeight = Math.min(42, cardRect.height / 3);
@@ -776,6 +876,26 @@ async function runGenreHierarchyScenario() {
 		const explicitSearchFocused = document.activeElement === search;
 		await clickAndSettle(buttonContaining(dialog.querySelector(".genre-selection-actions"), "Select all"));
 		const selectedAll = dialog.querySelector(".genre-selection-toolbar")?.textContent.includes("27 of 27 selected") ?? false;
+		selectionCountStates.push(genreSummaryState(dialog, 27));
+		const largeDisclosureElement = dialog.querySelector(".genre-hierarchy-selected-tray .removable-selection-disclosure");
+		const largeDisclosureDialogRect = dialog.getBoundingClientRect();
+		const largeDisclosureActionRect = action.getBoundingClientRect();
+		const largeDisclosureDocumentScroll = window.scrollY;
+		await clickAndSettle(largeDisclosureElement.querySelector("summary"));
+		const largeDisclosureList = largeDisclosureElement.querySelector("ul");
+		const largeDisclosure = {
+			opened: largeDisclosureElement.open,
+			removeControlCount: largeDisclosureElement.querySelectorAll('[aria-label^="Remove "]').length,
+			bounded: largeDisclosureList.clientHeight <= Math.min(window.innerHeight * 0.36, 340) + 2,
+			scrollable: getComputedStyle(largeDisclosureList).overflowY === "auto" && largeDisclosureList.scrollHeight >= largeDisclosureList.clientHeight,
+		};
+		await clickAndSettle(largeDisclosureElement.querySelector("summary"));
+		largeDisclosure.closed = !largeDisclosureElement.open;
+		largeDisclosure.outerStable = Math.abs(dialog.getBoundingClientRect().top - largeDisclosureDialogRect.top) <= 1
+			&& Math.abs(dialog.getBoundingClientRect().bottom - largeDisclosureDialogRect.bottom) <= 1;
+		largeDisclosure.documentStable = window.scrollY === largeDisclosureDocumentScroll;
+		largeDisclosure.actionStable = Math.abs(action.getBoundingClientRect().top - largeDisclosureActionRect.top) <= 1
+			&& Math.abs(action.getBoundingClientRect().bottom - largeDisclosureActionRect.bottom) <= 1;
 		const selectionIndicator = dialog.querySelector('.genre-catalogue-choice[data-selected="true"] .selectable-card-indicator');
 		await clickAndSettle(dialog.querySelector(".add-source-actions .editor-apply"));
 		const mediaPill = dialog.querySelector('.genre-hierarchy-configuration-surface input[name="genre-hierarchy-media"][value="both"]')?.closest("label");
@@ -957,6 +1077,9 @@ async function runGenreHierarchyScenario() {
 		return {
 			width: window.innerWidth,
 			initial,
+			selectionCountStates,
+			summaryInteraction,
+			largeDisclosure,
 			explicitSearchFocused,
 			selectedAll,
 			selectionState: selectionIndicator?.dataset.selectionState ?? null,
@@ -980,6 +1103,59 @@ async function runGenreHierarchyScenario() {
 			},
 			oneScrollOwner: dialog.querySelectorAll(".add-source-scroll").length === 1,
 			noHorizontalOverflow: document.documentElement.scrollWidth <= window.innerWidth && dialog.scrollWidth <= dialog.clientWidth,
+		};
+	} finally {
+		await act(async () => root.unmount());
+		host.remove();
+	}
+}
+
+async function runGenreNewFolderSummaryScenario() {
+	const controller = createController();
+	const imported = controller.importValue([{ id: "destination", title: "Destination", folders: [] }]);
+	if (!imported.ok) throw new Error("Genre New Folder summary fixture could not import its destination collection.");
+	const destination = controller.getState().project.collections[0];
+	const host = document.createElement("div");
+	document.body.append(host);
+	const root = createRoot(host);
+	await act(async () => {
+		root.render(createElement(CreationDialog, {
+			scope: "new-folder",
+			project: controller.getState().project,
+			projectRevision: controller.getState().revision,
+			currentYear: 2026,
+			destinationCollectionInternalId: destination.internalId,
+			destinationCollectionTitle: destination.editable.title,
+			initialOptionId: "genres",
+			onCancel() {},
+			onCreateBlank() {},
+			onApplyDecades() { return { ok: true }; },
+			onApplyPeople() { return { ok: true }; },
+			onApplyFranchises() { return { ok: true }; },
+			onApplyStudios() { return { ok: true }; },
+			onApplyNetworks() { return { ok: true }; },
+			onApplyGenres() { return { ok: true }; },
+		}));
+		await afterCommittedEffects();
+	});
+	try {
+		const dialog = document.querySelector('[data-creation-option="genres"]');
+		const zero = genreSummaryState(dialog, 0);
+		for (const name of GENRE_SUMMARY_TEST_NAMES.slice(0, 4)) await clickAndSettle(genreCardByName(dialog, name));
+		const four = genreSummaryState(dialog, 4);
+		const disclosure = dialog.querySelector(".genre-hierarchy-selected-tray .removable-selection-disclosure");
+		await clickAndSettle(disclosure.querySelector("summary"));
+		const opened = disclosure.open && disclosure.querySelectorAll('[aria-label^="Remove "]').length === 4;
+		await clickAndSettle(disclosure.querySelector("summary"));
+		return {
+			width: window.innerWidth,
+			scope: dialog.dataset.creationScope ?? null,
+			stage: dialog.querySelector(".genre-hierarchy-form")?.dataset.genreHierarchyStage ?? null,
+			zero,
+			four,
+			opened,
+			closed: !disclosure.open,
+			oneScrollOwner: dialog.querySelectorAll(".add-source-scroll").length === 1,
 		};
 	} finally {
 		await act(async () => root.unmount());
@@ -4076,6 +4252,7 @@ async function runMountedRegressions() {
 window.__builderSourceEditMounted = { status: "running" };
 window.__runGenreToolbarScenario = runGenreToolbarScenario;
 window.__runGenreHierarchyScenario = runGenreHierarchyScenario;
+window.__runGenreNewFolderSummaryScenario = runGenreNewFolderSummaryScenario;
 window.__runDecadesActionLayoutScenario = runDecadesActionLayoutScenario;
 window.__runDecadesGenreLayoutScenario = runDecadesGenreLayoutScenario;
 window.__runDecadesExclusionLayoutScenario = runDecadesExclusionLayoutScenario;


### PR DESCRIPTION
## Problem

Genre used inline removable pills for 1–6 selections and switched to a compact disclosure at 7+. On mobile, several pills could collapse the adjacent selected-count column and visibly overlap the count.

Other searchable guided hierarchy families already use a compact selected-items disclosure from the first selection.

## Changes

- Genre now uses the existing compact disclosure for every positive selection count.
- The existing `RemovableSelectionSummary` capability is reused.
- `View selected Genres` does not repeat the selected count.
- No inline Genre pill state remains.
- The same behavior applies at mobile and desktop widths.
- Selection removal, filter persistence, ordering, and remove/reselect-at-end behavior are preserved.
- Decades, People, Franchises, Studios, and Networks are unchanged.

## Safety

- Only one production UI file changed.
- No CSS change.
- No shared-component change.
- No new abstraction.
- No responsive JavaScript.
- No Add Source change.
- No model, schema, serializer, or controller change.
- No Worker, V1, CI, dependency, or catalogue change.

## Validation

- Focused Genre hierarchy: 10/10.
- Mounted real-Chrome: 30/30.
- Six-family regression: 89/89.
- Selection counts: 0–7 and 27.
- Responsive widths: 360, 384, 393, 402, 412, 899, 900, 901, and 1280.
- Filtering, removal, ordering, bounded scrolling, and overlap checks passed.
- New Collection and New Folder both passed.
- `scripts/check.cmd` passed.
- Builder production build passed.
- [Push CI run 32711012652](https://github.com/davecollections/tmdb-id-lookup/actions/runs/32711012652) passed on attempt 1 for `633c46168bccd14757c0909254aab6f38a3b6cce`.
- Physical-device owner review approved.

Closes #148