### PR TITLE
Simplify Source Edit identity presentation

### DIFF
--- a/builder/src/styles.css
+++ b/builder/src/styles.css
@@ -181,18 +181,6 @@
 	font-size: 0.72rem;
 }
 
-.genre-edit-mark {
-	display: grid;
-	width: 50px;
-	height: 50px;
-	place-items: center;
-	color: #031119;
-	font-size: 1.1rem;
-	font-weight: 950;
-	background: linear-gradient(145deg, var(--cyan-bright), var(--green));
-	border-radius: 12px;
-}
-
 @media (max-width: 900px) {
 	.genre-catalogue-list button,
 	.genre-catalogue-choice {
@@ -5892,16 +5880,6 @@ body.hierarchy-pointer-dragging .builder-shell {
 .streaming-generated-name-field .editor-field-help,
 .streaming-generated-name-field .editor-field-error {
 	margin: 0;
-}
-
-.streaming-edit-identity {
-	grid-template-columns: 72px minmax(0, 1fr);
-}
-
-.streaming-edit-identity > .tmdb-entity-logo-tile--streaming-edit {
-	width: 58px;
-	height: 58px;
-	padding: 7px;
 }
 
 .studio-elsewhere-note {

--- a/builder/src/ui/SourceEditorDialog.jsx
+++ b/builder/src/ui/SourceEditorDialog.jsx
@@ -65,16 +65,13 @@ import {
 import { focusElementWithoutScroll } from "./hierarchy-menu-placement.js";
 import { handleDialogKeyDown } from "./modal-focus.js";
 import { MovieCollectionPicker } from "./MovieCollectionPicker.jsx";
-import { NetworkLogo } from "./NetworkSourceFlow.jsx";
 import { NetworkSortChoices } from "./NetworkSortChoices.jsx";
-import { StudioLogo } from "./StudioSourceFlow.jsx";
 import { StudioSortChoices } from "./StudioSortChoices.jsx";
 import { TmdbEntityLink } from "./TmdbEntityLink.jsx";
 import { TmdbKnownZeroNotice } from "./TmdbKnownZeroNotice.jsx";
 import { SemanticSortChoices } from "./SemanticSortChoices.jsx";
 import { GenreAdvancedOptions, GenreAdvancedSecondarySurface } from "./GenreAdvancedOptions.jsx";
 import { DecadesAdvancedOptions } from "./DecadesAdvancedOptions.jsx";
-import { TmdbEntityLogo } from "./TmdbEntityLogo.jsx";
 import {
 	focusSourceEditAlert,
 	sourceEditErrorPresentation,
@@ -261,12 +258,11 @@ export function StudioEditorFields({
 	const mediaLabel = mediaType === "TV" ? "Series" : "Movies";
 	return (
 		<section className="source-edit-options studio-source-edit-options" aria-labelledby="source-edit-options-title">
-			<div className="studio-configure-identity tmdb-review-identity">
-				<StudioLogo studio={studio} size="w185" context="configure" loading="eager" />
+			<div className="add-source-section-heading tmdb-review-identity">
 				<div className="tmdb-review-identity-copy">
 					<p className="panel-kicker">{mediaLabel} source</p>
 					<h3 id="source-edit-options-title">{studio.name}</h3>
-					{formatStudioLocation(studio) ? <p>{formatStudioLocation(studio)}</p> : null}
+					{formatStudioLocation(studio) ? <p className="editor-field-help">{formatStudioLocation(studio)}</p> : null}
 				</div>
 				<TmdbEntityLink entityType="company" tmdbId={studio.id} entityName={studio.name} />
 			</div>
@@ -290,12 +286,11 @@ export function NetworkEditorFields({ draft, network, countState, sortRef, title
 			: { text: "Checking Series Count…", state: "checking" };
 	return (
 		<section className="source-edit-options studio-source-edit-options network-source-edit-options" aria-labelledby="source-edit-options-title">
-			<div className="studio-configure-identity tmdb-review-identity network-configure-identity">
-				<NetworkLogo network={network} size="w185" context="configure" loading="eager" />
+			<div className="add-source-section-heading tmdb-review-identity">
 				<div className="tmdb-review-identity-copy">
 					<p className="panel-kicker">Network Series source</p>
 					<h3 id="source-edit-options-title">{network.name}</h3>
-					{formatNetworkLocation(network) ? <p>{formatNetworkLocation(network)}</p> : null}
+					{formatNetworkLocation(network) ? <p className="editor-field-help">{formatNetworkLocation(network)}</p> : null}
 				</div>
 				<TmdbEntityLink entityType="network" tmdbId={network.id} entityName={network.name} />
 			</div>
@@ -316,12 +311,11 @@ export function StreamingEditorFields({ draft, providerIdentity, sortRef, onDefa
 	const mediaLabel = draft.mediaType === "TV" ? "Series" : "Movies";
 	return (
 		<section className="source-edit-options studio-source-edit-options streaming-source-edit-options" aria-labelledby="source-edit-options-title">
-			<div className="studio-configure-identity tmdb-review-identity streaming-edit-identity">
-				<TmdbEntityLogo entity={providerIdentity} entityType="streaming-provider" size="w92" context="streaming-edit" loading="eager" />
+			<div className="add-source-section-heading">
 				<div className="tmdb-review-identity-copy">
 					<p className="panel-kicker">Streaming provider</p>
 					<h3 id="source-edit-options-title">{providerIdentity.name}</h3>
-					<p>Provider ID {draft.providerId} · {draft.regionCode} · {mediaLabel}</p>
+					<p className="editor-field-help">Provider ID {draft.providerId} · {draft.regionCode} · {mediaLabel}</p>
 				</div>
 			</div>
 			<p className="source-edit-fixed-note">Provider, region and media type stay fixed for this physical source.</p>
@@ -336,12 +330,11 @@ export function GenreEditorFields({ draft, sortRef, onDefaultName, onSortChange,
 	const mediaLabel = draft.mediaType === "TV" ? "Series" : "Movies";
 	return (
 		<section className="source-edit-options studio-source-edit-options genre-source-edit-options" aria-labelledby="source-edit-options-title">
-			<div className="studio-configure-identity tmdb-review-identity genre-edit-identity">
-				<div className="genre-edit-mark" aria-hidden="true">G</div>
+			<div className="add-source-section-heading">
 				<div className="tmdb-review-identity-copy">
 					<p className="panel-kicker">Official TMDB Genre</p>
 					<h3 id="source-edit-options-title">{draft.genreName}</h3>
-					<p>Genre ID {draft.genreId} · {mediaLabel}</p>
+					<p className="editor-field-help">Genre ID {draft.genreId} · {mediaLabel}</p>
 				</div>
 			</div>
 			<p className="source-edit-fixed-note">Genre ID and media type stay fixed for this source.</p>

--- a/tests/builder-genre-ui.test.mjs
+++ b/tests/builder-genre-ui.test.mjs
@@ -377,6 +377,7 @@ test("Genre Source Edit shares the advanced controls while Genre identity and me
 	}));
 	assert.ok(markup.includes("Official TMDB Genre"));
 	assert.ok(markup.includes("Genre ID 35 · Series"));
+	assert.equal(markup.includes("genre-edit-mark"), false);
 	assert.ok(markup.includes("Genre ID and media type stay fixed for this source"));
 	assert.ok(markup.includes("Use default name"));
 	assert.ok(markup.includes("Advanced options"));
@@ -385,6 +386,7 @@ test("Genre Source Edit shares the advanced controls while Genre identity and me
 	assert.equal(markup.includes("? What do these options do?"), false);
 	assert.equal(markup.includes("physical source"), false);
 	for (const label of ["Popular", "Recent", "Top Rated", "Most Votes"]) assert.ok(markup.includes(`>${label}<`), label);
+	assert.doesNotMatch(read("builder/src/styles.css"), /\.genre-edit-mark\s*\{/);
 });
 
 test("workspace wiring keeps Genres out of the Folders header and supports responsive subviews", () => {

--- a/tests/builder-network-ui.test.mjs
+++ b/tests/builder-network-ui.test.mjs
@@ -205,8 +205,11 @@ test("Network Source Edit renders fixed linked identity, count, and editable sem
 		onSortChange() {},
 	}));
 	assert.ok(markup.includes("Network Series source"));
+	assert.ok(markup.includes("US · New York City, New York"));
 	assert.ok(markup.includes("Series Count: 42"));
 	assert.ok(markup.includes('href="https://www.themoviedb.org/network/2"'));
+	assert.equal(markup.includes('data-entity-logo="network"'), false);
+	assert.equal(markup.includes("ABC logo"), false);
 	assert.equal((markup.match(/type="radio"/g) ?? []).length, 4);
 	assert.equal(markup.includes('type="checkbox"'), false);
 	assert.ok(markup.indexOf("Open ABC on TMDB") < markup.indexOf("Source name"));

--- a/tests/builder-source-edit-ui.test.mjs
+++ b/tests/builder-source-edit-ui.test.mjs
@@ -338,6 +338,8 @@ test("Studio editor opens the fixed Studio identity with count, TMDB link, sort,
 	assert.ok(markup.includes("Movies source"));
 	assert.ok(markup.includes("Pixar"));
 	assert.ok(markup.includes('href="https://www.themoviedb.org/company/3"'));
+	assert.equal(markup.includes('data-entity-logo="studio"'), false);
+	assert.equal(markup.includes("Pixar logo"), false);
 	assert.ok(markup.includes("42 movies"));
 	assert.ok(markup.includes("Sort titles by"));
 	assert.ok(markup.includes('data-selected="true"'));
@@ -364,6 +366,8 @@ test("Studio editor preserves an unusual imported sort until a supported option 
 		countState: { movie: { status: "unavailable", count: null, error: { retryable: true } }, series: { status: "unavailable", count: null, error: { retryable: true } } },
 		onSortChange() {},
 	}));
+	assert.ok(markup.includes("US · Emeryville, California"));
+	assert.equal(markup.includes('data-entity-logo="studio"'), false);
 	assert.ok(markup.includes("Current imported sort is preserved until you choose a supported sort: Owner.MixedCase"));
 	assert.equal(markup.includes("checked=\"\""), false);
 	assert.ok(markup.includes("Count unavailable"));
@@ -405,14 +409,16 @@ test("resolved Streaming provider presentation enables default naming while impo
 	}));
 	assert.ok(markup.includes("Netflix"));
 	assert.ok(markup.includes("Provider ID 8 · AU · Series"));
-	assert.ok(markup.includes("tmdb-entity-logo-tile--streaming-edit"));
-	assert.ok(markup.includes("/w92/netflix.png"));
+	assert.equal(markup.includes('data-entity-logo="streaming-provider"'), false);
+	assert.equal(markup.includes("tmdb-entity-logo-tile--streaming-edit"), false);
+	assert.equal(markup.includes("/w92/netflix.png"), false);
 	assert.ok(markup.includes("Use default name"));
 	assert.ok(markup.includes("Current imported sort is preserved until you choose a supported sort: owner.imported"));
 	assert.equal(markup.includes("checked=\"\""), false);
 	const styles = fs.readFileSync(path.join(rootDir, "builder", "src", "styles.css"), "utf8");
-	assert.match(styles, /\.streaming-edit-identity\s*>\s*\.tmdb-entity-logo-tile--streaming-edit\s*\{/);
+	assert.doesNotMatch(styles, /\.streaming-edit-identity|\.tmdb-entity-logo-tile--streaming-edit/);
 	const dialogSource = fs.readFileSync(path.join(rootDir, "builder", "src", "ui", "SourceEditorDialog.jsx"), "utf8");
+	assert.match(dialogSource, /streamingCatalogueProvider\.loadCatalogue\(\)/);
 	assert.match(dialogSource, /streamingDefaultSourceName\(streamingProviderIdentity\.name, draft\.regionCode, draft\.mediaType\)/);
 });
 
@@ -679,6 +685,7 @@ test("the extracted Collection picker retains accepted Search inputs and recover
 	const source = read("builder/src/ui/MovieCollectionPicker.jsx");
 	assert.match(source, /provider\.searchCollections/);
 	assert.match(source, /provider\.getCollection/);
+	assert.match(source, /<AddSourceSearchStep/);
 	assert.match(source, /onRetryLookup/);
 	assert.match(source, /onRetrySelection/);
 	assert.match(source, /changePage/);


### PR DESCRIPTION
## Problem

Normal Source Edit still displayed decorative TMDB/entity imagery for several already-established sources. This added visual weight and could create a misleading mismatch when imported collections or folders preserved different custom artwork.

## Changes

- Removed the Studio logo from normal Source Edit.
- Removed the Network logo from normal Source Edit.
- Removed the Streaming provider logo from normal Source Edit.
- Removed the Genre decorative G mark from normal Source Edit.
- Reused the existing text-heading layout and removed obsolete Source Edit-only wrappers and styles.
- Preserved identity text, IDs, locations, links, media, region, counts, naming, sorting, and advanced controls.

## Important boundary

- Source Edit is now text-first for established identity.
- Imagery remains available while choosing or replacing identities.
- The Franchise replacement picker still uses TMDB posters.
- Search, Browse, Select, Configure, hierarchy, and artwork imagery remain unchanged.
- Imported or custom collection and folder artwork is untouched and is not reconciled by this change.

## Safety

- Two production Builder files and three focused test files changed.
- No new abstraction or shared image-component change.
- No Add Source change.
- No model, schema, serializer, or controller change.
- No Worker, V1, CI, dependency, or catalogue change.

## Validation

- Focused UI: 107/107.
- Supporting domain, hierarchy, and artwork: 98/98.
- Mounted Source Edit: 30/30.
- Responsive widths: 360, 384, 393, 402, 412, 899, 900, 901, and 1280.
- Live Add Source and Franchise imagery regression checks passed.
- scripts/check.cmd passed.
- Builder production build passed.
- Push CI Nuvio Contract Validation passed on attempt 1: https://github.com/davecollections/tmdb-id-lookup/actions/runs/32719389016
- Desktop and mobile owner review approved.

Closes #150