### PR TITLE
Make guided title visibility live and reversible

### DIFF
--- a/builder/src/nuvio/titles.js
+++ b/builder/src/nuvio/titles.js
@@ -26,3 +26,26 @@ export function isValidVisibleNuvioTitle(title) {
 		&& !isInvisibleNuvioTitle(title)
 	);
 }
+
+export function reversibleTitleFieldProps(visibleTitleDraft, hiddenEverywhere) {
+	return Object.freeze({
+		value: hiddenEverywhere ? "" : typeof visibleTitleDraft === "string" ? visibleTitleDraft : "",
+		disabled: hiddenEverywhere,
+	});
+}
+
+export function transitionReversibleTitleDraft({
+	title,
+	visibleTitleDraft,
+	hiddenEverywhere,
+	hiddenTitle = "",
+}) {
+	const rememberedTitle = hiddenEverywhere && isValidVisibleNuvioTitle(title)
+		? title
+		: visibleTitleDraft;
+
+	return Object.freeze({
+		title: hiddenEverywhere ? hiddenTitle : rememberedTitle ?? "",
+		visibleTitleDraft: rememberedTitle,
+	});
+}

--- a/builder/src/source-add/decades-plan.js
+++ b/builder/src/source-add/decades-plan.js
@@ -222,7 +222,7 @@ function folderEditable(title, { folderTileShape, folderTitleVisibility }) {
 	});
 }
 
-function normalizeCollectionTitles(value, roles, errors) {
+function normalizeCollectionTitles(value, roles, errors, visibleTitlesRequired = true) {
 	const defaults = { movies: "Movie Decades", series: "TV Decades", mixed: "Decades" };
 	const supplied = value ?? {};
 	if (!plainObject(supplied) || Object.keys(supplied).some((key) => !roles.includes(key))) {
@@ -231,7 +231,7 @@ function normalizeCollectionTitles(value, roles, errors) {
 	const titles = {};
 	for (const role of roles) {
 		const title = plainObject(supplied) && Object.hasOwn(supplied, role) ? supplied[role] : defaults[role];
-		if (typeof title !== "string" || title.trim().length === 0) {
+		if (typeof title !== "string" || (visibleTitlesRequired && title.trim().length === 0)) {
 			errors.push(diagnostic("INVALID_DECADES_COLLECTION_TITLE", `$decadesPlan.collectionTitles.${role}`, "Collection title proposals must be nonblank strings."));
 		} else titles[role] = title;
 	}
@@ -387,7 +387,7 @@ export function createDecadesHierarchyPlan(project, options) {
 			: sourcePlan.configuration.mediaMode === "series"
 				? ["series"]
 				: layout === "mixed-collection" ? ["mixed"] : ["movies", "series"];
-		collectionTitles = normalizeCollectionTitles(options.collectionTitles, roles, errors);
+		collectionTitles = normalizeCollectionTitles(options.collectionTitles, roles, errors, hideCollectionTitle !== true);
 		if (options.destinationCollectionInternalId !== undefined) errors.push(diagnostic("UNEXPECTED_DECADES_DESTINATION", "$decadesPlan.destinationCollectionInternalId", "New Collection scope does not target an existing collection."));
 	} else if (scope === "new-folder") {
 		if (typeof options.destinationCollectionInternalId !== "string" || options.destinationCollectionInternalId.length === 0) {

--- a/builder/src/source-add/franchise-plan.js
+++ b/builder/src/source-add/franchise-plan.js
@@ -162,7 +162,7 @@ export function createFranchiseHierarchyPlan(project, options) {
 		viewMode = options.viewMode ?? "TABBED_GRID";
 		const requestedShowAllTab = options.showAllTab ?? true;
 		pinToTop = options.pinToTop ?? false;
-		if (typeof collectionTitle !== "string" || !collectionTitle.trim() || collectionTitle !== collectionTitle.trim()) errors.push(diagnostic("INVALID_FRANCHISE_COLLECTION_TITLE", "$franchisePlan.collectionTitle", "The Franchises collection name must be a nonblank trimmed string."));
+		if (typeof collectionTitle !== "string" || (hideCollectionTitle !== true && (!collectionTitle.trim() || collectionTitle !== collectionTitle.trim()))) errors.push(diagnostic("INVALID_FRANCHISE_COLLECTION_TITLE", "$franchisePlan.collectionTitle", "The Franchises collection name must be a nonblank trimmed string."));
 		if (typeof hideCollectionTitle !== "boolean") errors.push(diagnostic("INVALID_FRANCHISE_COLLECTION_TITLE_VISIBILITY", "$franchisePlan.hideCollectionTitle", "Collection title visibility must be true or false."));
 		if (!COLLECTION_VIEW_MODES.has(viewMode)) errors.push(diagnostic("INVALID_FRANCHISE_COLLECTION_VIEW", "$franchisePlan.viewMode", "Choose the existing Tabs or Rows collection layout."));
 		if (typeof requestedShowAllTab !== "boolean" || typeof pinToTop !== "boolean") errors.push(diagnostic("INVALID_FRANCHISE_COLLECTION_OPTIONS", "$franchisePlan", "Collection options must be explicit boolean values."));

--- a/builder/src/source-add/genre-hierarchy-plan.js
+++ b/builder/src/source-add/genre-hierarchy-plan.js
@@ -84,7 +84,7 @@ function titleCollisions(project, title) {
 		.map((collection) => Object.freeze({ collectionInternalId: collection.internalId, collectionTitle: title })));
 }
 
-function normalizeCollectionTitles(value, errors) {
+function normalizeCollectionTitles(value, errors, visibleTitlesRequired = true) {
 	const supplied = value ?? DEFAULT_GENRE_HIERARCHY_COLLECTION_TITLES;
 	if (!plainObject(supplied) || Object.keys(supplied).some((key) => !["movies", "series"].includes(key))) {
 		errors.push(diagnostic("INVALID_GENRE_HIERARCHY_COLLECTION_TITLES", "$genreHierarchy.collectionTitles", "Separate collections require Movie and Series collection names."));
@@ -93,7 +93,7 @@ function normalizeCollectionTitles(value, errors) {
 	const titles = {};
 	for (const role of ["movies", "series"]) {
 		const title = Object.hasOwn(supplied, role) ? supplied[role] : DEFAULT_GENRE_HIERARCHY_COLLECTION_TITLES[role];
-		if (typeof title !== "string" || !title.trim() || title !== title.trim()) {
+		if (typeof title !== "string" || (visibleTitlesRequired && (!title.trim() || title !== title.trim()))) {
 			errors.push(diagnostic("INVALID_GENRE_HIERARCHY_COLLECTION_TITLE", `$genreHierarchy.collectionTitles.${role}`, "Collection names must be nonblank trimmed strings."));
 		} else titles[role] = title;
 	}
@@ -165,11 +165,11 @@ export function createGenreHierarchyPlan(project, options) {
 		const requestedShowAllTab = options.showAllTab ?? true;
 		pinToTop = options.pinToTop ?? false;
 		if (structure === "separate-media-collections") {
-			collectionTitles = normalizeCollectionTitles(options.collectionTitles, errors);
+			collectionTitles = normalizeCollectionTitles(options.collectionTitles, errors, hideCollectionTitle !== true);
 			if (options.collectionTitle !== undefined && options.collectionTitle !== null) errors.push(diagnostic("UNEXPECTED_GENRE_HIERARCHY_COLLECTION_TITLE", "$genreHierarchy.collectionTitle", "Separate collections use Movie and Series collection names."));
 		} else {
 			collectionTitle = options.collectionTitle ?? DEFAULT_GENRE_HIERARCHY_COLLECTION_TITLE;
-			if (typeof collectionTitle !== "string" || !collectionTitle.trim() || collectionTitle !== collectionTitle.trim()) errors.push(diagnostic("INVALID_GENRE_HIERARCHY_COLLECTION_TITLE", "$genreHierarchy.collectionTitle", "The Genres collection name must be a nonblank trimmed string."));
+			if (typeof collectionTitle !== "string" || (hideCollectionTitle !== true && (!collectionTitle.trim() || collectionTitle !== collectionTitle.trim()))) errors.push(diagnostic("INVALID_GENRE_HIERARCHY_COLLECTION_TITLE", "$genreHierarchy.collectionTitle", "The Genres collection name must be a nonblank trimmed string."));
 			if (options.collectionTitles !== undefined && Object.keys(options.collectionTitles ?? {}).length > 0) errors.push(diagnostic("UNEXPECTED_GENRE_HIERARCHY_COLLECTION_TITLES", "$genreHierarchy.collectionTitles", "This structure creates one collection."));
 		}
 		if (typeof hideCollectionTitle !== "boolean") errors.push(diagnostic("INVALID_GENRE_HIERARCHY_COLLECTION_TITLE_VISIBILITY", "$genreHierarchy.hideCollectionTitle", "Collection title visibility must be true or false."));

--- a/builder/src/source-add/network-plan.js
+++ b/builder/src/source-add/network-plan.js
@@ -218,7 +218,7 @@ export function createNetworkHierarchyPlan(project, options) {
 		viewMode = options.viewMode ?? "TABBED_GRID";
 		const requestedShowAllTab = options.showAllTab ?? true;
 		pinToTop = options.pinToTop ?? false;
-		if (typeof collectionTitle !== "string" || !collectionTitle.trim() || collectionTitle !== collectionTitle.trim()) errors.push(diagnostic("INVALID_NETWORK_COLLECTION_TITLE", "$networkPlan.collectionTitle", "The Networks collection name must be a nonblank trimmed string."));
+		if (typeof collectionTitle !== "string" || (hideCollectionTitle !== true && (!collectionTitle.trim() || collectionTitle !== collectionTitle.trim()))) errors.push(diagnostic("INVALID_NETWORK_COLLECTION_TITLE", "$networkPlan.collectionTitle", "The Networks collection name must be a nonblank trimmed string."));
 		if (typeof hideCollectionTitle !== "boolean") errors.push(diagnostic("INVALID_NETWORK_COLLECTION_TITLE_VISIBILITY", "$networkPlan.hideCollectionTitle", "Collection title visibility must be true or false."));
 		if (!COLLECTION_VIEW_MODES.has(viewMode)) errors.push(diagnostic("INVALID_NETWORK_COLLECTION_VIEW", "$networkPlan.viewMode", "Choose the existing Tabs or Rows collection layout."));
 		if (typeof requestedShowAllTab !== "boolean" || typeof pinToTop !== "boolean") errors.push(diagnostic("INVALID_NETWORK_COLLECTION_OPTIONS", "$networkPlan", "Collection options must be explicit boolean values."));

--- a/builder/src/source-add/people-plan.js
+++ b/builder/src/source-add/people-plan.js
@@ -190,7 +190,7 @@ export function createPeopleHierarchyPlan(project, options) {
 		viewMode = options.viewMode ?? "TABBED_GRID";
 		const requestedShowAllTab = options.showAllTab ?? true;
 		pinToTop = options.pinToTop ?? false;
-		if (typeof collectionTitle !== "string" || !collectionTitle.trim() || collectionTitle !== collectionTitle.trim()) errors.push(diagnostic("INVALID_PEOPLE_COLLECTION_TITLE", "$peoplePlan.collectionTitle", "The People collection name must be a nonblank trimmed string."));
+		if (typeof collectionTitle !== "string" || (hideCollectionTitle !== true && (!collectionTitle.trim() || collectionTitle !== collectionTitle.trim()))) errors.push(diagnostic("INVALID_PEOPLE_COLLECTION_TITLE", "$peoplePlan.collectionTitle", "The People collection name must be a nonblank trimmed string."));
 		if (typeof hideCollectionTitle !== "boolean") errors.push(diagnostic("INVALID_PEOPLE_COLLECTION_TITLE_VISIBILITY", "$peoplePlan.hideCollectionTitle", "Collection title visibility must be true or false."));
 		if (!COLLECTION_VIEW_MODES.has(viewMode)) errors.push(diagnostic("INVALID_PEOPLE_COLLECTION_VIEW", "$peoplePlan.viewMode", "Choose the existing Tabs or Rows collection layout."));
 		if (typeof requestedShowAllTab !== "boolean" || typeof pinToTop !== "boolean") errors.push(diagnostic("INVALID_PEOPLE_COLLECTION_OPTIONS", "$peoplePlan", "Collection options must be explicit boolean values."));

--- a/builder/src/source-add/streaming-plan.js
+++ b/builder/src/source-add/streaming-plan.js
@@ -129,7 +129,7 @@ function normalizeProviders(providers, regionCodes, mediaChoice, errors) {
 	return Object.freeze(normalized);
 }
 
-function normalizeFolderTitleOverrides(value, errors) {
+function normalizeFolderTitleOverrides(value, errors, visibleTitlesRequired = true) {
 	if (value === undefined || value === null) return Object.freeze({});
 	if (!plainObject(value)) {
 		errors.push(diagnostic("INVALID_STREAMING_HIERARCHY_FOLDER_TITLES", "$streamingHierarchy.folderTitleOverrides", "Custom Streaming folder names must use stable planned-folder keys."));
@@ -137,7 +137,7 @@ function normalizeFolderTitleOverrides(value, errors) {
 	}
 	const normalized = {};
 	for (const [key, title] of Object.entries(value)) {
-		if (!key || !isValidVisibleNuvioTitle(title)) {
+		if (!key || typeof title !== "string" || (visibleTitlesRequired && !isValidVisibleNuvioTitle(title))) {
 			errors.push(diagnostic("INVALID_STREAMING_HIERARCHY_FOLDER_TITLE", `$streamingHierarchy.folderTitleOverrides.${key}`, "Enter a folder title before applying changes."));
 			continue;
 		}
@@ -383,7 +383,7 @@ export function createStreamingHierarchyPlan(project, options) {
 	const providers = normalizeProviders(options.providers, regionCodes, mediaChoice, errors);
 	const folderTitleVisibility = options.folderTitleVisibility ?? DEFAULT_STREAMING_HIERARCHY_FOLDER_TITLE_VISIBILITY;
 	if (!folderTitleVisibilities.has(folderTitleVisibility)) errors.push(diagnostic("INVALID_STREAMING_HIERARCHY_FOLDER_TITLE_VISIBILITY", "$streamingHierarchy.folderTitleVisibility", "Choose an existing folder-title visibility outcome."));
-	const requestedFolderTitleOverrides = normalizeFolderTitleOverrides(options.folderTitleOverrides, errors);
+	const requestedFolderTitleOverrides = normalizeFolderTitleOverrides(options.folderTitleOverrides, errors, folderTitleVisibility !== "HIDE_EVERYWHERE");
 
 	let collectionTitle = null;
 	let hideCollectionTitle = null;
@@ -397,7 +397,7 @@ export function createStreamingHierarchyPlan(project, options) {
 		viewMode = options.viewMode ?? "TABBED_GRID";
 		showAllTab = normalizeHierarchyShowAllTab(viewMode, options.showAllTab ?? true);
 		pinToTop = options.pinToTop ?? false;
-		if (!canonicalText(collectionTitle) || collectionTitle !== canonicalText(collectionTitle)) errors.push(diagnostic("INVALID_STREAMING_HIERARCHY_COLLECTION_TITLE", "$streamingHierarchy.collectionTitle", "The Streaming Services collection name must be a nonblank trimmed string."));
+		if (typeof collectionTitle !== "string" || (hideCollectionTitle !== true && (!canonicalText(collectionTitle) || collectionTitle !== canonicalText(collectionTitle)))) errors.push(diagnostic("INVALID_STREAMING_HIERARCHY_COLLECTION_TITLE", "$streamingHierarchy.collectionTitle", "The Streaming Services collection name must be a nonblank trimmed string."));
 		if (typeof hideCollectionTitle !== "boolean" || typeof showAllTab !== "boolean" || typeof pinToTop !== "boolean" || !collectionViewModes.has(viewMode)) errors.push(diagnostic("INVALID_STREAMING_HIERARCHY_COLLECTION_PRESENTATION", "$streamingHierarchy", "Choose supported collection presentation values."));
 		if (options.destinationCollectionInternalId !== undefined && options.destinationCollectionInternalId !== null) errors.push(diagnostic("UNEXPECTED_STREAMING_HIERARCHY_DESTINATION", "$streamingHierarchy.destinationCollectionInternalId", "New Collection scope does not target an existing collection."));
 	} else if (scope === "new-folder") {

--- a/builder/src/source-add/studio-plan.js
+++ b/builder/src/source-add/studio-plan.js
@@ -194,7 +194,7 @@ export function createStudioHierarchyPlan(project, options) {
 		viewMode = options.viewMode ?? "TABBED_GRID";
 		const requestedShowAllTab = options.showAllTab ?? true;
 		pinToTop = options.pinToTop ?? false;
-		if (typeof collectionTitle !== "string" || !collectionTitle.trim() || collectionTitle !== collectionTitle.trim()) errors.push(diagnostic("INVALID_STUDIO_COLLECTION_TITLE", "$studioPlan.collectionTitle", "The Studios collection name must be a nonblank trimmed string."));
+		if (typeof collectionTitle !== "string" || (hideCollectionTitle !== true && (!collectionTitle.trim() || collectionTitle !== collectionTitle.trim()))) errors.push(diagnostic("INVALID_STUDIO_COLLECTION_TITLE", "$studioPlan.collectionTitle", "The Studios collection name must be a nonblank trimmed string."));
 		if (typeof hideCollectionTitle !== "boolean") errors.push(diagnostic("INVALID_STUDIO_COLLECTION_TITLE_VISIBILITY", "$studioPlan.hideCollectionTitle", "Collection title visibility must be true or false."));
 		if (!COLLECTION_VIEW_MODES.has(viewMode)) errors.push(diagnostic("INVALID_STUDIO_COLLECTION_VIEW", "$studioPlan.viewMode", "Choose the existing Tabs or Rows collection layout."));
 		if (typeof requestedShowAllTab !== "boolean" || typeof pinToTop !== "boolean") errors.push(diagnostic("INVALID_STUDIO_COLLECTION_OPTIONS", "$studioPlan", "Collection options must be explicit boolean values."));

--- a/builder/src/source-add/tmdb-list-plan.js
+++ b/builder/src/source-add/tmdb-list-plan.js
@@ -28,12 +28,11 @@ export function createTmdbListHierarchyPlan(project, options) {
 	const scope = TMDB_LIST_CREATION_SCOPES.includes(options.scope) ? options.scope : null;
 	if (!scope) errors.push(diagnostic("INVALID_TMDB_LIST_PLAN_SCOPE", "$tmdbListPlan.scope", "Choose New Collection or New Folder scope."));
 	if (!Number.isSafeInteger(options.projectRevision) || options.projectRevision < 0) errors.push(diagnostic("INVALID_TMDB_LIST_PLAN_REVISION", "$tmdbListPlan.projectRevision", "Capture the current nonnegative Builder revision."));
-	if (!isValidVisibleNuvioTitle(options.folderTitle) || options.folderTitle !== text(options.folderTitle)) errors.push(diagnostic("INVALID_TMDB_LIST_FOLDER_TITLE", "$tmdbListPlan.folderTitle", "Enter a visible folder name."));
-	if (scope === "new-collection" && (!isValidVisibleNuvioTitle(options.collectionTitle) || options.collectionTitle !== text(options.collectionTitle))) errors.push(diagnostic("INVALID_TMDB_LIST_COLLECTION_TITLE", "$tmdbListPlan.collectionTitle", "Enter a visible collection name."));
 	const folderTitleVisibility = options.folderTitleVisibility ?? DEFAULT_TMDB_LIST_FOLDER_TITLE_VISIBILITY;
 	const folderTileShape = options.folderTileShape ?? DEFAULT_TMDB_LIST_FOLDER_TILE_SHAPE;
 	if (!FOLDER_TITLE_VISIBILITIES.has(folderTitleVisibility)) errors.push(diagnostic("INVALID_TMDB_LIST_FOLDER_TITLE_VISIBILITY", "$tmdbListPlan.folderTitleVisibility", "Choose an existing folder-title visibility outcome."));
 	if (!FOLDER_TILE_SHAPES.has(folderTileShape)) errors.push(diagnostic("INVALID_TMDB_LIST_FOLDER_TILE_SHAPE", "$tmdbListPlan.folderTileShape", "Choose the existing Poster or Landscape folder tile shape."));
+	if (typeof options.folderTitle !== "string" || (folderTitleVisibility !== "HIDE_EVERYWHERE" && (!isValidVisibleNuvioTitle(options.folderTitle) || options.folderTitle !== text(options.folderTitle)))) errors.push(diagnostic("INVALID_TMDB_LIST_FOLDER_TITLE", "$tmdbListPlan.folderTitle", "Enter a visible folder name."));
 	let hideCollectionTitle = null;
 	let viewMode = null;
 	let showAllTab = null;
@@ -43,6 +42,7 @@ export function createTmdbListHierarchyPlan(project, options) {
 		viewMode = options.viewMode ?? "TABBED_GRID";
 		const requestedShowAllTab = options.showAllTab ?? true;
 		pinToTop = options.pinToTop ?? false;
+		if (typeof options.collectionTitle !== "string" || (hideCollectionTitle !== true && (!isValidVisibleNuvioTitle(options.collectionTitle) || options.collectionTitle !== text(options.collectionTitle)))) errors.push(diagnostic("INVALID_TMDB_LIST_COLLECTION_TITLE", "$tmdbListPlan.collectionTitle", "Enter a visible collection name."));
 		if (typeof hideCollectionTitle !== "boolean") errors.push(diagnostic("INVALID_TMDB_LIST_COLLECTION_TITLE_VISIBILITY", "$tmdbListPlan.hideCollectionTitle", "Collection title visibility must be true or false."));
 		if (!COLLECTION_VIEW_MODES.has(viewMode)) errors.push(diagnostic("INVALID_TMDB_LIST_COLLECTION_VIEW", "$tmdbListPlan.viewMode", "Choose the existing Tabs or Rows collection layout."));
 		if (typeof requestedShowAllTab !== "boolean" || typeof pinToTop !== "boolean") errors.push(diagnostic("INVALID_TMDB_LIST_COLLECTION_OPTIONS", "$tmdbListPlan", "Collection presentation options must be explicit boolean values."));

--- a/builder/src/ui/CreationDialog.jsx
+++ b/builder/src/ui/CreationDialog.jsx
@@ -18,7 +18,7 @@ import {
 	createAsyncRequestCoordinator,
 	decadesRepresentativeItems,
 } from "../source-add/index.js";
-import { isInvisibleNuvioTitle } from "../nuvio/titles.js";
+import { isInvisibleNuvioTitle, reversibleTitleFieldProps } from "../nuvio/titles.js";
 import {
 	lockAddSourceDocumentBody,
 	observeAddSourceViewport,
@@ -59,6 +59,7 @@ import { LauncherOptionCard } from "./LauncherOptionCard.jsx";
 import { handleDialogKeyDown } from "./modal-focus.js";
 import {
 	FolderShapeChoices,
+	HiddenTitleFieldHelp,
 	PresentationSwitch,
 	TitleOptions,
 } from "./PresentationControls.jsx";
@@ -418,7 +419,7 @@ function TitlesAndVisibility({ state, onStateChange }) {
 				descriptionId: "decades-hidden-title-help",
 				onChange: (hideCollectionTitle) => onStateChange(Object.freeze({ ...state, hideCollectionTitle })),
 			} : null}
-			collectionStatus={state.scope === "new-collection" && state.hideCollectionTitle ? <p id={DECADES_HIDDEN_COLLECTION_TITLES_HELP_ID} className="editor-field-help" role="status">Collection titles are intentionally hidden in Nuvio. Turn this off to edit visible titles.</p> : null}
+			collectionStatus={<HiddenTitleFieldHelp id={DECADES_HIDDEN_COLLECTION_TITLES_HELP_ID} hidden={state.scope === "new-collection" && state.hideCollectionTitle} kind="collection" plural />}
 			folderTitleVisibility={{
 				selectedId: state.folderTitleVisibility,
 				name: "decades-folder-title-visibility",
@@ -536,7 +537,7 @@ export function DecadesReviewStep({ state, planResult, headingRef, applyDiagnost
 				<h3 id="decades-review-error-title" ref={headingRef} tabIndex={-1}>Review needs attention</h3>
 				<SelectedDecadesSummary selectedDecadeIds={state.selectedDecadeIds} />
 				{state.scope === "new-collection" ? <div className="decades-collection-names">
-					{Object.entries(state.collectionTitles).map(([role, title]) => <div className="editor-field" key={role}><label htmlFor={`decades-collection-${role}`}>{role === "mixed" ? "Collection name" : `${role === "movies" ? "Movie" : "TV"} collection name`}</label><input id={`decades-collection-${role}`} type="text" value={state.hideCollectionTitle ? "" : title} disabled={state.hideCollectionTitle} aria-describedby={state.hideCollectionTitle ? DECADES_HIDDEN_COLLECTION_TITLES_HELP_ID : undefined} onChange={(event) => onCollectionTitleChange(role, event.target.value)} /></div>)}
+					{Object.entries(state.collectionTitles).map(([role, title]) => <div className="editor-field" key={role}><label htmlFor={`decades-collection-${role}`}>{role === "mixed" ? "Collection name" : `${role === "movies" ? "Movie" : "TV"} collection name`}</label><input id={`decades-collection-${role}`} type="text" {...reversibleTitleFieldProps(title, state.hideCollectionTitle)} aria-describedby={state.hideCollectionTitle ? DECADES_HIDDEN_COLLECTION_TITLES_HELP_ID : undefined} onChange={(event) => onCollectionTitleChange(role, event.target.value)} /></div>)}
 				</div> : null}
 				<TitlesAndVisibility state={state} onStateChange={onStateChange} />
 				<ul className="genre-advanced-errors" role="alert">{planResult.errors.map((entry) => <li key={`${entry.code}-${entry.path}`}>{entry.message}</li>)}</ul>
@@ -559,7 +560,7 @@ export function DecadesReviewStep({ state, planResult, headingRef, applyDiagnost
 					{plan.collections.map((collection) => (
 						<div className="editor-field" key={collection.role}>
 							<label htmlFor={`decades-collection-${collection.role}`}>{collection.role === "mixed" ? "Collection name" : `${collection.role === "movies" ? "Movie" : "TV"} collection name`}</label>
-							<input id={`decades-collection-${collection.role}`} type="text" value={state.hideCollectionTitle ? "" : state.collectionTitles[collection.role] ?? ""} disabled={state.hideCollectionTitle} aria-describedby={[state.hideCollectionTitle ? DECADES_HIDDEN_COLLECTION_TITLES_HELP_ID : null, collection.titleCollisions.length > 0 ? `decades-title-collision-${collection.role}` : null].filter(Boolean).join(" ") || undefined} onChange={(event) => onCollectionTitleChange(collection.role, event.target.value)} />
+							<input id={`decades-collection-${collection.role}`} type="text" {...reversibleTitleFieldProps(state.collectionTitles[collection.role], state.hideCollectionTitle)} aria-describedby={[state.hideCollectionTitle ? DECADES_HIDDEN_COLLECTION_TITLES_HELP_ID : null, collection.titleCollisions.length > 0 ? `decades-title-collision-${collection.role}` : null].filter(Boolean).join(" ") || undefined} onChange={(event) => onCollectionTitleChange(collection.role, event.target.value)} />
 							{collection.titleCollisions.length > 0 ? <p id={`decades-title-collision-${collection.role}`} className="editor-field-help">A collection with this name already exists. The new collection will still be created.</p> : null}
 						</div>
 					))}

--- a/builder/src/ui/FranchiseSourceFlow.jsx
+++ b/builder/src/ui/FranchiseSourceFlow.jsx
@@ -12,12 +12,13 @@ import {
 	toggleSelectedFranchise,
 	buildTmdbPosterUrl,
 } from "../source-add/index.js";
+import { reversibleTitleFieldProps } from "../nuvio/titles.js";
 import { HierarchyCollectionPresentationControls } from "./CollectionPresentationChoices.jsx";
 import { CreationHeader } from "./CreationHeader.jsx";
 import { focusElementWithoutScroll } from "./hierarchy-menu-placement.js";
 import { NestedPreviewDialog } from "./NestedPreviewDialog.jsx";
 import { PosterOnlyPreviewGrid } from "./PosterOnlyPreviewGrid.jsx";
-import { PresentationSwitch, TitleOptions } from "./PresentationControls.jsx";
+import { HiddenTitleFieldHelp, PresentationSwitch, TitleOptions } from "./PresentationControls.jsx";
 import { SourceElsewhereNotice } from "./SourceElsewhereNotice.jsx";
 
 const SEARCH_DEBOUNCE_MS = 250;
@@ -95,7 +96,7 @@ function ReviewStep({ planResult, options, onOptionsChange, onPreview, diagnosti
 		<section className="franchise-review" aria-labelledby="franchise-review-title">
 			<div className="add-source-section-heading"><div><p className="panel-kicker">Review &amp; Appearance</p><h3 id="franchise-review-title">{plan.counts.folderCount} folder{plan.counts.folderCount === 1 ? "" : "s"} · {plan.counts.sourceCount} source{plan.counts.sourceCount === 1 ? "" : "s"}</h3></div></div>
 			{plan.configuration.scope === "new-collection" ? <>
-				<div className="editor-field"><label htmlFor="franchise-collection-name">Collection name</label><input id="franchise-collection-name" type="text" value={options.collectionTitle} onChange={(event) => onOptionsChange({ collectionTitle: event.target.value })} /></div>
+				<div className="editor-field"><label htmlFor="franchise-collection-name">Collection name</label><input id="franchise-collection-name" type="text" {...reversibleTitleFieldProps(options.collectionTitle, options.hideCollectionTitle)} aria-describedby={options.hideCollectionTitle ? "franchise-collection-title-hidden-help" : undefined} onChange={(event) => onOptionsChange({ collectionTitle: event.target.value })} /><HiddenTitleFieldHelp id="franchise-collection-title-hidden-help" hidden={options.hideCollectionTitle} kind="collection" /></div>
 				<TitleOptions idPrefix="franchise" collectionTitleVisibility={{ checked: options.hideCollectionTitle, onChange: (hideCollectionTitle) => onOptionsChange({ hideCollectionTitle }), descriptionId: "franchise-hide-title-help", controlName: "franchiseHideNuvioTitle" }} folderTitleVisibility={{ selectedId: options.folderTitleVisibility, name: "franchise-folder-title-visibility", onChange: (folderTitleVisibility) => onOptionsChange({ folderTitleVisibility }) }} />
 				<fieldset className="editor-field editor-choice-field"><legend>Collection layout</legend><HierarchyCollectionPresentationControls selectedId={options.viewMode} name="franchise-collection-layout" showAllTab={options.showAllTab} onPresentationChange={onOptionsChange} showAllDescription="Combines every franchise folder in one All tab." showAllDescriptionId="franchise-all-tab-help" showAllControlName="franchiseShowAllTab" /></fieldset>
 				<PresentationSwitch label="Pin collection to top" description="Keeps this collection near the top of Nuvio." descriptionId="franchise-pin-help" controlName="franchisePinToTop" checked={options.pinToTop} onChange={(pinToTop) => onOptionsChange({ pinToTop })} />

--- a/builder/src/ui/GenreHierarchyFlow.jsx
+++ b/builder/src/ui/GenreHierarchyFlow.jsx
@@ -24,6 +24,7 @@ import {
 	pruneGenreExclusionConfiguration,
 	searchGenreConcepts,
 } from "../source-add/index.js";
+import { reversibleTitleFieldProps } from "../nuvio/titles.js";
 import { HierarchyCollectionPresentationControls } from "./CollectionPresentationChoices.jsx";
 import { CreationHeader } from "./CreationHeader.jsx";
 import { ChoiceCards } from "./ChoiceCards.jsx";
@@ -33,7 +34,7 @@ import { toggleGenreSelection } from "./GenreSourceFlow.jsx";
 import { focusElementWithoutScroll } from "./hierarchy-menu-placement.js";
 import { NestedPreviewDialog } from "./NestedPreviewDialog.jsx";
 import { PosterOnlyPreviewGrid } from "./PosterOnlyPreviewGrid.jsx";
-import { FolderShapeChoices, PresentationSwitch, TitleOptions } from "./PresentationControls.jsx";
+import { FolderShapeChoices, HiddenTitleFieldHelp, PresentationSwitch, TitleOptions } from "./PresentationControls.jsx";
 import { RemovableSelectionSummary } from "./RemovableSelectionSummary.jsx";
 import { SemanticSortChoices } from "./SemanticSortChoices.jsx";
 import { SourceElsewhereNotice } from "./SourceElsewhereNotice.jsx";
@@ -264,7 +265,10 @@ function AppearanceStep({ planResult, options, onOptionsChange, diagnostic, head
 			<div className="decades-plan-totals" data-plan-scope={plan.configuration.scope} aria-label="Plan totals">{plan.configuration.scope === "new-collection" ? <div><strong>{plan.counts.collectionCount}</strong><span>Collection</span></div> : null}<div><strong>{plan.counts.folderCount}</strong><span>Folder{plan.counts.folderCount === 1 ? "" : "s"}</span></div><div><strong>{plan.counts.sourceCount}</strong><span>Source{plan.counts.sourceCount === 1 ? "" : "s"}</span></div></div>
 			{omittedCount || elsewhereCount ? <p className="studio-configure-helper">{omittedCount ? `${omittedCount} destination match${omittedCount === 1 ? " is" : "es are"} omitted. ` : ""}{elsewhereCount ? `${elsewhereCount} elsewhere match${elsewhereCount === 1 ? " remains" : "es remain"} addable.` : ""}</p> : null}
 			{plan.configuration.scope === "new-collection" ? <>
-				{separateCollections ? <div className="genre-collection-name-grid">{[["movies", "Movie collection name"], ["series", "Series collection name"]].map(([role, label]) => <div className="editor-field" key={role}><label htmlFor={`genre-hierarchy-collection-${role}`}>{label}</label><input id={`genre-hierarchy-collection-${role}`} type="text" value={options.collectionTitles[role]} disabled={options.hideCollectionTitle} onChange={(event) => onOptionsChange({ collectionTitles: Object.freeze({ ...options.collectionTitles, [role]: event.target.value }) })} /></div>)}</div> : <div className="editor-field"><label htmlFor="genre-hierarchy-collection-name">Collection name</label><input id="genre-hierarchy-collection-name" type="text" value={options.collectionTitle} disabled={options.hideCollectionTitle} onChange={(event) => onOptionsChange({ collectionTitle: event.target.value })} /></div>}
+				{separateCollections ? <>
+					<div className="genre-collection-name-grid">{[["movies", "Movie collection name"], ["series", "Series collection name"]].map(([role, label]) => <div className="editor-field" key={role}><label htmlFor={`genre-hierarchy-collection-${role}`}>{label}</label><input id={`genre-hierarchy-collection-${role}`} type="text" {...reversibleTitleFieldProps(options.collectionTitles[role], options.hideCollectionTitle)} aria-describedby={options.hideCollectionTitle ? "genre-hierarchy-collection-titles-hidden-help" : undefined} onChange={(event) => onOptionsChange({ collectionTitles: Object.freeze({ ...options.collectionTitles, [role]: event.target.value }) })} /></div>)}</div>
+					<HiddenTitleFieldHelp id="genre-hierarchy-collection-titles-hidden-help" hidden={options.hideCollectionTitle} kind="collection" plural />
+				</> : <div className="editor-field"><label htmlFor="genre-hierarchy-collection-name">Collection name</label><input id="genre-hierarchy-collection-name" type="text" {...reversibleTitleFieldProps(options.collectionTitle, options.hideCollectionTitle)} aria-describedby={options.hideCollectionTitle ? "genre-hierarchy-collection-title-hidden-help" : undefined} onChange={(event) => onOptionsChange({ collectionTitle: event.target.value })} /><HiddenTitleFieldHelp id="genre-hierarchy-collection-title-hidden-help" hidden={options.hideCollectionTitle} kind="collection" /></div>}
 				<TitleOptions idPrefix="genre-hierarchy" collectionTitleVisibility={{ checked: options.hideCollectionTitle, onChange: (hideCollectionTitle) => onOptionsChange({ hideCollectionTitle }), descriptionId: "genre-hierarchy-hide-collection-title-help", controlName: "genreHierarchyHideNuvioTitle" }} folderTitleVisibility={folderTitleVisibility} />
 				{mediaFolders ? <p className="genre-fixed-media-note">Movies and Series folders use the safe folder fallback, so their titles remain visible.</p> : null}
 				<fieldset className="editor-field editor-choice-field"><legend>Collection layout</legend><HierarchyCollectionPresentationControls selectedId={options.viewMode} name="genre-hierarchy-collection-layout" showAllTab={options.showAllTab} onPresentationChange={onOptionsChange} showAllDescription="Combines every Genre folder in one All tab." showAllDescriptionId="genre-hierarchy-all-tab-help" showAllControlName="genreHierarchyShowAllTab" /></fieldset>

--- a/builder/src/ui/NetworkHierarchyFlow.jsx
+++ b/builder/src/ui/NetworkHierarchyFlow.jsx
@@ -17,6 +17,7 @@ import {
 	selectedNetworks,
 	toggleSelectedNetwork,
 } from "../source-add/index.js";
+import { reversibleTitleFieldProps } from "../nuvio/titles.js";
 import { HierarchyCollectionPresentationControls } from "./CollectionPresentationChoices.jsx";
 import { CreationHeader } from "./CreationHeader.jsx";
 import { focusElementWithoutScroll } from "./hierarchy-menu-placement.js";
@@ -24,7 +25,7 @@ import { NestedPreviewDialog } from "./NestedPreviewDialog.jsx";
 import { NetworkLogo, NetworkResultContent, NetworkSearchStep } from "./NetworkSourceFlow.jsx";
 import { NetworkSortChoices } from "./NetworkSortChoices.jsx";
 import { PosterOnlyPreviewGrid } from "./PosterOnlyPreviewGrid.jsx";
-import { FolderShapeChoices, PresentationSwitch, TitleOptions } from "./PresentationControls.jsx";
+import { FolderShapeChoices, HiddenTitleFieldHelp, PresentationSwitch, TitleOptions } from "./PresentationControls.jsx";
 import { SourceElsewhereNotice } from "./SourceElsewhereNotice.jsx";
 import { useNetworkCatalogueSearch } from "./use-network-catalogue-search.js";
 
@@ -135,7 +136,7 @@ function AppearanceStep({ planResult, options, onOptionsChange, onArtworkChange,
 			<div className="add-source-section-heading"><div><p className="panel-kicker">Step 3</p><h3 id="network-hierarchy-appearance-title" ref={headingRef} tabIndex={-1}>Appearance</h3></div></div>
 			{plan ? <div className="decades-plan-totals" data-plan-scope={plan.configuration.scope} aria-label="Plan totals">{plan.configuration.scope === "new-collection" ? <div><strong>{plan.counts.collectionCount}</strong><span>Collection</span></div> : null}<div><strong>{plan.counts.folderCount}</strong><span>Folder{plan.counts.folderCount === 1 ? "" : "s"}</span></div><div><strong>{plan.counts.sourceCount}</strong><span>Source{plan.counts.sourceCount === 1 ? "" : "s"}</span></div></div> : null}
 			{options.scope === "new-collection" ? <>
-				<div className="editor-field"><label htmlFor="network-collection-name">Collection name</label><input id="network-collection-name" type="text" value={options.collectionTitle} onChange={(event) => onOptionsChange({ collectionTitle: event.target.value })} /></div>
+				<div className="editor-field"><label htmlFor="network-collection-name">Collection name</label><input id="network-collection-name" type="text" {...reversibleTitleFieldProps(options.collectionTitle, options.hideCollectionTitle)} aria-describedby={options.hideCollectionTitle ? "network-collection-title-hidden-help" : undefined} onChange={(event) => onOptionsChange({ collectionTitle: event.target.value })} /><HiddenTitleFieldHelp id="network-collection-title-hidden-help" hidden={options.hideCollectionTitle} kind="collection" /></div>
 				<TitleOptions idPrefix="network-hierarchy" collectionTitleVisibility={{ checked: options.hideCollectionTitle, onChange: (hideCollectionTitle) => onOptionsChange({ hideCollectionTitle }), descriptionId: "network-hide-title-help", controlName: "networkHideNuvioTitle" }} folderTitleVisibility={{ selectedId: options.folderTitleVisibility, name: "network-folder-title-visibility", onChange: (folderTitleVisibility) => onOptionsChange({ folderTitleVisibility }) }} />
 				<ArtworkChoices options={options} onArtworkChange={onArtworkChange} disabled={isPreparing} />
 				<fieldset className="editor-field editor-choice-field"><legend>Collection layout</legend><HierarchyCollectionPresentationControls selectedId={options.viewMode} name="network-collection-layout" showAllTab={options.showAllTab} onPresentationChange={onOptionsChange} showAllDescription="Combines every Network folder in one All tab." showAllDescriptionId="network-all-tab-help" showAllControlName="networkShowAllTab" /></fieldset>

--- a/builder/src/ui/NodeEditor.jsx
+++ b/builder/src/ui/NodeEditor.jsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from "react";
 import {
 	isValidNuvioTitle,
 	isValidVisibleNuvioTitle,
+	reversibleTitleFieldProps,
 } from "../nuvio/titles.js";
 import {
 	missingCuratedFolderFocusOrientationNotice,
@@ -20,7 +21,9 @@ import {
 } from "./FolderArtworkFields.jsx";
 import { folderSiblingTileShapeNotice } from "./node-editor.js";
 import {
+	COLLECTION_INVISIBLE_TITLE_HELP,
 	CollectionTitleVisibilitySwitch,
+	FOLDER_INVISIBLE_TITLE_HELP,
 	FOLDER_TITLE_VISIBILITY_LABEL,
 	FolderShapeChoices,
 	FolderTitleVisibilityChoices,
@@ -457,18 +460,17 @@ export function NodeEditor({
 				id={`${prefix}-title-input`}
 				name="title"
 				type="text"
-				value={titleHiddenEverywhere ? "" : draft.values.title}
+				{...reversibleTitleFieldProps(draft.values.title, titleHiddenEverywhere)}
 				data-editor-field="title"
-				disabled={titleHiddenEverywhere}
 				aria-invalid={titleError ? "true" : undefined}
 				aria-describedby={describedBy(titleError)}
 				onChange={(event) => onChange("title", event.target.value)}
 			/>
 			<p className="editor-field-help" id={`${prefix}-title-help`}>
 				{draft.nodeType === "folder" && draft.values.folderTitleVisibility === "HIDE_EVERYWHERE"
-					? "The folder title is intentionally invisible everywhere in Nuvio. Choose a visible option below to enter a visible title."
+					? FOLDER_INVISIBLE_TITLE_HELP
 					: draft.nodeType === "collection" && draft.values.hideNuvioTitle
-					? `The ${noun} title is intentionally invisible in Nuvio. Turn off the setting below to enter a visible title.`
+					? COLLECTION_INVISIBLE_TITLE_HELP
 					: `Displayed as the ${noun} title in Nuvio.`}
 			</p>
 			<TitleStatus

--- a/builder/src/ui/PeopleSourceFlow.jsx
+++ b/builder/src/ui/PeopleSourceFlow.jsx
@@ -44,6 +44,7 @@ import {
 	updatePeopleConfiguration,
 	validatePeopleCombinationSelection,
 } from "../source-add/index.js";
+import { reversibleTitleFieldProps } from "../nuvio/titles.js";
 import { HierarchyCollectionPresentationControls } from "./CollectionPresentationChoices.jsx";
 import {
 	lockAddSourceDocumentBody,
@@ -55,7 +56,7 @@ import { focusElementWithoutScroll } from "./hierarchy-menu-placement.js";
 import { PosterOnlyPreviewGrid } from "./PosterOnlyPreviewGrid.jsx";
 import { handleDialogKeyDown } from "./modal-focus.js";
 import { TmdbEntityLink } from "./TmdbEntityLink.jsx";
-import { FolderShapeChoices, PresentationSwitch, TitleOptions } from "./PresentationControls.jsx";
+import { FolderShapeChoices, HiddenTitleFieldHelp, PresentationSwitch, TitleOptions } from "./PresentationControls.jsx";
 import { RemovableSelectionSummary } from "./RemovableSelectionSummary.jsx";
 import { SemanticSortChoices } from "./SemanticSortChoices.jsx";
 import { SourceElsewhereNotice } from "./SourceElsewhereNotice.jsx";
@@ -543,7 +544,7 @@ export function PeopleReviewStep({
 			collectionTitleVisibility={plan.configuration.scope === "new-collection" ? {
 				checked: collectionOptions.hideTitle,
 				descriptionId: "people-hide-collection-title-help",
-				onChange: (hideTitle) => onCollectionOptionsChange({ ...collectionOptions, hideTitle, title: hideTitle && !collectionOptions.title.trim() ? "People" : collectionOptions.title }),
+				onChange: (hideTitle) => onCollectionOptionsChange({ ...collectionOptions, hideTitle }),
 			} : null}
 			folderTitleVisibility={{
 				selectedId: folderTitleVisibility,
@@ -564,7 +565,8 @@ export function PeopleReviewStep({
 				<>
 					<div className="decades-collection-names"><div className="editor-field">
 						<label htmlFor="people-collection-title">Collection name</label>
-						<input id="people-collection-title" type="text" value={collectionOptions.hideTitle ? "" : collectionOptions.title} disabled={collectionOptions.hideTitle} onChange={(event) => onCollectionOptionsChange({ ...collectionOptions, title: event.target.value })} />
+						<input id="people-collection-title" type="text" {...reversibleTitleFieldProps(collectionOptions.title, collectionOptions.hideTitle)} aria-describedby={collectionOptions.hideTitle ? "people-collection-title-hidden-help" : undefined} onChange={(event) => onCollectionOptionsChange({ ...collectionOptions, title: event.target.value })} />
+						<HiddenTitleFieldHelp id="people-collection-title-hidden-help" hidden={collectionOptions.hideTitle} kind="collection" />
 						{plan.collections[0].titleCollisions.length > 0 ? <p className="editor-field-help">A collection with this name already exists. The new collection will still be created.</p> : null}
 					</div></div>
 					{titleOptions}

--- a/builder/src/ui/PresentationControls.jsx
+++ b/builder/src/ui/PresentationControls.jsx
@@ -3,6 +3,18 @@ function isSelected(value, canonicalValue) {
 }
 
 export const FOLDER_TITLE_VISIBILITY_LABEL = "Folder title visibility";
+export const COLLECTION_INVISIBLE_TITLE_HELP = "The collection title is intentionally invisible in Nuvio. Turn off the setting below to enter a visible title.";
+export const COLLECTIONS_INVISIBLE_TITLE_HELP = "Collection titles are intentionally hidden in Nuvio. Turn this off to edit visible titles.";
+export const FOLDER_INVISIBLE_TITLE_HELP = "The folder title is intentionally invisible everywhere in Nuvio. Choose a visible option below to enter a visible title.";
+export const FOLDERS_INVISIBLE_TITLE_HELP = "Folder titles are intentionally invisible everywhere in Nuvio. Choose a visible option below to enter visible titles.";
+
+export function HiddenTitleFieldHelp({ id, hidden, kind, plural = false }) {
+	if (!hidden) return null;
+	const message = kind === "folder"
+		? plural ? FOLDERS_INVISIBLE_TITLE_HELP : FOLDER_INVISIBLE_TITLE_HELP
+		: plural ? COLLECTIONS_INVISIBLE_TITLE_HELP : COLLECTION_INVISIBLE_TITLE_HELP;
+	return <p id={id} className="editor-field-help" role="status">{message}</p>;
+}
 
 export function PresentationSwitch({
 	label,

--- a/builder/src/ui/StreamingHierarchyFlow.jsx
+++ b/builder/src/ui/StreamingHierarchyFlow.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { isValidVisibleNuvioTitle } from "../nuvio/titles.js";
+import { isValidVisibleNuvioTitle, reversibleTitleFieldProps } from "../nuvio/titles.js";
 import {
 	browseStreamingProviders,
 	browseStreamingRegions,
@@ -32,7 +32,7 @@ import { CreationHeader } from "./CreationHeader.jsx";
 import { focusElementWithoutScroll } from "./hierarchy-menu-placement.js";
 import { NestedPreviewDialog } from "./NestedPreviewDialog.jsx";
 import { PosterOnlyPreviewGrid } from "./PosterOnlyPreviewGrid.jsx";
-import { PresentationSwitch, TitleOptions } from "./PresentationControls.jsx";
+import { HiddenTitleFieldHelp, PresentationSwitch, TitleOptions } from "./PresentationControls.jsx";
 import { SemanticSortChoices } from "./SemanticSortChoices.jsx";
 import { SourceElsewhereNotice } from "./SourceElsewhereNotice.jsx";
 import { StreamingRegionStep, toggleStreamingRegionSelection } from "./StreamingSourceFlow.jsx";
@@ -288,7 +288,7 @@ export function StreamingDestinationChooser({ candidates, selectedDestination, e
 	);
 }
 
-function FolderNameEditor({ folders, drafts, errors, onChange, onUseDefault }) {
+function FolderNameEditor({ folders, drafts, errors, hiddenEverywhere, onChange, onUseDefault }) {
 	if (!folders.length) return null;
 	return (
 		<details className="streaming-folder-names" data-streaming-folder-name-count={folders.length}>
@@ -299,8 +299,9 @@ function FolderNameEditor({ folders, drafts, errors, onChange, onUseDefault }) {
 				const custom = Object.hasOwn(drafts, folder.key);
 				const value = custom ? drafts[folder.key] : folder.generatedTitle;
 				const error = errors.get(folder.key);
-				return <div className="editor-field streaming-folder-name-field" key={folder.key}><label htmlFor={inputId}>{folder.generatedTitle}</label><input id={inputId} type="text" value={value} aria-invalid={error ? "true" : undefined} aria-describedby={`${inputId}-error`} onChange={(event) => onChange(folder.key, event.target.value)} />{custom ? <div><button type="button" onClick={() => onUseDefault(folder.key)}>Use default name</button></div> : null}<p className="editor-field-error" id={`${inputId}-error`}>{error?.message ?? ""}</p></div>;
+				return <div className="editor-field streaming-folder-name-field" key={folder.key}><label htmlFor={inputId}>{folder.generatedTitle}</label><input id={inputId} type="text" {...reversibleTitleFieldProps(value, hiddenEverywhere)} aria-invalid={error ? "true" : undefined} aria-describedby={[`${inputId}-error`, hiddenEverywhere ? "streaming-folder-titles-hidden-help" : null].filter(Boolean).join(" ")} onChange={(event) => onChange(folder.key, event.target.value)} />{custom ? <div><button type="button" onClick={() => onUseDefault(folder.key)}>Use default name</button></div> : null}<p className="editor-field-error" id={`${inputId}-error`}>{error?.message ?? ""}</p></div>;
 			})}</div>
+			<HiddenTitleFieldHelp id="streaming-folder-titles-hidden-help" hidden={hiddenEverywhere} kind="folder" plural={folders.length > 1} />
 		</details>
 	);
 }
@@ -334,7 +335,7 @@ function ReviewStep({ planResult, intentConfiguration, newCollectionElsewhereEvi
 				{existingScope ? <section className="streaming-placement-review" aria-label="Streaming placement changes"><div className="studio-configure-list">{plan.outcomes.map((outcome) => <PlacementReviewRow key={outcome.key} outcome={outcome} collectionDisplayContext={collectionDisplayContext} />)}</div></section> : <NewCollectionElsewhereEvidence evidence={plan.elsewhereEvidence} collectionDisplayContext={collectionDisplayContext} />}
 				{plan.conflicts.length ? <div className="editor-diagnostics" role="alert">{plan.conflicts.map((conflict, index) => <p key={`${conflict.code}-${index}`}>{conflict.message}</p>)}</div> : null}
 				{routedExisting && plan.conflicts.length === 0 && plan.counts.newSourceCount === 0 ? <section className="streaming-nothing-to-add" role="status"><strong>Nothing to add</strong><p>All selected Streaming sources already exist in {activeDestinationLabel}. No project changes are needed.</p></section> : null}
-				{activeScope === "new-collection" ? <><div className="editor-field"><label htmlFor="streaming-collection-name">Collection name</label><input id="streaming-collection-name" type="text" value={options.collectionTitle} onChange={(event) => onOptionsChange({ collectionTitle: event.target.value })} /></div><FolderNameEditor folders={plan.newFolders} drafts={folderTitleDrafts} errors={folderTitleErrors} onChange={onFolderTitleChange} onUseDefault={onUseDefaultFolderTitle} /><TitleOptions idPrefix="streaming-hierarchy" collectionTitleVisibility={{ checked: options.hideCollectionTitle, onChange: (hideCollectionTitle) => onOptionsChange({ hideCollectionTitle }), descriptionId: "streaming-hide-title-help", controlName: "streamingHideNuvioTitle" }} folderTitleVisibility={{ selectedId: options.folderTitleVisibility, name: "streaming-folder-title-visibility", onChange: (folderTitleVisibility) => onOptionsChange({ folderTitleVisibility }) }} /><fieldset className="editor-field editor-choice-field"><legend>Collection layout</legend><HierarchyCollectionPresentationControls selectedId={options.viewMode} name="streaming-collection-layout" showAllTab={options.showAllTab} onPresentationChange={onOptionsChange} showAllDescription="Combines every Streaming folder in one All tab." showAllDescriptionId="streaming-all-tab-help" showAllControlName="streamingShowAllTab" /></fieldset><PresentationSwitch label="Pin collection to top" description="Keeps this collection near the top of Nuvio." descriptionId="streaming-pin-help" controlName="streamingPinToTop" checked={options.pinToTop} onChange={(pinToTop) => onOptionsChange({ pinToTop })} /></> : <><div className="franchise-inherited-summary"><strong>Collection settings stay unchanged</strong><span>{activeDestinationLabel} · {plan.destination.viewMode === "ROWS" ? "Rows" : "Tabs"}. This operation does not rename or reconfigure the existing collection; appearance choices below apply only to new folders.</span></div><FolderNameEditor folders={plan.newFolders} drafts={folderTitleDrafts} errors={folderTitleErrors} onChange={onFolderTitleChange} onUseDefault={onUseDefaultFolderTitle} />{plan.newFolders.length ? <TitleOptions idPrefix="streaming-hierarchy" folderTitleVisibility={{ selectedId: options.folderTitleVisibility, name: "streaming-folder-title-visibility", onChange: (folderTitleVisibility) => onOptionsChange({ folderTitleVisibility }) }} /> : null}</>}
+				{activeScope === "new-collection" ? <><div className="editor-field"><label htmlFor="streaming-collection-name">Collection name</label><input id="streaming-collection-name" type="text" {...reversibleTitleFieldProps(options.collectionTitle, options.hideCollectionTitle)} aria-describedby={options.hideCollectionTitle ? "streaming-collection-title-hidden-help" : undefined} onChange={(event) => onOptionsChange({ collectionTitle: event.target.value })} /><HiddenTitleFieldHelp id="streaming-collection-title-hidden-help" hidden={options.hideCollectionTitle} kind="collection" /></div><FolderNameEditor folders={plan.newFolders} drafts={folderTitleDrafts} errors={folderTitleErrors} hiddenEverywhere={options.folderTitleVisibility === "HIDE_EVERYWHERE"} onChange={onFolderTitleChange} onUseDefault={onUseDefaultFolderTitle} /><TitleOptions idPrefix="streaming-hierarchy" collectionTitleVisibility={{ checked: options.hideCollectionTitle, onChange: (hideCollectionTitle) => onOptionsChange({ hideCollectionTitle }), descriptionId: "streaming-hide-title-help", controlName: "streamingHideNuvioTitle" }} folderTitleVisibility={{ selectedId: options.folderTitleVisibility, name: "streaming-folder-title-visibility", onChange: (folderTitleVisibility) => onOptionsChange({ folderTitleVisibility }) }} /><fieldset className="editor-field editor-choice-field"><legend>Collection layout</legend><HierarchyCollectionPresentationControls selectedId={options.viewMode} name="streaming-collection-layout" showAllTab={options.showAllTab} onPresentationChange={onOptionsChange} showAllDescription="Combines every Streaming folder in one All tab." showAllDescriptionId="streaming-all-tab-help" showAllControlName="streamingShowAllTab" /></fieldset><PresentationSwitch label="Pin collection to top" description="Keeps this collection near the top of Nuvio." descriptionId="streaming-pin-help" controlName="streamingPinToTop" checked={options.pinToTop} onChange={(pinToTop) => onOptionsChange({ pinToTop })} /></> : <><div className="franchise-inherited-summary"><strong>Collection settings stay unchanged</strong><span>{activeDestinationLabel} · {plan.destination.viewMode === "ROWS" ? "Rows" : "Tabs"}. This operation does not rename or reconfigure the existing collection; appearance choices below apply only to new folders.</span></div><FolderNameEditor folders={plan.newFolders} drafts={folderTitleDrafts} errors={folderTitleErrors} hiddenEverywhere={options.folderTitleVisibility === "HIDE_EVERYWHERE"} onChange={onFolderTitleChange} onUseDefault={onUseDefaultFolderTitle} />{plan.newFolders.length ? <TitleOptions idPrefix="streaming-hierarchy" folderTitleVisibility={{ selectedId: options.folderTitleVisibility, name: "streaming-folder-title-visibility", onChange: (folderTitleVisibility) => onOptionsChange({ folderTitleVisibility }) }} /> : null}</>}
 				{diagnostic ? <div className="editor-diagnostics" role="alert"><p>{diagnostic.message}</p></div> : null}
 			</>}
 		</section>
@@ -446,9 +447,9 @@ export function StreamingHierarchyFlow({
 	const logicalFolderKeySignature = logicalFolderKeys?.join("\n") ?? "";
 	const activeNewFolderKeys = new Set(planResult?.ok ? planResult.plan.newFolders.map((folder) => folder.key) : []);
 	const activeNewFolderKeySignature = [...activeNewFolderKeys].join("\n");
-	const folderTitleErrors = useMemo(() => new Map(Object.entries(folderTitleDrafts)
+	const folderTitleErrors = useMemo(() => options.folderTitleVisibility === "HIDE_EVERYWHERE" ? new Map() : new Map(Object.entries(folderTitleDrafts)
 		.filter(([key, title]) => activeNewFolderKeys.has(key) && !isValidVisibleNuvioTitle(title))
-		.map(([key]) => [key, { message: "Enter a folder title before applying changes." }])), [activeNewFolderKeySignature, folderTitleDrafts]);
+		.map(([key]) => [key, { message: "Enter a folder title before applying changes." }])), [activeNewFolderKeySignature, folderTitleDrafts, options.folderTitleVisibility]);
 	const currentElsewhereEvidenceSignature = JSON.stringify(newCollectionElsewhereEvidence ?? null);
 
 	useEffect(() => {

--- a/builder/src/ui/StudioHierarchyFlow.jsx
+++ b/builder/src/ui/StudioHierarchyFlow.jsx
@@ -18,12 +18,13 @@ import {
 	studioSortValue,
 	toggleSelectedStudio,
 } from "../source-add/index.js";
+import { reversibleTitleFieldProps } from "../nuvio/titles.js";
 import { HierarchyCollectionPresentationControls } from "./CollectionPresentationChoices.jsx";
 import { CreationHeader } from "./CreationHeader.jsx";
 import { focusElementWithoutScroll } from "./hierarchy-menu-placement.js";
 import { NestedPreviewDialog } from "./NestedPreviewDialog.jsx";
 import { PosterOnlyPreviewGrid } from "./PosterOnlyPreviewGrid.jsx";
-import { PresentationSwitch, TitleOptions } from "./PresentationControls.jsx";
+import { HiddenTitleFieldHelp, PresentationSwitch, TitleOptions } from "./PresentationControls.jsx";
 import { SemanticSortChoices } from "./SemanticSortChoices.jsx";
 import { SourceElsewhereNotice } from "./SourceElsewhereNotice.jsx";
 import { StudioLogo, StudioResultContent, StudioSearchStep } from "./StudioSourceFlow.jsx";
@@ -144,7 +145,7 @@ function AppearanceStep({ planResult, options, onOptionsChange, diagnostic, head
 			<div className="add-source-section-heading"><div><p className="panel-kicker">Step 3</p><h3 id="studio-hierarchy-appearance-title" ref={headingRef} tabIndex={-1}>Appearance</h3></div></div>
 			<div className="decades-plan-totals" data-plan-scope={plan.configuration.scope} aria-label="Plan totals">{plan.configuration.scope === "new-collection" ? <div><strong>{plan.counts.collectionCount}</strong><span>Collection</span></div> : null}<div><strong>{plan.counts.folderCount}</strong><span>Folder{plan.counts.folderCount === 1 ? "" : "s"}</span></div><div><strong>{plan.counts.sourceCount}</strong><span>Source{plan.counts.sourceCount === 1 ? "" : "s"}</span></div></div>
 			{plan.configuration.scope === "new-collection" ? <>
-				<div className="editor-field"><label htmlFor="studio-collection-name">Collection name</label><input id="studio-collection-name" type="text" value={options.collectionTitle} onChange={(event) => onOptionsChange({ collectionTitle: event.target.value })} /></div>
+				<div className="editor-field"><label htmlFor="studio-collection-name">Collection name</label><input id="studio-collection-name" type="text" {...reversibleTitleFieldProps(options.collectionTitle, options.hideCollectionTitle)} aria-describedby={options.hideCollectionTitle ? "studio-collection-title-hidden-help" : undefined} onChange={(event) => onOptionsChange({ collectionTitle: event.target.value })} /><HiddenTitleFieldHelp id="studio-collection-title-hidden-help" hidden={options.hideCollectionTitle} kind="collection" /></div>
 				<TitleOptions idPrefix="studio-hierarchy" collectionTitleVisibility={{ checked: options.hideCollectionTitle, onChange: (hideCollectionTitle) => onOptionsChange({ hideCollectionTitle }), descriptionId: "studio-hide-title-help", controlName: "studioHideNuvioTitle" }} folderTitleVisibility={{ selectedId: options.folderTitleVisibility, name: "studio-folder-title-visibility", onChange: (folderTitleVisibility) => onOptionsChange({ folderTitleVisibility }) }} />
 				<fieldset className="editor-field editor-choice-field"><legend>Collection layout</legend><HierarchyCollectionPresentationControls selectedId={options.viewMode} name="studio-collection-layout" showAllTab={options.showAllTab} onPresentationChange={onOptionsChange} showAllDescription="Combines every Studio folder in one All tab." showAllDescriptionId="studio-all-tab-help" showAllControlName="studioShowAllTab" /></fieldset>
 				<PresentationSwitch label="Pin collection to top" description="Keeps this collection near the top of Nuvio." descriptionId="studio-pin-help" controlName="studioPinToTop" checked={options.pinToTop} onChange={(pinToTop) => onOptionsChange({ pinToTop })} />

--- a/builder/src/ui/TmdbListSourceFlow.jsx
+++ b/builder/src/ui/TmdbListSourceFlow.jsx
@@ -12,12 +12,13 @@ import {
 	tmdbListDuplicateOverrideIdentity,
 	TMDB_LIST_PLACEMENT_STATUSES,
 } from "../source-add/index.js";
+import { reversibleTitleFieldProps } from "../nuvio/titles.js";
 import { lockAddSourceDocumentBody, observeAddSourceViewport, resolveAddSourceViewportStyle } from "./add-source-modal-lifecycle.js";
 import { HierarchyCollectionPresentationControls } from "./CollectionPresentationChoices.jsx";
 import { CreationHeader } from "./CreationHeader.jsx";
 import { focusElementWithoutScroll } from "./hierarchy-menu-placement.js";
 import { handleDialogKeyDown } from "./modal-focus.js";
-import { FolderShapeChoices, PresentationSwitch, TitleOptions } from "./PresentationControls.jsx";
+import { FolderShapeChoices, HiddenTitleFieldHelp, PresentationSwitch, TitleOptions } from "./PresentationControls.jsx";
 import { SourceElsewhereNotice } from "./SourceElsewhereNotice.jsx";
 import { SourceTitlePreviewDialog } from "./SourceTitlePreviewDialog.jsx";
 
@@ -207,6 +208,13 @@ export function TmdbListSourceFlow({
 	}
 	function updatePresentation(patch) {
 		setPresentation((current) => Object.freeze({ ...current, ...patch }));
+		if (patch.hideCollectionTitle === true || patch.folderTitleVisibility === "HIDE_EVERYWHERE") {
+			setRequiredNameErrors((current) => Object.freeze({
+				...current,
+				...(patch.hideCollectionTitle === true ? { collection: false } : {}),
+				...(patch.folderTitleVisibility === "HIDE_EVERYWHERE" ? { folder: false } : {}),
+			}));
+		}
 		setDiagnostic(null);
 	}
 	function updateRequiredName(field, value) {
@@ -222,8 +230,8 @@ export function TmdbListSourceFlow({
 		if (applying) return;
 		if (!standalone) {
 			const missing = Object.freeze({
-				collection: scope === "new-collection" && !collectionTitle.trim(),
-				folder: !folderTitle.trim(),
+				collection: scope === "new-collection" && !presentation.hideCollectionTitle && !collectionTitle.trim(),
+				folder: presentation.folderTitleVisibility !== "HIDE_EVERYWHERE" && !folderTitle.trim(),
 			});
 			if (missing.collection || missing.folder) {
 				setRequiredNameErrors(missing);
@@ -260,6 +268,8 @@ export function TmdbListSourceFlow({
 	}) : planResult?.ok ? planResult.plan.outcomes : [];
 	const count = standalone ? (duplicateOverride ? lists.length : normalAddCount) : planResult?.ok ? planResult.plan.counts.sourceCount : lists.length;
 	const requiredNameMessage = requiredNamesMessage(requiredNameErrors);
+	const collectionTitleHiddenEverywhere = presentation.hideCollectionTitle;
+	const folderTitleHiddenEverywhere = presentation.folderTitleVisibility === "HIDE_EVERYWHERE";
 	const back = () => { if (applying) return; if (step === "review") { setStep("select"); setDiagnostic(null); setRequiredNameErrors(Object.freeze({ collection: false, folder: false })); } else onBack(); };
 
 	const inner = <>
@@ -274,8 +284,8 @@ export function TmdbListSourceFlow({
 					{lists.length ? <SelectedLists lists={lists} onPreview={openPreview} onRemove={(id) => setLists((current) => Object.freeze(current.filter((list) => list.id !== id)))} /> : null}
 				</> : <section className="tmdb-list-review" aria-labelledby="tmdb-list-review-title">
 					<div className="add-source-section-heading"><div><p className="panel-kicker">Review</p><h3 ref={headingRef} id="tmdb-list-review-title" tabIndex={-1}>{count ? `${count} source${count === 1 ? "" : "s"} will be added` : "Nothing to add"}</h3></div></div>
-					{!standalone && scope === "new-collection" ? <div className="editor-field"><label htmlFor="tmdb-list-collection-title">Collection name</label><input ref={collectionTitleRef} id="tmdb-list-collection-title" type="text" value={collectionTitle} aria-invalid={requiredNameErrors.collection ? "true" : undefined} aria-describedby={requiredNameErrors.collection ? "tmdb-list-required-names" : undefined} onChange={(event) => updateRequiredName("collection", event.target.value)} /></div> : null}
-					{!standalone ? <div className="editor-field"><label htmlFor="tmdb-list-folder-title">Folder name</label><input ref={folderTitleRef} id="tmdb-list-folder-title" type="text" value={folderTitle} aria-invalid={requiredNameErrors.folder ? "true" : undefined} aria-describedby={`tmdb-list-folder-help${requiredNameErrors.folder ? " tmdb-list-required-names" : ""}`} onChange={(event) => updateRequiredName("folder", event.target.value)} /><p id="tmdb-list-folder-help" className="editor-field-help">One folder will contain the selected List sources in this order.</p></div> : null}
+					{!standalone && scope === "new-collection" ? <div className="editor-field"><label htmlFor="tmdb-list-collection-title">Collection name</label><input ref={collectionTitleRef} id="tmdb-list-collection-title" type="text" {...reversibleTitleFieldProps(collectionTitle, collectionTitleHiddenEverywhere)} aria-invalid={requiredNameErrors.collection ? "true" : undefined} aria-describedby={[collectionTitleHiddenEverywhere ? "tmdb-list-collection-title-hidden-help" : null, requiredNameErrors.collection ? "tmdb-list-required-names" : null].filter(Boolean).join(" ") || undefined} onChange={(event) => updateRequiredName("collection", event.target.value)} /><HiddenTitleFieldHelp id="tmdb-list-collection-title-hidden-help" hidden={collectionTitleHiddenEverywhere} kind="collection" /></div> : null}
+					{!standalone ? <div className="editor-field"><label htmlFor="tmdb-list-folder-title">Folder name</label><input ref={folderTitleRef} id="tmdb-list-folder-title" type="text" {...reversibleTitleFieldProps(folderTitle, folderTitleHiddenEverywhere)} aria-invalid={requiredNameErrors.folder ? "true" : undefined} aria-describedby={[folderTitleHiddenEverywhere ? "tmdb-list-folder-title-hidden-help" : "tmdb-list-folder-help", requiredNameErrors.folder ? "tmdb-list-required-names" : null].filter(Boolean).join(" ")} onChange={(event) => updateRequiredName("folder", event.target.value)} /><HiddenTitleFieldHelp id="tmdb-list-folder-title-hidden-help" hidden={folderTitleHiddenEverywhere} kind="folder" />{!folderTitleHiddenEverywhere ? <p id="tmdb-list-folder-help" className="editor-field-help">One folder will contain the selected List sources in this order.</p> : null}</div> : null}
 					{!standalone ? <GuidedPresentationControls scope={scope} options={presentation} destinationCollectionTitle={destinationCollectionTitle} onChange={updatePresentation} /> : null}
 					<div className="tmdb-list-review-items">{lists.map((list, index) => { const outcome = reviewOutcomes[index] ?? { status: TMDB_LIST_PLACEMENT_STATUSES.READY, elsewhere: [] }; const sourceHelpId = `tmdb-list-source-title-${list.id}-help`; return <article key={list.id} className="tmdb-list-review-item"><div><strong>{list.name || `TMDB list ${list.id}`}</strong><em>{statusLabel(outcome.status)}</em></div><small>TMDB {list.id} · {list.itemCount} title{list.itemCount === 1 ? "" : "s"} · Original order</small><div className="editor-field"><label htmlFor={`tmdb-list-source-title-${list.id}`}>Source name</label><input id={`tmdb-list-source-title-${list.id}`} type="text" value={list.sourceTitle} aria-describedby={sourceHelpId} onChange={(event) => updateTitle(list.id, event.target.value)} /><p id={sourceHelpId} className="editor-field-help">{SOURCE_NAME_HELPER}</p></div>{outcome.elsewhere?.length ? <SourceElsewhereNotice occurrences={outcome.elsewhere} heading="This TMDB List source exists elsewhere" action="It can still be added here." /> : null}</article>; })}</div>
 					{standalone && destinationDuplicates.length ? <div className="editor-diagnostics"><p>{destinationDuplicates.length} selected source{destinationDuplicates.length === 1 ? " is" : "s are"} already in this folder and will be omitted.</p><button type="button" onClick={() => setDuplicateOverride((value) => !value)}>{duplicateOverride ? "Omit existing sources" : "Add all anyway"}</button></div> : null}

--- a/builder/src/ui/node-editor.js
+++ b/builder/src/ui/node-editor.js
@@ -3,6 +3,7 @@ import {
 	isValidNuvioTitle,
 	isValidVisibleNuvioTitle,
 	NUVIO_INVISIBLE_TITLE,
+	transitionReversibleTitleDraft,
 } from "../nuvio/titles.js";
 import { FOLDER_ARTWORK_TEXT_FIELD_NAMES } from "../nuvio/folder-artwork-fields.js";
 import {
@@ -249,19 +250,18 @@ export function updateNodeEditorField(draft, field, value) {
 	}
 
 	if (field === "hideNuvioTitle") {
-		const visibleTitleDraft = value
-			? (
-				isValidVisibleNuvioTitle(draft.values.title)
-					? draft.values.title
-					: draft.visibleTitleDraft
-			)
-			: draft.visibleTitleDraft;
+		const titleTransition = transitionReversibleTitleDraft({
+			title: draft.values.title,
+			visibleTitleDraft: draft.visibleTitleDraft,
+			hiddenEverywhere: value,
+			hiddenTitle: NUVIO_INVISIBLE_TITLE,
+		});
 
 		return {
 			...draft,
 			values: {
 				...draft.values,
-				title: value ? NUVIO_INVISIBLE_TITLE : visibleTitleDraft ?? "",
+				title: titleTransition.title,
 				hideNuvioTitle: value,
 			},
 			touched: {
@@ -269,19 +269,17 @@ export function updateNodeEditorField(draft, field, value) {
 				title: true,
 				hideNuvioTitle: true,
 			},
-			visibleTitleDraft,
+			visibleTitleDraft: titleTransition.visibleTitleDraft,
 		};
 	}
 
 	if (field === "folderTitleVisibility") {
 		const hidingEverywhere = value === "HIDE_EVERYWHERE";
-		const visibleTitleDraft = hidingEverywhere
-			? (
-				isValidVisibleNuvioTitle(draft.values.title)
-					? draft.values.title
-					: draft.visibleTitleDraft
-			)
-			: draft.visibleTitleDraft;
+		const titleTransition = transitionReversibleTitleDraft({
+			title: draft.values.title,
+			visibleTitleDraft: draft.visibleTitleDraft,
+			hiddenEverywhere: hidingEverywhere,
+		});
 		const canonicalizeFolderInvisibleTitle = hidingEverywhere && (
 			!draft.original.title.hidden
 			|| (draft.touched.title && isValidVisibleNuvioTitle(draft.values.title))
@@ -291,14 +289,14 @@ export function updateNodeEditorField(draft, field, value) {
 			...draft,
 			values: {
 				...draft.values,
-				title: hidingEverywhere ? "" : visibleTitleDraft ?? "",
+				title: titleTransition.title,
 				folderTitleVisibility: value,
 			},
 			touched: {
 				...draft.touched,
 				folderTitleVisibility: true,
 			},
-			visibleTitleDraft,
+			visibleTitleDraft: titleTransition.visibleTitleDraft,
 			canonicalizeFolderInvisibleTitle,
 		};
 	}

--- a/tests/builder-decades-plan.test.mjs
+++ b/tests/builder-decades-plan.test.mjs
@@ -134,6 +134,16 @@ test("New Collection applies one selected collection and folder appearance confi
 	assert.ok(current.getState().project.collections.every((collection) => collection.editable.title === NUVIO_INVISIBLE_TITLE));
 });
 
+test("Decades keyed hidden collection drafts do not participate in final visible-title validation", () => {
+	const current = controller();
+	const options = { collectionTitles: { movies: "" }, source: sourceConfiguration({ mediaMode: "movies" }) };
+	const hidden = planFor(current, { ...options, hideCollectionTitle: true });
+	assert.equal(hidden.ok, true);
+	assert.deepEqual(hidden.plan.configuration.collectionTitles, { movies: "" });
+	assert.equal(hidden.plan.collections[0].editable.title, NUVIO_INVISIBLE_TITLE);
+	assert.equal(planFor(current, { ...options, hideCollectionTitle: false }).ok, false);
+});
+
 test("source names follow physical folder media composition and keep All aggregate distinct", () => {
 	for (const [mediaMode, genreName] of [["movies", "Horror"], ["series", "Drama"]]) {
 		const current = controller();

--- a/tests/builder-franchise-hierarchy.test.mjs
+++ b/tests/builder-franchise-hierarchy.test.mjs
@@ -151,6 +151,17 @@ test("folder title visibility remains batch-safe while Franchise tile artwork st
 	assert.equal(unsupported.errors[0].code, "INVALID_FRANCHISE_PLAN_OPTIONS");
 });
 
+test("Franchise hidden collection output does not require its remembered visible title draft", () => {
+	const app = controller();
+	const state = app.getState();
+	const selected = [franchise(10, "Example Collection")];
+	const hidden = createFranchiseHierarchyPlan(state.project, { scope: "new-collection", projectRevision: state.revision, collectionTitle: "", hideCollectionTitle: true, franchises: selected });
+	assert.equal(hidden.ok, true);
+	assert.equal(hidden.plan.configuration.collectionTitle, "");
+	assert.equal(hidden.plan.collections[0].editable.title, NUVIO_INVISIBLE_TITLE);
+	assert.equal(createFranchiseHierarchyPlan(state.project, { scope: "new-collection", projectRevision: state.revision, collectionTitle: "", hideCollectionTitle: false, franchises: selected }).ok, false);
+});
+
 test("Franchise Rows plans force the compatibility All-tab value on while Tabs keeps an explicit choice", () => {
 	const app = controller();
 	const state = app.getState();

--- a/tests/builder-genre-hierarchy.test.mjs
+++ b/tests/builder-genre-hierarchy.test.mjs
@@ -133,6 +133,23 @@ test("Genre hierarchy applies every canonical Folder title outcome independently
 	}
 });
 
+test("Genre keyed hidden collection drafts do not participate in final visible-title validation", () => {
+	const app = controller();
+	const state = app.getState();
+	const options = {
+		scope: "new-collection",
+		projectRevision: state.revision,
+		structure: "separate-media-collections",
+		collectionTitles: { movies: "", series: "" },
+		genres: ["Comedy"],
+	};
+	const hidden = createGenreHierarchyPlan(state.project, { ...options, hideCollectionTitle: true });
+	assert.equal(hidden.ok, true);
+	assert.deepEqual(hidden.plan.configuration.collectionTitles, { movies: "", series: "" });
+	assert.deepEqual(hidden.plan.collections.map((collection) => collection.editable.title), [NUVIO_INVISIBLE_TITLE, NUVIO_INVISIBLE_TITLE]);
+	assert.equal(createGenreHierarchyPlan(state.project, { ...options, hideCollectionTitle: false }).ok, false);
+});
+
 test("all 27 official Genre concepts have explicit published Landscape and Poster mappings", () => {
 	assert.equal(GENRE_CONCEPTS.length, 27);
 	for (const concept of GENRE_CONCEPTS) {

--- a/tests/builder-network-hierarchy.test.mjs
+++ b/tests/builder-network-hierarchy.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { createBuilderController } from "../builder/src/application/index.js";
+import { NUVIO_INVISIBLE_TITLE } from "../builder/src/nuvio/titles.js";
 import {
 	DEFAULT_NETWORK_SERIES_COUNT_FILTER,
 	networkMatchesSeriesCountFilter,
@@ -219,6 +220,16 @@ test("Network plan defaults to Networks, Popular, Show everywhere, Poster, canon
 	assert.equal(folder.editable.hideTitle, false);
 	assert.equal(folder.editable.tileShape, "POSTER");
 	assert.equal(folder.sources[0].draft.editable.title, "Series");
+});
+
+test("Network hidden collection output does not require its remembered visible title draft", () => {
+	const app = controller();
+	const state = app.getState();
+	const hidden = createNetworkHierarchyPlan(state.project, { scope: "new-collection", projectRevision: state.revision, collectionTitle: "", hideCollectionTitle: true, networks: planEntries([network(2)]) });
+	assert.equal(hidden.ok, true);
+	assert.equal(hidden.plan.configuration.collectionTitle, "");
+	assert.equal(hidden.plan.collections[0].editable.title, NUVIO_INVISIBLE_TITLE);
+	assert.equal(createNetworkHierarchyPlan(state.project, { scope: "new-collection", projectRevision: state.revision, collectionTitle: "", hideCollectionTitle: false, networks: planEntries([network(2)]) }).ok, false);
 });
 
 test("New Folder distinguishes Already, Elsewhere and Ready without a Partial state", () => {

--- a/tests/builder-node-editing.test.mjs
+++ b/tests/builder-node-editing.test.mjs
@@ -13,6 +13,8 @@ import {
 	isValidNuvioTitle,
 	isValidVisibleNuvioTitle,
 	NUVIO_INVISIBLE_TITLE,
+	reversibleTitleFieldProps,
+	transitionReversibleTitleDraft,
 } from "../builder/src/nuvio/titles.js";
 import {
 	COLLECTION_EDITABLE_FIELDS,
@@ -48,6 +50,13 @@ const {
 	BuilderWorkspace,
 	shouldOpenHierarchyEditorFromDoubleClick,
 } = await vite.ssrLoadModule("/src/ui/BuilderWorkspace.jsx");
+const {
+	COLLECTION_INVISIBLE_TITLE_HELP,
+	COLLECTIONS_INVISIBLE_TITLE_HELP,
+	FOLDER_INVISIBLE_TITLE_HELP,
+	FOLDERS_INVISIBLE_TITLE_HELP,
+	HiddenTitleFieldHelp,
+} = await vite.ssrLoadModule("/src/ui/PresentationControls.jsx");
 after(() => vite.close());
 
 function countingIdFactory(prefix = "internal") {
@@ -1059,6 +1068,68 @@ test("collection hidden-title toggle emits one U+200E and restores the prior vis
 	assert.equal(draft.values.title, "Collection title");
 	assert.equal(draft.values.hideNuvioTitle, false);
 	assert.deepEqual(buildNodeEditorPatch(draft), {});
+});
+
+test("shared reversible title fields blank only the control and restore the latest visible draft", () => {
+	let draft = { title: "Custom", visibleTitleDraft: null };
+	assert.deepEqual(reversibleTitleFieldProps(draft.title, false), { value: "Custom", disabled: false });
+
+	draft = transitionReversibleTitleDraft({ ...draft, hiddenEverywhere: true, hiddenTitle: NUVIO_INVISIBLE_TITLE });
+	assert.deepEqual(draft, { title: NUVIO_INVISIBLE_TITLE, visibleTitleDraft: "Custom" });
+	assert.deepEqual(reversibleTitleFieldProps(draft.visibleTitleDraft, true), { value: "", disabled: true });
+
+	draft = transitionReversibleTitleDraft({ ...draft, hiddenEverywhere: false, hiddenTitle: NUVIO_INVISIBLE_TITLE });
+	assert.deepEqual(draft, { title: "Custom", visibleTitleDraft: "Custom" });
+	draft = { ...draft, title: "Custom 2", visibleTitleDraft: "Custom 2" };
+	draft = transitionReversibleTitleDraft({ ...draft, hiddenEverywhere: true, hiddenTitle: NUVIO_INVISIBLE_TITLE });
+	draft = transitionReversibleTitleDraft({ ...draft, hiddenEverywhere: false, hiddenTitle: NUVIO_INVISIBLE_TITLE });
+	assert.deepEqual(draft, { title: "Custom 2", visibleTitleDraft: "Custom 2" });
+});
+
+test("shared hidden-title help uses the authoritative singular and grouped wording only while hidden", () => {
+	assert.equal(COLLECTION_INVISIBLE_TITLE_HELP, "The collection title is intentionally invisible in Nuvio. Turn off the setting below to enter a visible title.");
+	assert.equal(COLLECTIONS_INVISIBLE_TITLE_HELP, "Collection titles are intentionally hidden in Nuvio. Turn this off to edit visible titles.");
+	assert.equal(FOLDER_INVISIBLE_TITLE_HELP, "The folder title is intentionally invisible everywhere in Nuvio. Choose a visible option below to enter a visible title.");
+	assert.equal(FOLDERS_INVISIBLE_TITLE_HELP, "Folder titles are intentionally invisible everywhere in Nuvio. Choose a visible option below to enter visible titles.");
+
+	assert.equal(renderToStaticMarkup(createElement(HiddenTitleFieldHelp, { id: "visible", hidden: false, kind: "collection" })), "");
+	const collection = renderToStaticMarkup(createElement(HiddenTitleFieldHelp, { id: "collection-help", hidden: true, kind: "collection" }));
+	assert.match(collection, /id="collection-help"[^>]*role="status"/);
+	assert.ok(collection.includes(COLLECTION_INVISIBLE_TITLE_HELP));
+	const collections = renderToStaticMarkup(createElement(HiddenTitleFieldHelp, { id: "collections-help", hidden: true, kind: "collection", plural: true }));
+	assert.ok(collections.includes(COLLECTIONS_INVISIBLE_TITLE_HELP));
+	const folder = renderToStaticMarkup(createElement(HiddenTitleFieldHelp, { id: "folder-help", hidden: true, kind: "folder" }));
+	assert.ok(folder.includes(FOLDER_INVISIBLE_TITLE_HELP));
+	const folders = renderToStaticMarkup(createElement(HiddenTitleFieldHelp, { id: "folders-help", hidden: true, kind: "folder", plural: true }));
+	assert.ok(folders.includes(FOLDERS_INVISIBLE_TITLE_HELP));
+});
+
+test("all guided output-title fields reuse reversible fields and contextual hidden-state help", () => {
+	for (const file of [
+		"CreationDialog.jsx",
+		"PeopleSourceFlow.jsx",
+		"FranchiseSourceFlow.jsx",
+		"StudioHierarchyFlow.jsx",
+		"NetworkHierarchyFlow.jsx",
+		"GenreHierarchyFlow.jsx",
+		"StreamingHierarchyFlow.jsx",
+		"TmdbListSourceFlow.jsx",
+	]) {
+		const source = fs.readFileSync(path.join(rootDir, "builder", "src", "ui", file), "utf8");
+		assert.match(source, /reversibleTitleFieldProps/, file);
+		assert.match(source, /HiddenTitleFieldHelp/, file);
+	}
+
+	const decades = fs.readFileSync(path.join(rootDir, "builder", "src", "ui", "CreationDialog.jsx"), "utf8");
+	assert.match(decades, /kind="collection" plural/);
+	const genres = fs.readFileSync(path.join(rootDir, "builder", "src", "ui", "GenreHierarchyFlow.jsx"), "utf8");
+	assert.match(genres, /genre-hierarchy-collection-titles-hidden-help[\s\S]*kind="collection" plural/);
+	const streaming = fs.readFileSync(path.join(rootDir, "builder", "src", "ui", "StreamingHierarchyFlow.jsx"), "utf8");
+	assert.match(streaming, /kind="folder" plural=\{folders\.length > 1\}/);
+	assert.match(streaming, /options\.folderTitleVisibility === "HIDE_EVERYWHERE"/);
+	const lists = fs.readFileSync(path.join(rootDir, "builder", "src", "ui", "TmdbListSourceFlow.jsx"), "utf8");
+	assert.match(lists, /folderTitleHiddenEverywhere \? "tmdb-list-folder-title-hidden-help" : "tmdb-list-folder-help"/);
+	assert.match(lists, /!folderTitleHiddenEverywhere \? <p id="tmdb-list-folder-help"/);
 });
 
 test("folder Hide everywhere emits one U+200E and restores the original visible choice", () => {

--- a/tests/builder-people-hierarchy.test.mjs
+++ b/tests/builder-people-hierarchy.test.mjs
@@ -206,6 +206,17 @@ test("People New Collection plan preserves order, canonical naming, source seman
 	assert.deepEqual(result.plan.counts, { collectionCount: 1, folderCount: 2, sourceCount: 4 });
 });
 
+test("People hidden collection output does not require its remembered visible title draft", () => {
+	const app = controller();
+	const state = app.getState();
+	const people = [planEntry({ id: 31, name: "Tom Hanks" }, ["acting-movies"])];
+	const hidden = createPeopleHierarchyPlan(state.project, { scope: "new-collection", projectRevision: state.revision, collectionTitle: "", hideCollectionTitle: true, people });
+	assert.equal(hidden.ok, true);
+	assert.equal(hidden.plan.configuration.collectionTitle, "");
+	assert.equal(hidden.plan.collections[0].editable.title, NUVIO_INVISIBLE_TITLE);
+	assert.equal(createPeopleHierarchyPlan(state.project, { scope: "new-collection", projectRevision: state.revision, collectionTitle: "", hideCollectionTitle: false, people }).ok, false);
+});
+
 test("People Rows plans force the compatibility All-tab value on while Tabs keeps an explicit choice", () => {
 	const app = controller();
 	const state = app.getState();

--- a/tests/builder-people-ui.test.mjs
+++ b/tests/builder-people-ui.test.mjs
@@ -584,6 +584,16 @@ test("People Review keeps shared Title options and Layout visible and only colla
 	assert.equal(markup.includes("decades-settings-disclosure"), false);
 	assert.equal((markup.match(/<details/g) ?? []).length, 1);
 	assert.ok(markup.includes("View person details · 1"));
+	assert.equal(markup.includes("The collection title is intentionally invisible in Nuvio."), false);
+	const hiddenTitleMarkup = renderToStaticMarkup(createElement(PeopleReviewStep, {
+		planResult: { ok: true, plan: { configuration: { scope: "new-collection" }, counts: { collectionCount: 1, folderCount: 1, sourceCount: 2 }, collections: [{ titleCollisions: [] }], destination: null, outcomes: [{ status: "ready-to-create", occurrences: [] }] } },
+		entries: [{ person: selected, drafts: { drafts: [{}, {}] }, artworkState: { artwork: { source: "manifest" } } }],
+		collectionOptions: { title: "People", hideTitle: true, viewMode: "TABBED_GRID", showAllTab: true, pinToTop: false },
+		onCollectionOptionsChange() {}, folderTileShape: "POSTER", onFolderTileShapeChange() {}, folderTitleVisibility: "HIDE_HOME_SCREEN", onFolderTitleVisibilityChange() {}, applyDiagnostic: null, headingRef: null,
+	}));
+	assert.match(hiddenTitleMarkup, /<input(?=[^>]*id="people-collection-title")(?=[^>]*value="")(?=[^>]*disabled="")(?=[^>]*aria-describedby="people-collection-title-hidden-help")[^>]*>/);
+	assert.equal((hiddenTitleMarkup.match(/The collection title is intentionally invisible in Nuvio\. Turn off the setting below to enter a visible title\./g) ?? []).length, 1);
+	assert.ok(hiddenTitleMarkup.includes(selected.name));
 	const rowsMarkup = renderToStaticMarkup(createElement(PeopleReviewStep, {
 		planResult: { ok: true, plan: { configuration: { scope: "new-collection" }, counts: { collectionCount: 1, folderCount: 1, sourceCount: 2 }, collections: [{ titleCollisions: [] }], destination: null, outcomes: [{ status: "ready-to-create", occurrences: [] }] } },
 		entries: [{ person: selected, drafts: { drafts: [{}, {}] }, artworkState: { artwork: { source: "manifest" } } }],

--- a/tests/builder-source-edit-mounted.test.mjs
+++ b/tests/builder-source-edit-mounted.test.mjs
@@ -2234,6 +2234,18 @@ test("mounted Streaming New Collection disambiguates duplicate titles and routes
 			apple: "Curated Apple New",
 			dekkoo: "Curated Dekkoo",
 		}, `${result.width}px New Collection naming state`);
+		assert.deepEqual(result.review.titleVisibility, {
+			collectionHidden: true,
+			collectionHiddenHelp: true,
+			collectionRestored: true,
+			collectionHiddenHelpRemoved: true,
+			latestCollectionRestored: true,
+			folderHidden: true,
+			folderHiddenHelp: true,
+			folderHomeOnlyRestored: true,
+			folderHiddenHelpRemovedOnHomeOnly: true,
+			planningLabelsRetained: true,
+		}, `${result.width}px live reversible Collection and keyed Folder title fields`);
 		assert.deepEqual(result.review.existingDestinationState, {
 			collectionNameAbsent: true,
 			folderNameCount: 1,

--- a/tests/builder-streaming-hierarchy-ui.test.mjs
+++ b/tests/builder-streaming-hierarchy-ui.test.mjs
@@ -333,7 +333,8 @@ test("Folder naming is collapsed, stable-keyed, validated, and limited to new fo
 	assert.match(flow, /Use default name/);
 	assert.doesNotMatch(flow, /Display title for this new folder/);
 	assert.match(flow, /Keep the generated names or customise new folders/);
-	assert.match(flow, /aria-describedby=\{`\$\{inputId\}-error`\}/);
+	assert.match(flow, /aria-describedby=\{\[`\$\{inputId\}-error`, hiddenEverywhere \? "streaming-folder-titles-hidden-help" : null\]/);
+	assert.match(flow, /<HiddenTitleFieldHelp id="streaming-folder-titles-hidden-help" hidden=\{hiddenEverywhere\} kind="folder" plural=\{folders\.length > 1\}/);
 	assert.doesNotMatch(flow, /Source names and Streaming identity stay unchanged/);
 	assert.match(flow, /setFolderTitleDrafts\(\(current\) => \(\{ \.\.\.current, \[key\]: title \}\)\)/);
 	assert.match(flow, /currentKeys\.has\(key\)/);

--- a/tests/builder-streaming-hierarchy.test.mjs
+++ b/tests/builder-streaming-hierarchy.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { createBuilderController } from "../builder/src/application/index.js";
+import { NUVIO_INVISIBLE_TITLE } from "../builder/src/nuvio/titles.js";
 import {
 	applyStreamingHierarchyPlan,
 	buildStreamingSourceDrafts,
@@ -710,6 +711,24 @@ test("folder-name overrides reuse Folder title validation and discard removed lo
 	assert.equal(removed.ok, true);
 	assert.deepEqual(removed.plan.configuration.folderTitleOverrides, { "8": "Kept" });
 	assert.equal(removed.plan.newFolders[0].editable.title, "Kept");
+});
+
+test("Streaming hidden collection and keyed folder drafts bypass only final visible-title validation", () => {
+	const controller = createController();
+	const hidden = createStreamingHierarchyPlan(controller.getState().project, baseOptions(controller, {
+		collectionTitle: "",
+		hideCollectionTitle: true,
+		folderTitleVisibility: "HIDE_EVERYWHERE",
+		folderTitleOverrides: { "8": "" },
+		providers: [netflix],
+	}));
+	assert.equal(hidden.ok, true);
+	assert.equal(hidden.plan.configuration.collectionTitle, "");
+	assert.deepEqual(hidden.plan.configuration.folderTitleOverrides, { "8": "" });
+	assert.equal(hidden.plan.collections[0].editable.title, NUVIO_INVISIBLE_TITLE);
+	assert.equal(hidden.plan.newFolders[0].editable.title, NUVIO_INVISIBLE_TITLE);
+	assert.equal(createStreamingHierarchyPlan(controller.getState().project, baseOptions(controller, { collectionTitle: "", providers: [netflix] })).ok, false);
+	assert.equal(createStreamingHierarchyPlan(controller.getState().project, baseOptions(controller, { folderTitleOverrides: { "8": "" }, providers: [netflix] })).ok, false);
 });
 
 test("grouped plan atomically extends existing Netflix and creates Disney+", () => {

--- a/tests/builder-studio-hierarchy.test.mjs
+++ b/tests/builder-studio-hierarchy.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { createBuilderController } from "../builder/src/application/index.js";
+import { NUVIO_INVISIBLE_TITLE } from "../builder/src/nuvio/titles.js";
 import {
 	applyStudioHierarchyPlan,
 	buildStudioSourceDrafts,
@@ -118,6 +119,16 @@ test("Studio plan defaults to Movies, Popular, Show everywhere and fixed Landsca
 	assert.equal(result.plan.configuration.folderTileShape, "LANDSCAPE");
 	assert.equal(result.plan.collections[0].folders[0].editable.hideTitle, false);
 	assert.equal(result.plan.collections[0].folders[0].sources[0].draft.editable.title, "Movies");
+});
+
+test("Studio hidden collection output does not require its remembered visible title draft", () => {
+	const app = controller();
+	const state = app.getState();
+	const hidden = createStudioHierarchyPlan(state.project, { scope: "new-collection", projectRevision: state.revision, collectionTitle: "", hideCollectionTitle: true, studios: planEntries([studio(3)]) });
+	assert.equal(hidden.ok, true);
+	assert.equal(hidden.plan.configuration.collectionTitle, "");
+	assert.equal(hidden.plan.collections[0].editable.title, NUVIO_INVISIBLE_TITLE);
+	assert.equal(createStudioHierarchyPlan(state.project, { scope: "new-collection", projectRevision: state.revision, collectionTitle: "", hideCollectionTitle: false, studios: planEntries([studio(3)]) }).ok, false);
 });
 
 test("one artwork runtime load resolves a batch before plan creation and falls back logo then emoji", async () => {

--- a/tests/builder-tmdb-lists-ui.test.mjs
+++ b/tests/builder-tmdb-lists-ui.test.mjs
@@ -121,7 +121,7 @@ test("guided Lists starts with empty names, uses concise shared create copy, and
 
 test("guided Lists directly reuses standard Collection and Folder presentation controls while Add Source remains container-free", () => {
 	assert.match(flow, /import \{ HierarchyCollectionPresentationControls \} from "\.\/CollectionPresentationChoices\.jsx"/);
-	assert.match(flow, /import \{ FolderShapeChoices, PresentationSwitch, TitleOptions \} from "\.\/PresentationControls\.jsx"/);
+	assert.match(flow, /import \{ FolderShapeChoices, HiddenTitleFieldHelp, PresentationSwitch, TitleOptions \} from "\.\/PresentationControls\.jsx"/);
 	assert.match(flow, /<TitleOptions[\s\S]*collectionTitleVisibility=\{scope === "new-collection"[\s\S]*folderTitleVisibility=/);
 	assert.match(flow, /<HierarchyCollectionPresentationControls[\s\S]*showAllTab=\{options\.showAllTab\}/);
 	assert.match(flow, /<PresentationSwitch label="Pin collection to top"/);

--- a/tests/builder-tmdb-lists.test.mjs
+++ b/tests/builder-tmdb-lists.test.mjs
@@ -296,6 +296,27 @@ test("guided TMDB Lists maps the shared Collection and Folder presentation choic
 	]) assert.equal(createTmdbListHierarchyPlan(state.project, { scope: "new-collection", projectRevision: state.revision, collectionTitle: "Lists", folderTitle: "Folder", lists: [list(33)], ...invalid }).ok, false);
 });
 
+test("guided TMDB Lists validates remembered titles only when their final fields stay visible", () => {
+	const controller = app();
+	const state = controller.getState();
+	const hidden = createTmdbListHierarchyPlan(state.project, {
+		scope: "new-collection",
+		projectRevision: state.revision,
+		collectionTitle: "",
+		hideCollectionTitle: true,
+		folderTitle: "",
+		folderTitleVisibility: "HIDE_EVERYWHERE",
+		lists: [list(34)],
+	});
+	assert.equal(hidden.ok, true);
+	assert.equal(hidden.plan.configuration.collectionTitle, "");
+	assert.equal(hidden.plan.configuration.folderTitle, "");
+	assert.equal(hidden.plan.collections[0].editable.title, NUVIO_INVISIBLE_TITLE);
+	assert.equal(hidden.plan.collections[0].folders[0].editable.title, NUVIO_INVISIBLE_TITLE);
+	assert.equal(createTmdbListHierarchyPlan(state.project, { scope: "new-collection", projectRevision: state.revision, collectionTitle: "", folderTitle: "Folder", lists: [list(35)] }).ok, false);
+	assert.equal(createTmdbListHierarchyPlan(state.project, { scope: "new-collection", projectRevision: state.revision, collectionTitle: "Lists", folderTitle: "", lists: [list(36)] }).ok, false);
+});
+
 test("guided TMDB Lists has no arbitrary bulk cap and a late atomic failure rolls back all hierarchy nodes", () => {
 	const controller = app();
 	let state = controller.getState();

--- a/tests/fixtures/builder-source-edit-mounted.jsx
+++ b/tests/fixtures/builder-source-edit-mounted.jsx
@@ -3280,13 +3280,47 @@ async function runStreamingHierarchyScenario(runLivePreview = false) {
 		review = required(dialog.querySelector(".streaming-hierarchy-review"), "New Collection Review");
 		let newFolderNames = required(review.querySelector(".streaming-folder-names"), "New Collection folder names");
 		await clickAndSettle(required(newFolderNames.querySelector("summary"), "New Collection Folder names summary"));
+		let newCollectionName = required(review.querySelector("#streaming-collection-name"), "new Collection name");
 		let newAppleName = required(review.querySelector("#streaming-folder-name-2"), "new Apple folder name");
 		let newDekkooName = required(review.querySelector("#streaming-folder-name-444"), "new Dekkoo folder name");
 		await act(async () => {
+			setInputValue(newCollectionName, "Custom Collection");
 			setInputValue(newAppleName, "Curated Apple New");
 			setInputValue(newDekkooName, "Curated Dekkoo");
 			await afterCommittedEffects();
 		});
+		const hideCollectionTitle = required(review.querySelector('[data-editor-control="streamingHideNuvioTitle"]'), "Hide Collection title switch");
+		await clickAndSettle(hideCollectionTitle);
+		review = required(dialog.querySelector(".streaming-hierarchy-review"), "hidden Collection Review");
+		newCollectionName = required(review.querySelector("#streaming-collection-name"), "hidden Collection name");
+		const collectionHidden = newCollectionName.value === "" && newCollectionName.disabled;
+		const collectionHiddenHelp = review.querySelector("#streaming-collection-title-hidden-help")?.textContent.trim() === "The collection title is intentionally invisible in Nuvio. Turn off the setting below to enter a visible title.";
+		await clickAndSettle(required(review.querySelector('[data-editor-control="streamingHideNuvioTitle"]'), "Show Collection title switch"));
+		review = required(dialog.querySelector(".streaming-hierarchy-review"), "restored Collection Review");
+		newCollectionName = required(review.querySelector("#streaming-collection-name"), "restored Collection name");
+		const collectionRestored = newCollectionName.value === "Custom Collection" && !newCollectionName.disabled;
+		const collectionHiddenHelpRemoved = review.querySelector("#streaming-collection-title-hidden-help") === null;
+		await act(async () => { setInputValue(newCollectionName, "Custom Collection 2"); await afterCommittedEffects(); });
+		await clickAndSettle(required(review.querySelector('[data-editor-control="streamingHideNuvioTitle"]'), "rehide Collection title switch"));
+		review = required(dialog.querySelector(".streaming-hierarchy-review"), "rehidden Collection Review");
+		await clickAndSettle(required(review.querySelector('[data-editor-control="streamingHideNuvioTitle"]'), "reshow Collection title switch"));
+		review = required(dialog.querySelector(".streaming-hierarchy-review"), "second restored Collection Review");
+		newCollectionName = required(review.querySelector("#streaming-collection-name"), "second restored Collection name");
+		const latestCollectionRestored = newCollectionName.value === "Custom Collection 2" && !newCollectionName.disabled;
+		await clickAndSettle(required(review.querySelector('input[name="streaming-folder-title-visibility"][value="HIDE_EVERYWHERE"]'), "Hide Folder titles everywhere option"));
+		review = required(dialog.querySelector(".streaming-hierarchy-review"), "hidden Folder-title Review");
+		newAppleName = required(review.querySelector("#streaming-folder-name-2"), "hidden Apple folder name");
+		newDekkooName = required(review.querySelector("#streaming-folder-name-444"), "hidden Dekkoo folder name");
+		const folderHidden = [newAppleName, newDekkooName].every((input) => input.value === "" && input.disabled);
+		const folderHiddenHelp = review.querySelector("#streaming-folder-titles-hidden-help")?.textContent.trim() === "Folder titles are intentionally invisible everywhere in Nuvio. Choose a visible option below to enter visible titles.";
+		const planningLabelsRetained = [...review.querySelectorAll(".streaming-folder-name-field > label")].map((label) => label.textContent.trim()).join("|") === providerNames.join("|");
+		await clickAndSettle(required(review.querySelector('input[name="streaming-folder-title-visibility"][value="HIDE_HOME_SCREEN"]'), "Hide Folder titles on home only option"));
+		review = required(dialog.querySelector(".streaming-hierarchy-review"), "home-only Folder-title Review");
+		newAppleName = required(review.querySelector("#streaming-folder-name-2"), "home-only Apple folder name");
+		newDekkooName = required(review.querySelector("#streaming-folder-name-444"), "home-only Dekkoo folder name");
+		const folderHomeOnlyRestored = newAppleName.value === "Curated Apple New" && !newAppleName.disabled && newDekkooName.value === "Curated Dekkoo" && !newDekkooName.disabled;
+		const folderHiddenHelpRemovedOnHomeOnly = review.querySelector("#streaming-folder-titles-hidden-help") === null;
+		const titleVisibility = { collectionHidden, collectionHiddenHelp, collectionRestored, collectionHiddenHelpRemoved, latestCollectionRestored, folderHidden, folderHiddenHelp, folderHomeOnlyRestored, folderHiddenHelpRemovedOnHomeOnly, planningLabelsRetained };
 		const newCollectionDraftState = {
 			collectionNameVisible: review.querySelector("#streaming-collection-name") !== null,
 			folderNameCount: Number(review.querySelector(".streaming-folder-names")?.dataset.streamingFolderNameCount),
@@ -3332,6 +3366,7 @@ async function runStreamingHierarchyScenario(runLivePreview = false) {
 			focusEntered: reviewFocusEntered,
 			initialDestination,
 			newCollectionDraftState,
+			titleVisibility,
 			existingDestinationState,
 			newCollectionDraftsRestored,
 			planTotals: [...review.querySelectorAll(".decades-plan-totals strong")].map((node) => Number(node.textContent)),


### PR DESCRIPTION
## Summary

- Reuse shared reversible visible-title draft semantics across the Node Editor and all eight guided families: People, Studios, Networks, Genres, Decades, Streaming, Franchises, and TMDB Lists.
- Blank and disable hidden Collection and Hide Everywhere Folder output-title fields immediately, then restore the exact latest visible draft, including independent keyed Collection and Folder drafts.
- Preserve the Folder distinction: Hide on home screen only keeps the visible editable title, while Hide everywhere uses the existing invisible-title outcome.
- Add the shared quiet hidden-state helper with the approved singular and plural Collection and Folder copy.
- Keep existing Nuvio U+200E and hideTitle serialization behavior, source identities and titles, schema, and atomic controller application unchanged.

## Testing

- Focused Node Editor, planner, and guided UI suites: 381 passed.
- Live mounted responsive suite: 45 passed, 2 established truthful Decades deployment-gated skips.
- Responsive widths: 360, 384, 393, 402, 412, 899, 900, 901, and 1280 pixels, plus the retained 393 by 320 short-height case.
- Builder production build passed.
- Full scripts/check.cmd gate passed.
- git diff --check passed.
- Owner desktop visual approval completed for Decades, Genres, People, Franchises, and existing Collection and Folder settings.

Closes #172