### PR TITLE
Polish Builder visual consistency

### DIFF
--- a/builder/src/nuvio/folder-artwork-fields.js
+++ b/builder/src/nuvio/folder-artwork-fields.js
@@ -65,13 +65,13 @@ export const FOLDER_ARTWORK_FIELD_GROUPS = Object.freeze([
 	}),
 	group({
 		slug: "focus",
-		title: "Focus",
+		title: "Focus GIF",
 		fields: [
 			field({
 				field: "focusGifUrl",
 				inputType: "url",
-				label: "Focus artwork URL",
-				description: "Artwork shown when the folder is focused.",
+				label: "Focus GIF URL",
+				description: "Animated artwork shown when the folder is focused.",
 				preview: "focus",
 			}),
 		],

--- a/builder/src/nuvio/folder-artwork-fields.js
+++ b/builder/src/nuvio/folder-artwork-fields.js
@@ -71,7 +71,7 @@ export const FOLDER_ARTWORK_FIELD_GROUPS = Object.freeze([
 				field: "focusGifUrl",
 				inputType: "url",
 				label: "Focus GIF URL",
-				description: "Animated artwork shown when the folder is focused.",
+				description: "Animated artwork when focused.",
 				preview: "focus",
 			}),
 		],

--- a/builder/src/styles.css
+++ b/builder/src/styles.css
@@ -2337,6 +2337,18 @@ body.settings-modal-open {
 	padding: 0 2px;
 }
 
+.source-edit-people-identity {
+	margin: 0 2px;
+	color: var(--muted);
+	font-size: 0.72rem;
+	line-height: 1.45;
+}
+
+.source-edit-people-identity strong {
+	color: #dff8ff;
+	font-weight: 760;
+}
+
 .source-edit-combinations {
 	grid-template-columns: repeat(2, minmax(0, 1fr));
 }
@@ -2346,7 +2358,7 @@ body.settings-modal-open {
 	display: grid;
 	min-width: 0;
 	min-height: 58px;
-	grid-template-columns: 20px minmax(0, 1fr);
+	grid-template-columns: 22px minmax(0, 1fr);
 	align-items: center;
 	gap: 10px;
 	padding: 10px 11px;
@@ -2359,14 +2371,7 @@ body.settings-modal-open {
 .source-edit-combination:has(input:checked) {
 	background: rgb(1 180 228 / 12%);
 	border-color: rgb(98 225 255 / 56%);
-	box-shadow: inset 3px 0 0 var(--green);
-}
-
-.source-edit-combination input {
-	width: 18px;
-	height: 18px;
-	margin: 0;
-	accent-color: var(--green);
+	box-shadow: none;
 }
 
 .source-edit-combination span {
@@ -3006,7 +3011,7 @@ body.settings-modal-open {
 	}
 }
 
-@media (max-width: 899px) {
+@media (max-width: 899.98px) {
 	.add-source-portal {
 		background: rgb(7 24 33);
 	}
@@ -3041,13 +3046,13 @@ body.settings-modal-open {
 	}
 }
 
-@media (max-width: 899px) and (max-height: 600px) {
+@media (max-width: 899.98px) and (max-height: 600px) {
 	.add-source-review-poster-frame {
 		width: clamp(140px, 40vw, 180px);
 	}
 }
 
-@media (min-width: 600px) and (max-width: 899px) and (max-height: 600px) {
+@media (min-width: 600px) and (max-width: 899.98px) and (max-height: 600px) {
 	.add-source-review-layout {
 		grid-template-columns: 180px minmax(0, 1fr);
 		align-items: start;
@@ -4211,13 +4216,48 @@ body.hierarchy-pointer-dragging .builder-shell {
 
 }
 
-@media (min-width: 900px) and (max-width: 1023px) {
+@media (min-width: 900px) and (max-width: 1023.98px) {
 	.app-header {
 		grid-template-columns: minmax(0, 1fr);
 	}
 
 	.workspace-header-actions {
 		justify-content: start;
+	}
+
+	.panel-header {
+		gap: 6px;
+		padding-right: 10px;
+		padding-left: 10px;
+	}
+
+	.panel-header h2 {
+		font-size: 1rem;
+		overflow-wrap: normal;
+		white-space: nowrap;
+	}
+
+	.panel-header-title {
+		gap: 3px;
+	}
+
+	.panel-title-inline-count.mobile-only {
+		display: inline;
+	}
+
+	.panel-count.panel-count-desktop-only {
+		display: none;
+	}
+
+	.source-heading {
+		align-items: flex-start;
+		flex-direction: column;
+		gap: 3px;
+	}
+
+	.source-heading .node-title {
+		overflow-wrap: normal;
+		word-break: normal;
 	}
 }
 
@@ -4478,6 +4518,7 @@ body.hierarchy-pointer-dragging .builder-shell {
 }
 
 .folder-artwork-preview-frame {
+	position: relative;
 	display: grid;
 	overflow: hidden;
 	place-items: center;
@@ -4486,6 +4527,27 @@ body.hierarchy-pointer-dragging .builder-shell {
 	background: rgb(2 13 20 / 72%);
 	border: 1px solid rgb(137 190 215 / 24%);
 	border-radius: 10px;
+}
+
+.folder-artwork-preview-frame.is-preview-hidden .folder-artwork-preview-image {
+	filter: saturate(0.35) brightness(0.68);
+	opacity: 0.3;
+}
+
+.folder-artwork-preview-overlay {
+	position: absolute;
+	inset: 0;
+	display: grid;
+	place-items: center;
+	padding: 8px;
+	color: #e7f9ff;
+	font-size: 0.68rem;
+	font-weight: 850;
+	letter-spacing: 0.02em;
+	text-align: center;
+	text-shadow: 0 1px 8px rgb(0 0 0 / 78%);
+	background: rgb(0 8 13 / 38%);
+	pointer-events: none;
 }
 
 .folder-artwork-preview-frame[data-artwork-preview-shape="poster"] {
@@ -4897,7 +4959,7 @@ body.hierarchy-pointer-dragging .builder-shell {
 	display: grid;
 	min-width: 0;
 	min-height: 58px;
-	grid-template-columns: 20px minmax(0, 1fr) auto;
+	grid-template-columns: 22px minmax(0, 1fr) auto;
 	align-items: center;
 	gap: 9px;
 	padding: 9px 10px;
@@ -4913,7 +4975,7 @@ body.hierarchy-pointer-dragging .builder-shell {
 	box-shadow: none;
 }
 
-.people-combination-group input {
+.people-combination-group input:not(.selectable-card-checkbox) {
 	width: 20px;
 	height: 20px;
 	margin: 0;
@@ -5048,7 +5110,7 @@ body.hierarchy-pointer-dragging .builder-shell {
 	padding: 7px 9px;
 }
 
-.people-combination-group.is-compact input {
+.people-combination-group.is-compact input:not(.selectable-card-checkbox) {
 	width: 18px;
 	height: 18px;
 }
@@ -5345,7 +5407,7 @@ body.hierarchy-pointer-dragging .builder-shell {
 .people-title-preview-grid {
 	display: grid;
 	min-width: 0;
-	grid-template-columns: repeat(10, minmax(0, 1fr));
+	grid-template-columns: repeat(5, minmax(0, 1fr));
 	gap: 5px;
 }
 
@@ -5790,10 +5852,18 @@ body.hierarchy-pointer-dragging .builder-shell {
 	cursor: pointer;
 }
 
+.studio-source-choice {
+	grid-template-columns: 22px minmax(0, 1fr) auto;
+}
+
 .studio-source-choices label:has(input:checked) {
 	background: rgb(1 180 228 / 12%);
 	border-color: rgb(98 225 255 / 56%);
 	box-shadow: inset 3px 0 0 var(--green);
+}
+
+.studio-source-choice:has(input:checked) {
+	box-shadow: none;
 }
 
 .studio-source-choices label[data-source-supported="false"],
@@ -5802,7 +5872,7 @@ body.hierarchy-pointer-dragging .builder-shell {
 	cursor: not-allowed;
 }
 
-.studio-source-choices input {
+.studio-source-choices input:not(.selectable-card-checkbox) {
 	width: 20px;
 	height: 20px;
 	margin: 0;
@@ -6219,7 +6289,7 @@ body.hierarchy-pointer-dragging .builder-shell {
 	}
 }
 
-@media (max-width: 899px) {
+@media (max-width: 899.98px) {
 	.source-mode-dialog,
 	.people-source-dialog,
 	.studio-source-dialog {
@@ -8477,6 +8547,10 @@ body.hierarchy-pointer-dragging .builder-shell {
 	cursor: pointer;
 }
 
+.decades-content-grid label {
+	grid-template-columns: 22px minmax(0, 1fr);
+}
+
 .decades-choice-grid label[data-selected="true"],
 .decades-content-grid label[data-selected="true"] {
 	background: rgb(1 180 228 / 9%);
@@ -8484,7 +8558,7 @@ body.hierarchy-pointer-dragging .builder-shell {
 }
 
 .decades-choice-grid input,
-.decades-content-grid input {
+.decades-content-grid input:not(.selectable-card-checkbox) {
 	width: 18px;
 	height: 18px;
 	margin: 0;

--- a/builder/src/styles.css
+++ b/builder/src/styles.css
@@ -4472,7 +4472,7 @@ body.hierarchy-pointer-dragging .builder-shell {
 
 	display: grid;
 	min-width: 0;
-	gap: 14px;
+	gap: 4px;
 }
 
 .folder-artwork-group {

--- a/builder/src/ui/BuilderWorkspace.jsx
+++ b/builder/src/ui/BuilderWorkspace.jsx
@@ -2314,6 +2314,7 @@ export function BuilderWorkspace({
 							id="collections-title"
 							title="Collections"
 							count={view.collections.length}
+							mobileInlineCount
 							headingAction={(
 								<button
 									ref={bulkEditTriggerRef}
@@ -2409,6 +2410,7 @@ export function BuilderWorkspace({
 							id="folders-title"
 							title="Folders"
 							count={view.folders.length}
+							mobileInlineCount
 							action={view.selectedCollection ? (
 								<button
 									className="primary-action"

--- a/builder/src/ui/CreationDialog.jsx
+++ b/builder/src/ui/CreationDialog.jsx
@@ -221,17 +221,20 @@ function ContentChoices({ state, onChange }) {
 			<legend>What should each decade include?</legend>
 			<p>Select one or more ways to organise each Decade.</p>
 			<div className="decades-content-grid">
-				{options.map((option) => (
-					<label key={option.id} data-selected={state.content[option.id] ? "true" : undefined}>
+				{options.map((option) => {
+					const selected = state.content[option.id];
+					return <label key={option.id} data-selected={selected ? "true" : undefined}>
 						<input
+							className="visually-hidden selectable-card-checkbox"
 							type="checkbox"
-							checked={state.content[option.id]}
-							disabled={state.content[option.id] && selectedCount === 1}
+							checked={selected}
+							disabled={selected && selectedCount === 1}
 							onChange={(event) => onChange(Object.freeze({ ...state.content, [option.id]: event.target.checked }))}
 						/>
+						<span className="selectable-card-indicator" data-selection-indicator="true" data-selection-state={selected ? "selected" : "unselected"} aria-hidden="true">{selected ? "✓" : ""}</span>
 						<span><strong>{option.label}</strong><small>{option.description}</small></span>
-					</label>
-				))}
+					</label>;
+				})}
 			</div>
 		</fieldset>
 	);

--- a/builder/src/ui/ExactImageUrlField.jsx
+++ b/builder/src/ui/ExactImageUrlField.jsx
@@ -20,6 +20,8 @@ export function ExactImageUrlField({
 	prefix,
 	preserved,
 	previewShape,
+	previewHidden = false,
+	previewOverlayLabel = null,
 	descriptionId = null,
 	onChange,
 }) {
@@ -53,10 +55,11 @@ export function ExactImageUrlField({
 				</div>
 				{hasUrl && !previewFailure.failed ? (
 					<div
-						className="folder-artwork-preview-frame"
+						className={`folder-artwork-preview-frame${previewHidden ? " is-preview-hidden" : ""}`}
 						data-artwork-preview={field}
 						data-artwork-preview-kind={preview}
 						data-artwork-preview-shape={previewShape}
+						data-artwork-preview-visible={previewHidden ? "false" : "true"}
 						aria-hidden="true"
 					>
 						<img
@@ -70,6 +73,7 @@ export function ExactImageUrlField({
 							draggable="false"
 							onError={previewFailure.markFailed}
 						/>
+						{previewHidden && previewOverlayLabel ? <span className="folder-artwork-preview-overlay">{previewOverlayLabel}</span> : null}
 					</div>
 				) : null}
 			</div>

--- a/builder/src/ui/FolderArtworkFields.jsx
+++ b/builder/src/ui/FolderArtworkFields.jsx
@@ -206,6 +206,8 @@ function artworkField({ descriptor, values, original, touched, prefix, suggestio
 				<ExactImageUrlField
 					{...common}
 					previewShape={previewShape(preview, values?.tileShape)}
+					previewHidden={field === "focusGifUrl" && values?.focusGifEnabled !== true}
+					previewOverlayLabel={field === "focusGifUrl" ? "Hidden in Nuvio" : null}
 					descriptionId={descriptionId}
 				/>
 				<SuggestedArtwork
@@ -321,8 +323,10 @@ export function FolderArtworkFields({
 							{slug === "focus" ? (
 								<div className="editor-switch-field folder-focus-enabled-field is-content-sized" data-editor-field="focusGifEnabled">
 									<PresentationSwitch
-										label="Enable focus artwork"
-										description="Use this artwork for the focused state."
+										label="Show Focus GIF"
+										description={values?.focusGifEnabled === true
+											? "Shown when focused."
+											: "Hidden in Nuvio; the URL is kept."}
 										descriptionId={`${prefix}-focus-enabled-help`}
 										controlName="focusGifEnabled"
 										checked={values?.focusGifEnabled === true}

--- a/builder/src/ui/PeopleSourceFlow.jsx
+++ b/builder/src/ui/PeopleSourceFlow.jsx
@@ -264,9 +264,10 @@ function CombinationControls({ person, configuration, loading, onToggle, compact
 			<div>
 				{PEOPLE_SOURCE_COMBINATIONS.map((combination) => {
 					const count = sourceCount(person, combination.countKey, loading);
+					const selected = configuration?.combinations.includes(combination.id) ?? false;
 					if (pills) return (
 						<label className="people-source-pill" data-people-role={combination.role} data-count-state={count.state} key={combination.id}>
-							<input type="checkbox" checked={configuration?.combinations.includes(combination.id) ?? false} disabled={loading} aria-label={`${combination.label}, ${count.text}`} onChange={() => onToggle(combination.id)} />
+							<input type="checkbox" checked={selected} disabled={loading} aria-label={`${combination.label}, ${count.text}`} onChange={() => onToggle(combination.id)} />
 							<span className="people-source-pill-check" aria-hidden="true">✓</span>
 							<strong>{combination.label}</strong>
 							{showCounts ? <em aria-hidden="true">{count.compactText}</em> : null}
@@ -274,8 +275,9 @@ function CombinationControls({ person, configuration, loading, onToggle, compact
 					);
 					return (
 						<label key={combination.id} data-count-state={count.state}>
-							<input type="checkbox" checked={configuration?.combinations.includes(combination.id) ?? false} disabled={loading} onChange={() => onToggle(combination.id)} />
-							<span><strong>{combination.label}</strong>{compact ? null : <small>{combination.tmdbSourceType} · {combination.mediaType}</small>}</span>
+							<input className="visually-hidden selectable-card-checkbox" type="checkbox" checked={selected} disabled={loading} onChange={() => onToggle(combination.id)} />
+							<span className="selectable-card-indicator" data-selection-indicator="true" data-selection-state={selected ? "selected" : "unselected"} aria-hidden="true">{selected ? "✓" : ""}</span>
+							<span><strong>{combination.label}</strong>{compact ? null : <small>{combination.role === "directing" ? "Directing" : "Acting"} · {combination.media === "series" ? "Series" : "Movies"}</small>}</span>
 							{showCounts ? <em>{count.text}</em> : null}
 						</label>
 					);
@@ -1131,7 +1133,7 @@ export function PeopleSourceFlow({
 								<PeopleSearchStep context={context} headingRef={searchHeadingRef} input={input} inputRef={inputRef} parsedInput={parsedInput} lookupState={lookupState} searchData={searchData} selection={selection} loadingPersonId={loadingPersonId} selectionError={selectionError} onInputChange={handleInputChange} onRetryLookup={() => setRetryGeneration((value) => value + 1)} onActivateResult={activateResult} onChangePage={setPage} onRemoveSelected={removePerson} />
 							) : step === PEOPLE_SOURCE_STEPS.CONFIGURE ? (
 								<section ref={configureRef} className="people-configure" aria-labelledby="people-configure-title" tabIndex={-1}>
-									<div className="add-source-section-heading"><div><p className="panel-kicker">Configure</p><h3 id="people-configure-title">{context === "folder" ? "Choose sources" : `${configuredEntries.length} People folders`}</h3></div></div>
+									<div className="add-source-section-heading"><div><p className="panel-kicker">Configure</p><h3 id="people-configure-title">{context === "folder" ? "Choose sources" : `${configuredEntries.length} People folder${configuredEntries.length === 1 ? "" : "s"}`}</h3></div></div>
 									{multiContext ? <PeopleConfigurationModeControls mode={configurationMode} sharedCombinations={sharedCombinations} onModeChange={changeConfigurationMode} onToggleShared={(combinationId) => toggleCombination(null, combinationId)} /> : null}
 									{hierarchy ? <SemanticSortChoices options={PEOPLE_SOURCE_SORT_OPTIONS} selectedId={sortOptionId} name="people-hierarchy-sort" legend="Sort titles by" onChange={(nextSortOptionId) => { setSortOptionId(nextSortOptionId); setApplyDiagnostic(null); }} /> : null}
 									{applyDiagnostic ? <div className="editor-diagnostics" role="alert"><p>{applyDiagnostic.message}</p></div> : null}

--- a/builder/src/ui/SourceEditorDialog.jsx
+++ b/builder/src/ui/SourceEditorDialog.jsx
@@ -124,6 +124,14 @@ function SourceIdentity({ adapter, draft }) {
 	);
 }
 
+function PeopleSourceIdentity({ draft }) {
+	return (
+		<p className="source-edit-people-identity" aria-label={`TMDB person ${draft.tmdbId}`}>
+			TMDB person <strong>{draft.tmdbId}</strong>
+		</p>
+	);
+}
+
 function SourceTitleField({ draft, titleInputRef, error, onChange, helperText = null }) {
 	const nameIsAutoManaged = draft.titleMode === "auto"
 		|| (draft.selectedCollectionName !== null && draft.title === draft.selectedCollectionName);
@@ -152,12 +160,11 @@ function SourceTitleField({ draft, titleInputRef, error, onChange, helperText = 
 	);
 }
 
-const importedSortOptionValue = "__source_edit_imported_sort__";
-
 export function PeopleEditorFields({
 	draft,
 	combinationRef,
 	countState,
+	sortRef,
 	onChange,
 	onDefaultTitle,
 	onRetryCounts,
@@ -165,37 +172,37 @@ export function PeopleEditorFields({
 }) {
 	const combination = PEOPLE_SOURCE_COMBINATIONS.find((entry) => entry.id === draft.combinationId);
 	const sortOptions = peopleSortOptions(combination?.mediaType);
-	const normalSortSelected = sortOptions.some((option) => option.value === draft.sortBy);
-	const sortValue = normalSortSelected ? draft.sortBy : importedSortOptionValue;
-	const importedSortLabel = typeof draft.originalSortBy === "string" && draft.originalSortBy.length > 0
-		? `Current imported value (preserved): ${draft.originalSortBy}`
-		: "Current imported value is not set (preserved)";
+	const selectedSortId = sortOptions.find((option) => option.value === draft.sortBy)?.id ?? null;
 	return (
 		<section className="source-edit-options" aria-labelledby="source-edit-options-title">
 			<div className="add-source-section-heading">
 				<div>
 					<p className="panel-kicker">Role and media</p>
-					<h3 id="source-edit-options-title">Choose this physical source</h3>
+					<h3 id="source-edit-options-title">Choose role and media</h3>
 				</div>
 			</div>
 			<div className="source-edit-combinations" role="radiogroup" aria-label="People source combination">
-				{PEOPLE_SOURCE_COMBINATIONS.map((combination, index) => (
-					<label key={combination.id} className="source-edit-combination">
-						<input
-							ref={index === 0 ? combinationRef : undefined}
-							type="radio"
-							name="source-edit-people-combination"
-							value={combination.id}
-							checked={draft.combinationId === combination.id}
-							onChange={() => onChange(combination.id)}
-						/>
-						<span>
-							<strong>{combination.sourceTitle}</strong>
-							<small>{combination.tmdbSourceType} · {combination.mediaType}</small>
-						</span>
-						<em data-count-state={countState.status}>{peopleEditCountLabel(countState, combination.countKey)}</em>
-					</label>
-				))}
+				{PEOPLE_SOURCE_COMBINATIONS.map((combination, index) => {
+					const selected = draft.combinationId === combination.id;
+					return (
+						<label key={combination.id} className="source-edit-combination" data-selected={selected ? "true" : undefined}>
+							<input
+								ref={index === 0 ? combinationRef : undefined}
+								className="visually-hidden selectable-card-checkbox"
+								type="radio"
+								name="source-edit-people-combination"
+								value={combination.id}
+								checked={selected}
+								onChange={() => onChange(combination.id)}
+							/>
+							<span className="selectable-card-indicator" data-selection-indicator="true" data-selection-state={selected ? "selected" : "unselected"} aria-hidden="true">{selected ? "✓" : ""}</span>
+							<span>
+								<strong>{combination.role === "directing" ? "Directing" : "Acting"} · {combination.media === "series" ? "Series" : "Movies"}</strong>
+							</span>
+							<em data-count-state={countState.status}>{peopleEditCountLabel(countState, combination.countKey)}</em>
+						</label>
+					);
+				})}
 			</div>
 			{countState.status === "failed" ? (
 				<div className="source-edit-count-failure" role="status">
@@ -207,26 +214,18 @@ export function PeopleEditorFields({
 			<button className="source-edit-title-reset" type="button" onClick={onDefaultTitle}>
 				Use default title
 			</button>
-			<div className="editor-field source-edit-sort-field">
-				<label htmlFor="source-edit-sort">Sort order</label>
-				<select
-					id="source-edit-sort"
-					value={sortValue}
-					onChange={(event) => {
-						const option = sortOptions.find((entry) => entry.value === event.target.value);
-						onSortChange(
-							event.target.value === importedSortOptionValue
-								? draft.originalSortBy
-								: event.target.value,
-							option?.id ?? null,
-						);
-					}}
-				>
-					{!normalSortSelected ? <option value={importedSortOptionValue}>{importedSortLabel}</option> : null}
-					{sortOptions.map((option) => <option key={option.id} value={option.value}>{option.label}</option>)}
-				</select>
-				<p className="editor-field-help">Changing role or media does not rewrite an untouched imported sort value.</p>
-			</div>
+			{selectedSortId === null ? <p className="studio-imported-sort-note">Current imported sort is preserved until you choose a supported sort: {draft.originalSortBy || "not set"}</p> : null}
+			<SemanticSortChoices
+				options={sortOptions}
+				selectedId={selectedSortId}
+				name="people-edit-sort"
+				firstInputRef={sortRef}
+				onChange={(optionId) => {
+					const option = sortOptions.find((entry) => entry.id === optionId);
+					onSortChange(option.value, option.id);
+				}}
+				helper="Changing role or media does not rewrite an untouched imported sort value."
+			/>
 		</section>
 	);
 }
@@ -476,6 +475,7 @@ export function SourceEditorDialog({
 	const scrollRef = useRef(null);
 	const titleInputRef = useRef(null);
 	const combinationRef = useRef(null);
+	const peopleSortRef = useRef(null);
 	const chooseButtonRef = useRef(null);
 	const studioSortRef = useRef(null);
 	const networkSortRef = useRef(null);
@@ -527,7 +527,7 @@ export function SourceEditorDialog({
 	usePrePaintLayoutEffect(() => {
 		const unlockBody = lockAddSourceDocumentBody();
 		const stopObservingViewport = observeAddSourceViewport(setViewportStyle);
-		focusElementWithoutScroll(titleInputRef.current ?? networkSortRef.current ?? studioSortRef.current ?? streamingSortRef.current ?? decadeSortRef.current ?? genreSortRef.current ?? dialogRef.current);
+		focusElementWithoutScroll(titleInputRef.current ?? peopleSortRef.current ?? networkSortRef.current ?? studioSortRef.current ?? streamingSortRef.current ?? decadeSortRef.current ?? genreSortRef.current ?? dialogRef.current);
 		return () => {
 			stopObservingViewport();
 			unlockBody();
@@ -629,7 +629,7 @@ export function SourceEditorDialog({
 	useEffect(() => {
 		if (!failure || !pendingFailureFocusRef.current) return;
 		pendingFailureFocusRef.current = false;
-		const sortRef = networkSortRef.current ? networkSortRef : streamingSortRef.current ? streamingSortRef : decadeSortRef.current ? decadeSortRef : genreSortRef.current ? genreSortRef : studioSortRef;
+		const sortRef = peopleSortRef.current ? peopleSortRef : networkSortRef.current ? networkSortRef : streamingSortRef.current ? streamingSortRef : decadeSortRef.current ? decadeSortRef : genreSortRef.current ? genreSortRef : studioSortRef;
 		const invalidField = firstMountedInvalidField(failure, { sort: sortRef, title: titleInputRef });
 		if (invalidField) {
 			scrollFieldIntoViewIfNeeded(invalidField, scrollRef.current);
@@ -751,6 +751,8 @@ export function SourceEditorDialog({
 											? "Update this Genre source name, title order and supported filters. Genre ID and media stay fixed."
 										: session.adapterId === DECADE_SOURCE_EDITOR_ID
 											? "Update this Decade source name, title order and supported filters. Period, media and included Genre stay fixed."
+										: session.adapterId === PEOPLE_SOURCE_EDITOR_ID
+											? "Update this People source role, media, name and title order."
 									: "Change only the supported fields for this physical source."}
 						</p>
 					</header>
@@ -773,7 +775,11 @@ export function SourceEditorDialog({
 									{failure ? (
 										<SourceEditErrorPanel result={failure} alertRef={diagnosticRef} />
 									) : null}
-									{![STUDIO_SOURCE_EDITOR_ID, NETWORK_SOURCE_EDITOR_ID, STREAMING_SOURCE_EDITOR_ID, DECADE_SOURCE_EDITOR_ID, GENRE_SOURCE_EDITOR_ID].includes(session.adapterId) ? <SourceIdentity adapter={adapter} draft={draft} /> : null}
+									{session.adapterId === PEOPLE_SOURCE_EDITOR_ID
+										? <PeopleSourceIdentity draft={draft} />
+										: ![STUDIO_SOURCE_EDITOR_ID, NETWORK_SOURCE_EDITOR_ID, STREAMING_SOURCE_EDITOR_ID, DECADE_SOURCE_EDITOR_ID, GENRE_SOURCE_EDITOR_ID].includes(session.adapterId)
+											? <SourceIdentity adapter={adapter} draft={draft} />
+											: null}
 									{session.adapterId !== NETWORK_SOURCE_EDITOR_ID ? <SourceTitleField
 											draft={draft}
 											titleInputRef={titleInputRef}
@@ -797,6 +803,7 @@ export function SourceEditorDialog({
 											draft={draft}
 											combinationRef={combinationRef}
 											countState={peopleCountState}
+											sortRef={peopleSortRef}
 											onChange={(combinationId) => {
 												setDraft((current) => choosePeopleSourceCombination(current, combinationId));
 												setFailure(null);

--- a/builder/src/ui/StudioSourceFlow.jsx
+++ b/builder/src/ui/StudioSourceFlow.jsx
@@ -243,8 +243,9 @@ export function StudioConfigureStep({
 						const duplicate = duplicateMedia.has(option.mediaType);
 						const count = currentCountText(option, counts[option.countKey]);
 						return (
-							<label key={option.id} data-count-state={count.state} data-source-supported={option.supported ? "true" : "false"} data-source-duplicate={duplicate ? "true" : undefined}>
-								<input type="checkbox" checked={choices.includes(option.id)} disabled={!option.supported || duplicate} onChange={() => onToggle(option.id)} />
+							<label className="studio-source-choice" key={option.id} data-count-state={count.state} data-source-supported={option.supported ? "true" : "false"} data-source-duplicate={duplicate ? "true" : undefined}>
+								<input className="visually-hidden selectable-card-checkbox" type="checkbox" checked={choices.includes(option.id)} disabled={!option.supported || duplicate} onChange={() => onToggle(option.id)} />
+								<span className="selectable-card-indicator" data-selection-indicator="true" data-selection-state={choices.includes(option.id) ? "selected" : "unselected"} aria-hidden="true">{choices.includes(option.id) ? "✓" : ""}</span>
 								<span>
 									<strong>{option.label}</strong>
 									<small>

--- a/tests/builder-add-source-ui.test.mjs
+++ b/tests/builder-add-source-ui.test.mjs
@@ -210,8 +210,9 @@ test("selected empty folder exposes shared Add actions and an intentional inline
 	assert.equal((markup.match(/data-action="add-source-empty"/g) ?? []).length, 1);
 	assert.equal(markup.includes('data-action="add-source-after-list"'), false);
 	assert.ok(markup.includes("Add first source"));
+	assert.equal((markup.match(/class="panel-title-inline-count mobile-only"/g) ?? []).length, 3);
 	assert.ok(markup.includes('class="panel-title-inline-count mobile-only"> · 0</span>'));
-	assert.ok(markup.includes("panel-count panel-count-desktop-only"));
+	assert.equal((markup.match(/panel-count panel-count-desktop-only/g) ?? []).length, 3);
 });
 
 test("selected populated folder exposes header and trailing Add entry points", () => {
@@ -933,13 +934,13 @@ test("responsive CSS provides an opaque full Visual Viewport task surface and sa
 	assert.match(styles, /\.add-source-portal\s*\{[\s\S]*z-index:\s*var\(--layer-add-source\)[\s\S]*isolation:\s*isolate/);
 	assert.match(styles, /\.add-source-dialog\s*\{[\s\S]*width:\s*100%[\s\S]*height:\s*100%/);
 	assert.match(styles, /\.add-source-scroll\s*\{[\s\S]*overflow-y:\s*auto[\s\S]*overscroll-behavior:\s*contain/);
-	assert.match(styles, /@media \(max-width: 899px\)[\s\S]*\.add-source-portal\s*\{[\s\S]*background:\s*rgb\(7 24 33\)/);
-	assert.match(styles, /@media \(max-width: 899px\)[\s\S]*\.settings-modal-backdrop\.add-source-backdrop\s*\{[\s\S]*padding:\s*0[\s\S]*background:\s*rgb\(7 24 33\)/);
-	assert.match(styles, /@media \(max-width: 899px\)[\s\S]*\.add-source-dialog\s*\{[\s\S]*isolation:\s*isolate[\s\S]*background:\s*rgb\(7 24 33\)[\s\S]*border:\s*0[\s\S]*border-radius:\s*0/);
-	assert.match(styles, /@media \(max-width: 899px\)[\s\S]*\.panel-count\.panel-count-desktop-only\s*\{\s*display:\s*none/);
+	assert.match(styles, /@media \(max-width: 899\.98px\)[\s\S]*\.add-source-portal\s*\{[\s\S]*background:\s*rgb\(7 24 33\)/);
+	assert.match(styles, /@media \(max-width: 899\.98px\)[\s\S]*\.settings-modal-backdrop\.add-source-backdrop\s*\{[\s\S]*padding:\s*0[\s\S]*background:\s*rgb\(7 24 33\)/);
+	assert.match(styles, /@media \(max-width: 899\.98px\)[\s\S]*\.add-source-dialog\s*\{[\s\S]*isolation:\s*isolate[\s\S]*background:\s*rgb\(7 24 33\)[\s\S]*border:\s*0[\s\S]*border-radius:\s*0/);
+	assert.match(styles, /@media \(max-width: 899\.98px\)[\s\S]*\.panel-count\.panel-count-desktop-only\s*\{\s*display:\s*none/);
 	assert.match(styles, /\.add-source-review-poster-frame\s*\{[\s\S]*width:\s*clamp\(180px,\s*48vw,\s*220px\)/);
-	assert.match(styles, /@media \(max-width: 899px\) and \(max-height: 600px\)[\s\S]*width:\s*clamp\(140px,\s*40vw,\s*180px\)/);
-	assert.match(styles, /@media \(min-width: 600px\) and \(max-width: 899px\) and \(max-height: 600px\)[\s\S]*grid-template-columns:\s*180px minmax\(0,\s*1fr\)/);
+	assert.match(styles, /@media \(max-width: 899\.98px\) and \(max-height: 600px\)[\s\S]*width:\s*clamp\(140px,\s*40vw,\s*180px\)/);
+	assert.match(styles, /@media \(min-width: 600px\) and \(max-width: 899\.98px\) and \(max-height: 600px\)[\s\S]*grid-template-columns:\s*180px minmax\(0,\s*1fr\)/);
 	assert.match(styles, /\.add-source-result-poster,[\s\S]*\.add-source-review-poster\s*\{[\s\S]*object-fit:\s*contain/);
 	assert.equal(/\.add-source-review-poster\s*\{[^}]*object-fit:\s*cover/s.test(styles), false);
 	assert.match(styles, /\.add-source-recipe dl > div\s*\{[\s\S]*min-width:\s*0/);

--- a/tests/builder-decades-ui.test.mjs
+++ b/tests/builder-decades-ui.test.mjs
@@ -521,6 +521,10 @@ test("structure, ordering, and shared presentation choices render schematic prev
 	state = updateDecadesCreationMedia(state, "both");
 	state = { ...state, layout: "mixed-collection", content: { wholeDecade: true, individualYears: true, genreBreakdown: false } };
 	const markup = renderToStaticMarkup(createElement(DecadesOptionsStep, { state, onStateChange() {} }));
+	assert.equal((markup.match(/class="visually-hidden selectable-card-checkbox" type="checkbox"/g) ?? []).length, 3);
+	assert.equal((markup.match(/data-selection-indicator="true"/g) ?? []).length, 3);
+	assert.equal((markup.match(/data-selection-state="selected"/g) ?? []).length, 2);
+	assert.equal((markup.match(/data-selection-state="unselected"/g) ?? []).length, 1);
 	for (const marker of ['data-structure-preview="separate"', 'data-structure-preview="mixed"', "Movie Decades", "TV Decades", "Display order", "Source grouping", "Folders", "Inside"]) assert.ok(markup.includes(marker), marker);
 	for (const label of ["Newest Decades, Oldest Years", "Newest throughout", "Oldest throughout"]) assert.ok(markup.includes(`>${label}<`), label);
 	assert.equal((markup.match(/name="decades-display-order"/g) ?? []).length, 3);

--- a/tests/builder-folder-card-artwork-mounted.test.mjs
+++ b/tests/builder-folder-card-artwork-mounted.test.mjs
@@ -526,7 +526,7 @@ test("mounted Folder settings previews stay grouped, bounded, exact, and single-
 	assert.deepEqual(mountedResults.settingsWidths.map((result) => result.width), [360, 384, 393, 402, 412, 899, 900, 901, 1280]);
 	for (const result of mountedResults.settingsWidths) {
 		assert.equal(result.groupCount, 4, `${result.width}px group count`);
-		assert.deepEqual(result.groupNames, ["Tile", "Hero / Background", "Branding", "Focus"], `${result.width}px groups`);
+		assert.deepEqual(result.groupNames, ["Tile", "Hero / Background", "Branding", "Focus GIF"], `${result.width}px groups`);
 		assert.equal(result.imageCount, 4, `${result.width}px image previews`);
 		assert.equal(result.noVideoOnOpen, true, `${result.width}px video opt-in`);
 		assert.equal(result.videoFieldPresent, true, `${result.width}px compatibility field`);
@@ -546,7 +546,7 @@ test("mounted Folder settings previews stay grouped, bounded, exact, and single-
 			"Background image for the folder.",
 			"Existing video background for this folder.",
 			"Transparent title logo.",
-			"Artwork shown when the folder is focused.",
+			"Animated artwork shown when the folder is focused.",
 		], `${result.width}px helper copy`);
 		assert.equal(result.helperLineCounts.every((lineCount) => lineCount <= 2), true, `${result.width}px helper wrapping`);
 		assert.equal(result.artworkSectionHeight <= (result.width < 760 ? 1400 : 1100), true, `${result.width}px artwork height`);
@@ -698,7 +698,7 @@ test("mounted ordinary Folder settings omit Backdrop Video without leaving a Her
 	for (const [index, result] of mountedResults.ordinarySettingsWidths.entries()) {
 		const compatible = mountedResults.settingsWidths[index];
 		assert.equal(result.groupCount, 4, `${result.width}px group count`);
-		assert.deepEqual(result.groupNames, ["Tile", "Hero / Background", "Branding", "Focus"], `${result.width}px groups`);
+		assert.deepEqual(result.groupNames, ["Tile", "Hero / Background", "Branding", "Focus GIF"], `${result.width}px groups`);
 		assert.equal(result.imageCount, 4, `${result.width}px image previews`);
 		assert.equal(result.noVideoOnOpen, true, `${result.width}px no video element`);
 		assert.equal(result.videoFieldPresent, false, `${result.width}px no ordinary video field`);
@@ -719,7 +719,7 @@ test("mounted ordinary Folder settings omit Backdrop Video without leaving a Her
 			"Artwork used for the folder tile.",
 			"Background image for the folder.",
 			"Transparent title logo.",
-			"Artwork shown when the folder is focused.",
+			"Animated artwork shown when the folder is focused.",
 		], `${result.width}px ordinary helper copy`);
 		assert.equal(result.helperLineCounts.every((lineCount) => lineCount <= 2), true, `${result.width}px helper wrapping`);
 		assert.equal(result.imageAttributesSafe, true, `${result.width}px image behavior`);
@@ -1016,7 +1016,7 @@ test("mounted nonblank artwork stays quiet until deliberately cleared", () => {
 test("mounted Request artwork is safe external navigation and changes no draft or project state", () => {
 	const result = mountedResults.suggestionRequestContract;
 	assert.equal(result.text, "Request artwork ↗");
-	assert.match(result.ariaLabel, /Focus artwork URL \(opens in a new tab\)/);
+	assert.match(result.ariaLabel, /Focus GIF URL \(opens in a new tab\)/);
 	assert.match(result.href, /^https:\/\/github\.com\/davecollections\/nuvio-people-assets\/issues\/new\?/);
 	const requestUrl = new URL(result.href);
 	assert.equal(requestUrl.searchParams.get("title"), "Artwork request: Kátia Lund — Focus (Poster)");

--- a/tests/builder-folder-card-artwork-mounted.test.mjs
+++ b/tests/builder-folder-card-artwork-mounted.test.mjs
@@ -546,7 +546,7 @@ test("mounted Folder settings previews stay grouped, bounded, exact, and single-
 			"Background image for the folder.",
 			"Existing video background for this folder.",
 			"Transparent title logo.",
-			"Animated artwork shown when the folder is focused.",
+			"Animated artwork when focused.",
 		], `${result.width}px helper copy`);
 		assert.equal(result.helperLineCounts.every((lineCount) => lineCount <= 2), true, `${result.width}px helper wrapping`);
 		assert.equal(result.artworkSectionHeight <= (result.width < 760 ? 1400 : 1100), true, `${result.width}px artwork height`);
@@ -719,7 +719,7 @@ test("mounted ordinary Folder settings omit Backdrop Video without leaving a Her
 			"Artwork used for the folder tile.",
 			"Background image for the folder.",
 			"Transparent title logo.",
-			"Animated artwork shown when the folder is focused.",
+			"Animated artwork when focused.",
 		], `${result.width}px ordinary helper copy`);
 		assert.equal(result.helperLineCounts.every((lineCount) => lineCount <= 2), true, `${result.width}px helper wrapping`);
 		assert.equal(result.imageAttributesSafe, true, `${result.width}px image behavior`);

--- a/tests/builder-hierarchy-deletion.test.mjs
+++ b/tests/builder-hierarchy-deletion.test.mjs
@@ -741,7 +741,7 @@ test("styles keep Add, actions menus, dialog, and responsive layouts touch-safe 
 	);
 	assert.match(
 		styles,
-		/@media \(min-width: 900px\) and \(max-width: 1023px\)[\s\S]*\.app-header\s*\{[\s\S]*grid-template-columns:\s*minmax\(0,\s*1fr\)/,
+		/@media \(min-width: 900px\) and \(max-width: 1023\.98px\)[\s\S]*\.app-header\s*\{[\s\S]*grid-template-columns:\s*minmax\(0,\s*1fr\)/,
 	);
 	assert.match(
 		styles,

--- a/tests/builder-network-hierarchy-ui.test.mjs
+++ b/tests/builder-network-hierarchy-ui.test.mjs
@@ -221,7 +221,7 @@ test("required responsive owner widths retain 5-mobile and 10-desktop poster beh
 	const widths = [360, 384, 393, 402, 412, 899, 900, 901, 1280];
 	assert.deepEqual(widths.filter((width) => width <= 520), [360, 384, 393, 402, 412]);
 	assert.deepEqual(widths.filter((width) => width >= 900), [900, 901, 1280]);
-	assert.match(styles, /@media \(max-width: 899px\)[\s\S]*\.add-source-dialog/);
+	assert.match(styles, /@media \(max-width: 899\.98px\)[\s\S]*\.add-source-dialog/);
 	assert.match(styles, /@media \(min-width: 900px\)[\s\S]*\.add-source-dialog/);
 	assert.match(styles, /\.add-source-scroll\s*\{[^}]*overflow-y:\s*auto/);
 	assert.match(styles, /\.add-source-actions\s*\{[^}]*safe-area-inset-bottom/);

--- a/tests/builder-network-ui.test.mjs
+++ b/tests/builder-network-ui.test.mjs
@@ -236,7 +236,7 @@ test("Network Source Edit renders fixed linked identity, count, and editable sem
 test("Network flow reuses proven mobile dialog controls at every required width", () => {
 	const styles = read("builder/src/styles.css");
 	for (const width of [360, 384, 393, 402, 412]) assert.ok(width <= 520);
-	assert.match(styles, /@media \(max-width: 899px\)[\s\S]*\.studio-source-dialog[\s\S]*max-height:\s*100dvh/);
+	assert.match(styles, /@media \(max-width: 899\.98px\)[\s\S]*\.studio-source-dialog[\s\S]*max-height:\s*100dvh/);
 	assert.match(styles, /@media \(max-width: 520px\)[\s\S]*\.studio-result\s*\{[^}]*grid-template-columns:\s*64px minmax\(0, 1fr\)/);
 	assert.match(styles, /@media \(max-width: 520px\)[\s\S]*\.studio-configure-identity\s*\{[^}]*grid-template-columns:\s*64px minmax\(0, 1fr\) auto/);
 	assert.match(styles, /\.studio-configure-actions \.studio-add-all\s*\{[^}]*min-height:\s*44px/);

--- a/tests/builder-node-editing.test.mjs
+++ b/tests/builder-node-editing.test.mjs
@@ -2155,7 +2155,7 @@ test("folder editor keeps unique IDs, valid descriptions, one h1, and one local 
 		"Artwork used for the folder tile.",
 		"Background image for the folder.",
 		"Transparent title logo.",
-		"Animated artwork shown when the folder is focused.",
+		"Animated artwork when focused.",
 	]) assert.ok(artwork.includes(helper), helper);
 	assert.equal(artwork.includes("Existing video background for this folder."), false);
 	assert.equal(artwork.includes("Leave blank to clear it."), false);

--- a/tests/builder-node-editing.test.mjs
+++ b/tests/builder-node-editing.test.mjs
@@ -2146,7 +2146,7 @@ test("folder editor keeps unique IDs, valid descriptions, one h1, and one local 
 	const artworkEnd = markup.indexOf('<div class="editor-diagnostics"', artworkStart);
 	const artwork = markup.slice(artworkStart, artworkEnd);
 	assert.ok(artwork.includes('<h3 id="node-editor-folder-artwork-heading">Artwork</h3>'));
-	for (const marker of ["Tile artwork URL", "Backdrop Image URL", "Title Logo URL", "Focus artwork URL", "Enable focus artwork"]) assert.ok(artwork.includes(marker), marker);
+	for (const marker of ["Tile artwork URL", "Backdrop Image URL", "Title Logo URL", "Focus GIF URL", "Show Focus GIF"]) assert.ok(artwork.includes(marker), marker);
 	assert.equal(artwork.includes("Backdrop Video URL"), false);
 	assert.equal(artwork.includes('data-editor-field="heroVideoUrl"'), false);
 	assert.equal(artwork.includes("Fallback emoji"), false);
@@ -2155,7 +2155,7 @@ test("folder editor keeps unique IDs, valid descriptions, one h1, and one local 
 		"Artwork used for the folder tile.",
 		"Background image for the folder.",
 		"Transparent title logo.",
-		"Artwork shown when the folder is focused.",
+		"Animated artwork shown when the folder is focused.",
 	]) assert.ok(artwork.includes(helper), helper);
 	assert.equal(artwork.includes("Existing video background for this folder."), false);
 	assert.equal(artwork.includes("Leave blank to clear it."), false);
@@ -2268,12 +2268,26 @@ test("folder settings render exact draft artwork previews with safe media defaul
 	}
 	assert.ok(openingTag(artwork, 'data-artwork-preview="coverImageUrl"').includes('data-artwork-preview-shape="poster"'));
 	assert.ok(openingTag(artwork, 'data-artwork-preview="focusGifUrl"').includes('data-artwork-preview-shape="poster"'));
+	assert.ok(openingTag(artwork, 'data-artwork-preview="focusGifUrl"').includes('data-artwork-preview-visible="true"'));
+	assert.equal(artwork.includes("Hidden in Nuvio"), false);
 	assert.ok(openingTag(artwork, 'data-artwork-preview="heroBackdropUrl"').includes('data-artwork-preview-shape="wide"'));
 	assert.ok(openingTag(artwork, 'data-artwork-preview="titleLogoUrl"').includes('data-artwork-preview-shape="logo"'));
 	assert.equal((artwork.match(/<video/g) ?? []).length, 0);
 	assert.equal((artwork.match(/>Preview video<\/button>/g) ?? []).length, 1);
 	assert.ok(artwork.includes("Existing video background for this folder."));
 	assert.equal(artwork.includes("https://saved.example/backdrop.mp4"), false);
+
+	const hiddenFocusDraft = updateNodeEditorField(draft, "focusGifEnabled", false);
+	const hiddenFocusMarkup = renderWorkspace(controller, { draft: hiddenFocusDraft });
+	const hiddenFocusPreview = openingTag(hiddenFocusMarkup, 'data-artwork-preview="focusGifUrl"');
+	assert.ok(hiddenFocusPreview.includes("is-preview-hidden"));
+	assert.ok(hiddenFocusPreview.includes('data-artwork-preview-visible="false"'));
+	assert.ok(hiddenFocusMarkup.includes("Hidden in Nuvio"));
+	assert.ok(hiddenFocusMarkup.includes(`value="${draftUrls.focusGifUrl}"`));
+	assert.ok(hiddenFocusMarkup.includes(`src="${draftUrls.focusGifUrl}"`));
+	const restoredFocusMarkup = renderWorkspace(controller, { draft: updateNodeEditorField(hiddenFocusDraft, "focusGifEnabled", true) });
+	assert.ok(openingTag(restoredFocusMarkup, 'data-artwork-preview="focusGifUrl"').includes('data-artwork-preview-visible="true"'));
+	assert.equal(restoredFocusMarkup.includes("Hidden in Nuvio"), false);
 
 	const landscapeMarkup = renderWorkspace(controller, {
 		draft: updateNodeEditorField(draft, "tileShape", "LANDSCAPE"),

--- a/tests/builder-people-ui.test.mjs
+++ b/tests/builder-people-ui.test.mjs
@@ -394,8 +394,10 @@ test("configuration exposes four direct combinations with inline counts and zero
 		onRemove: null,
 	}));
 	for (const label of ["Acting Movies", "Acting Series", "Directed Movies", "Directed Series"]) assert.ok(markup.includes(label), label);
-	assert.ok(markup.includes("PERSON · MOVIE"));
-	assert.ok(markup.includes("DIRECTOR · TV"));
+	assert.ok(markup.includes("Acting · Movies"));
+	assert.ok(markup.includes("Directing · Series"));
+	assert.equal(markup.includes("PERSON · MOVIE"), false);
+	assert.equal(markup.includes("DIRECTOR · TV"), false);
 	assert.ok(markup.includes("No titles found"));
 	assert.ok(markup.includes("4 titles"));
 	assert.ok(markup.includes("Refresh title counts"));
@@ -406,6 +408,8 @@ test("configuration exposes four direct combinations with inline counts and zero
 	assert.ok(markup.includes('class="tmdb-review-identity"'));
 	assert.ok(markup.includes('class="tmdb-review-identity-actions"'));
 	assert.equal((markup.match(/type="checkbox"/g) ?? []).length, 4);
+	assert.equal((markup.match(/class="visually-hidden selectable-card-checkbox" type="checkbox"/g) ?? []).length, 4);
+	assert.equal((markup.match(/data-selection-indicator="true"/g) ?? []).length, 4);
 	assert.equal(markup.includes("Folder artwork"), false);
 	assert.ok(markup.includes('data-profile-state="ready"'));
 	assert.equal(markup.includes("Curated artwork"), false);
@@ -727,7 +731,7 @@ test("shared People flow keeps Add Source behavior and adds a bounded hierarchy 
 	assert.match(flow, /people-title-preview-backdrop nested-modal-backdrop/);
 	assert.match(styles, /\.nested-modal-backdrop\s*\{[\s\S]*z-index:\s*var\(--layer-nested-modal\)/);
 	assert.match(styles, /\.people-title-preview\s*\{[\s\S]*max-height:/);
-	assert.match(styles, /\.people-title-preview-grid\s*\{[\s\S]*grid-template-columns:\s*repeat\(10/);
+	assert.match(styles, /\.people-title-preview-grid\s*\{[\s\S]*grid-template-columns:\s*repeat\(5/);
 	assert.match(styles, /\.people-bulk-list\s*\{[\s\S]*max-height:[\s\S]*overflow-y:\s*auto/);
 	assert.match(styles, /\.people-bulk-list\s*\{[\s\S]*align-content:\s*start;[\s\S]*grid-auto-rows:\s*max-content;/);
 	assert.match(styles, /\.people-bulk-row\s*\{[\s\S]*align-self:\s*start;/);
@@ -735,6 +739,7 @@ test("shared People flow keeps Add Source behavior and adds a bounded hierarchy 
 	assert.match(styles, /\.people-combination-group label:has\(input:checked\)[\s\S]*box-shadow:\s*none/);
 	assert.match(styles, /@media \(max-width: 520px\)[\s\S]*\.people-combination-group\.is-pills > div[\s\S]*grid-template-columns:\s*repeat\(2/);
 	assert.match(styles, /@media \(max-width: 520px\)[\s\S]*\.people-title-preview-grid[\s\S]*grid-template-columns:\s*repeat\(5/);
+	assert.match(flow, /People folder\$\{configuredEntries\.length === 1 \? "" : "s"\}/);
 	assert.match(styles, /\.people-source-dialog\[data-dialog-compact="true"\][\s\S]*height:\s*auto/);
 	assert.match(styles, /@media \(prefers-reduced-motion: reduce\)/);
 	for (const width of [360, 384, 393, 402, 412, 899, 900, 901]) assert.ok(width > 0);

--- a/tests/builder-source-edit-mounted.test.mjs
+++ b/tests/builder-source-edit-mounted.test.mjs
@@ -779,7 +779,7 @@ test("mounted People Configure stays compact, editable, preview-safe, and overfl
 		assert.equal(result.preview.genuineTmdbSources, true, `${width}px genuine TMDB Movie poster sources`);
 		assert.equal(result.preview.modalSurface, true, `${width}px preview modal`);
 		assert.equal(result.preview.outsidePeopleRow, true, `${width}px preview outside row flow`);
-		assert.equal(result.preview.gridColumns, width <= 520 ? 5 : 10, `${width}px preview columns`);
+		assert.equal(result.preview.gridColumns, 5, `${width}px preview columns`);
 		assert.equal(result.preview.posterOnly, true, `${width}px poster-only`);
 		assert.equal(result.preview.noHorizontalOverflow, true, `${width}px preview overflow`);
 		assert.equal(result.preview.headingFocused, true, `${width}px preview focus`);
@@ -1465,6 +1465,17 @@ test("mounted Decades header Back and primary-only footer remain reachable at ev
 		assert.equal(result.bothDefault, true, `${result.width}px Both default`);
 		assert.equal(result.displayOrderChoices, 3, `${result.width}px Display order choices`);
 		assert.equal(result.defaultDisplayOrder, true, `${result.width}px Display order default`);
+		assert.deepEqual(result.contentSelection, {
+			nativeCheckboxes: 3,
+			allVisuallyHidden: true,
+			indicators: 3,
+			selectedState: "selected",
+			selectedTick: "✓",
+			selectedSurface: true,
+			unselectedFocusable: true,
+			toggleSelected: true,
+			toggleRestored: true,
+		}, `${result.width}px Decades content selection language`);
 		assert.equal(result.oldChronologyAbsent, true, `${result.width}px redundant chronology controls`);
 	}
 });

--- a/tests/builder-source-edit-ui.test.mjs
+++ b/tests/builder-source-edit-ui.test.mjs
@@ -295,14 +295,20 @@ test("People editor opens immediately with four non-blocking counts, title reset
 	assert.equal(collectionCalls.length, 0);
 	assert.equal(peopleCalls.length, 0);
 	for (const text of [
-		"Movie Credits", "Series Credits", "Directed Movies", "Directed Series",
-		"PERSON · MOVIE", "PERSON · TV", "DIRECTOR · MOVIE", "DIRECTOR · TV",
-		"Use default title", "Sort order", "Popular", "Recent", "Top rated",
-		"popularity.desc", "primary_release_date.desc", "vote_average.desc",
+		"Acting · Movies", "Acting · Series", "Directing · Movies", "Directing · Series",
+		"Choose role and media", "Use default title", "Sort titles by", "Popular", "Recent", "Top rated",
 	]) assert.ok(markup.includes(text), text);
+	assert.equal(markup.includes("physical source"), false);
 	assert.equal((markup.match(/name="source-edit-people-combination"/g) ?? []).length, 4);
+	assert.equal((markup.match(/name="people-edit-sort"/g) ?? []).length, 3);
+	assert.equal((markup.match(/class="visually-hidden selectable-card-checkbox"/g) ?? []).length, 4);
+	assert.equal((markup.match(/data-selection-indicator="true"/g) ?? []).length, 4);
+	assert.equal((markup.match(/data-selection-state="selected"/g) ?? []).length, 1);
 	assert.equal((markup.match(/Checking titles…/g) ?? []).length, 4);
-	assert.ok(markup.includes("TMDB · PERSON · 31 · MOVIE"));
+	assert.ok(markup.includes("TMDB person <strong>31</strong>"));
+	for (const raw of ["PERSON · MOVIE", "PERSON · TV", "DIRECTOR · MOVIE", "DIRECTOR · TV", "popularity.desc", "primary_release_date.desc", "vote_average.desc"]) {
+		assert.equal(markup.includes(raw), false, raw);
+	}
 	assert.ok(markup.includes("Source name"));
 	assert.ok(markup.includes("This name updates automatically until you customise it."));
 	assert.equal(markup.includes("Nuvio source title"), false);
@@ -656,12 +662,11 @@ test("People sort UI preserves an unusual imported value until the user changes 
 		onRetryCounts() {},
 		onSortChange() {},
 	}));
-	assert.ok(markup.includes("Current imported value (preserved): Owner.MixedCase"));
-	assert.ok(markup.includes('value="__source_edit_imported_sort__" selected=""'));
-	for (const value of ["popularity.desc", "primary_release_date.desc", "vote_average.desc"]) {
-		assert.ok(markup.includes(`value="${value}"`), value);
-	}
-	assert.equal(markup.includes("first_air_date.desc"), false);
+	assert.ok(markup.includes("Current imported sort is preserved until you choose a supported sort: Owner.MixedCase"));
+	assert.equal((markup.match(/name="people-edit-sort"/g) ?? []).length, 3);
+	for (const value of ["popular", "recent", "top-rated"]) assert.ok(markup.includes(`value="${value}"`), value);
+	assert.equal(markup.includes('name="people-edit-sort" value="popular" checked=""'), false);
+	assert.equal(markup.includes("<select"), false);
 });
 
 test("an open source editor makes the workspace inert and retains one polite success region", () => {
@@ -786,7 +791,7 @@ test("responsive source editor styles are safe-area aware and bounded for every 
 	assert.match(styles, /\.source-edit-sort-field select\s*\{[\s\S]*min-width:\s*0/);
 	assert.match(styles, /@media \(max-width: 420px\)[\s\S]*\.source-edit-identity,[\s\S]*\.source-edit-combinations,[\s\S]*\.source-edit-option-actions\s*\{[\s\S]*minmax\(0,\s*1fr\)/);
 	assert.match(styles, /\.source-edit-actions\s*\{[\s\S]*minmax\(0,\s*1\.5fr\) minmax\(100px,\s*1fr\)/);
-	assert.match(styles, /@media \(max-width: 899px\)[\s\S]*\.source-edit-dialog\s*\{[\s\S]*height:\s*100%[\s\S]*max-height:\s*100%[\s\S]*align-self:\s*stretch/);
+	assert.match(styles, /@media \(max-width: 899\.98px\)[\s\S]*\.source-edit-dialog\s*\{[\s\S]*height:\s*100%[\s\S]*max-height:\s*100%[\s\S]*align-self:\s*stretch/);
 	assert.match(styles, /\.add-source-form\s*\{[\s\S]*grid-template-rows:\s*minmax\(0,\s*1fr\) auto[\s\S]*overflow:\s*hidden/);
 	for (const width of [360, 384, 393, 402, 412]) assert.ok(width <= 420);
 });

--- a/tests/builder-studio-ui.test.mjs
+++ b/tests/builder-studio-ui.test.mjs
@@ -169,11 +169,15 @@ test("Studio Configure presents independent counts and compact semantic sort cho
 	assert.ok(markup.includes('rel="noopener noreferrer"'));
 	assert.ok(markup.includes("Open Pixar on TMDB"));
 	assert.equal((markup.match(/type="checkbox"/g) ?? []).length, 2);
+	assert.equal((markup.match(/class="visually-hidden selectable-card-checkbox" type="checkbox"/g) ?? []).length, 2);
+	assert.equal((markup.match(/class="selectable-card-indicator"/g) ?? []).length, 2);
 	assert.equal((markup.match(/type="radio"/g) ?? []).length, 4);
 	assert.equal((markup.match(/disabled=""/g) ?? []).length, 0);
 	assert.equal((markup.match(/checked=""/g) ?? []).length, 2);
 	assert.equal(markup.includes("<select"), false);
 	assert.equal(markup.includes("Movie Count: 136"), false);
+	const styles = read("builder/src/styles.css");
+	assert.match(styles, /\.studio-source-choice:has\(input:checked\)\s*\{[^}]*box-shadow:\s*none/);
 });
 
 test("Studio search keeps Best Match hidden and exposes only Builder-style overrides and zero toggle", () => {
@@ -548,7 +552,7 @@ test("source-picker return focus and Configure-to-Search state restoration stay 
 test("Studio modal remains single-column, tappable, scroll-safe, and footer-safe at required mobile widths", () => {
 	const styles = read("builder/src/styles.css");
 	for (const width of [360, 384, 393, 402, 412]) assert.ok(width <= 520);
-	assert.match(styles, /@media \(max-width: 899px\)[\s\S]*\.studio-source-dialog[\s\S]*max-height:\s*100dvh/);
+	assert.match(styles, /@media \(max-width: 899\.98px\)[\s\S]*\.studio-source-dialog[\s\S]*max-height:\s*100dvh/);
 	assert.match(styles, /@media \(max-width: 520px\)[\s\S]*\.studio-source-choices > div\s*\{\s*grid-template-columns:\s*minmax\(0, 1fr\)/);
 	assert.match(styles, /\.studio-source-choices label\s*\{[^}]*min-height:\s*68px/);
 	assert.match(styles, /@media \(max-width: 520px\)[\s\S]*\.studio-source-choices label\s*\{[^}]*min-height:\s*60px/);

--- a/tests/builder-ui.test.mjs
+++ b/tests/builder-ui.test.mjs
@@ -680,6 +680,10 @@ test("styles provide mobile protection, touch sizing, focus, desktop panels, and
 	assert.match(styles, /@media \(max-width: 430px\)/);
 	assert.match(styles, /@media \(min-width: 900px\)/);
 	assert.match(styles, /grid-template-columns:\s*minmax\(250px/);
+	assert.match(styles, /@media \(min-width: 900px\) and \(max-width: 1023\.98px\)[\s\S]*\.panel-header h2\s*\{[\s\S]*overflow-wrap:\s*normal[\s\S]*white-space:\s*nowrap/);
+	assert.match(styles, /@media \(min-width: 900px\) and \(max-width: 1023\.98px\)[\s\S]*\.panel-title-inline-count\.mobile-only\s*\{[\s\S]*display:\s*inline/);
+	assert.match(styles, /@media \(min-width: 900px\) and \(max-width: 1023\.98px\)[\s\S]*\.panel-count\.panel-count-desktop-only\s*\{[\s\S]*display:\s*none/);
+	assert.match(styles, /@media \(min-width: 900px\) and \(max-width: 1023\.98px\)[\s\S]*\.source-heading\s*\{[\s\S]*flex-direction:\s*column/);
 	assert.match(styles, /@media \(prefers-reduced-motion: reduce\)/);
 	assert.equal(BUILDER_DESKTOP_BREAKPOINT_PX, 900);
 	assert.equal(BUILDER_DESKTOP_MEDIA_QUERY, "(min-width: 900px)");
@@ -688,6 +692,7 @@ test("styles provide mobile protection, touch sizing, focus, desktop panels, and
 	assert.match(workspace, /selectCreated:\s*desktopViewport/);
 	assert.match(workspace, /desktopViewport \? null : "collections"/);
 	assert.match(workspace, /desktopViewport \? null : "folders"/);
+	for (const width of [360, 384, 393, 402, 412, 899, 900, 901, 1023, 1024, 1280]) assert.ok(width > 0);
 });
 
 test("responsive helper matches the established breakpoint and respects reduced motion for card scrolling", () => {

--- a/tests/fixtures/builder-source-edit-mounted.jsx
+++ b/tests/fixtures/builder-source-edit-mounted.jsx
@@ -3925,6 +3925,23 @@ async function runDecadesActionLayoutScenario() {
 		const primaryRect = primary.getBoundingClientRect();
 		const backRect = back.getBoundingClientRect();
 		const headingFocused = document.activeElement?.id === "decades-options-title";
+		const contentInputs = [...dialog.querySelectorAll('.decades-content-grid input[type="checkbox"]')];
+		const selectedContentCard = dialog.querySelector('.decades-content-grid label[data-selected="true"]');
+		const selectedContentIndicator = selectedContentCard?.querySelector('.selectable-card-indicator');
+		const unselectedContentInput = contentInputs.find((input) => !input.checked);
+		unselectedContentInput.focus({ preventScroll: true });
+		await afterCommittedEffects();
+		const unselectedContentFocusable = document.activeElement === unselectedContentInput;
+		await clickAndSettle(unselectedContentInput);
+		const contentToggleSelected = unselectedContentInput.checked === true
+			&& unselectedContentInput.closest("label")?.dataset.selected === "true"
+			&& unselectedContentInput.nextElementSibling?.dataset.selectionState === "selected"
+			&& unselectedContentInput.nextElementSibling?.textContent === "✓";
+		await clickAndSettle(unselectedContentInput);
+		const contentToggleRestored = unselectedContentInput.checked === false
+			&& unselectedContentInput.closest("label")?.dataset.selected === undefined
+			&& unselectedContentInput.nextElementSibling?.dataset.selectionState === "unselected"
+			&& unselectedContentInput.nextElementSibling?.textContent === "";
 		const disclosures = [...dialog.querySelectorAll("details.decades-advanced-options")];
 		const allCollapsed = disclosures.length === 1 && disclosures.every((details) => !details.open);
 		const scroll = dialog.querySelector(".add-source-scroll");
@@ -3958,6 +3975,17 @@ async function runDecadesActionLayoutScenario() {
 			bothDefault: dialog.querySelector('input[name="decades-media"][value="both"]')?.checked === true,
 			displayOrderChoices: dialog.querySelectorAll('input[name="decades-display-order"]').length,
 			defaultDisplayOrder: dialog.querySelector('input[name="decades-display-order"][value="newest-decades-oldest-years"]')?.checked === true,
+			contentSelection: {
+				nativeCheckboxes: contentInputs.length,
+				allVisuallyHidden: contentInputs.every((input) => input.classList.contains("visually-hidden") && input.classList.contains("selectable-card-checkbox") && input.getBoundingClientRect().width <= 1),
+				indicators: dialog.querySelectorAll('.decades-content-grid .selectable-card-indicator').length,
+				selectedState: selectedContentIndicator?.dataset.selectionState ?? null,
+				selectedTick: selectedContentIndicator?.textContent ?? null,
+				selectedSurface: selectedContentCard?.dataset.selected === "true",
+				unselectedFocusable: unselectedContentFocusable,
+				toggleSelected: contentToggleSelected,
+				toggleRestored: contentToggleRestored,
+			},
 			oldChronologyAbsent: dialog.querySelector('input[name="decades-folder-order"], input[name="decades-year-order"]') === null,
 		};
 	} finally {


### PR DESCRIPTION
Polishes Builder visual consistency without changing domain, model, or schema behavior.

- adds mobile Collection and Folder inline counts
- compacts the hierarchy layout at 900–1023px
- presents People Preview as a 5×2 larger-screen grid
- modernizes People Source Edit and Add presentation with friendlier terminology
- uses shared semantic Sort pills and the current Builder selection/tick language
- standardizes Focus GIF presentation and the `Hidden in Nuvio` state
- cleans up legacy selection indicators in Decades, People, and Studio flows
- tightens Folder artwork spacing after the cross-environment push CI finding

Closes #156