### PR TITLE
Avoid duplicate feature-branch validation runs

### DIFF
--- a/.github/workflows/nuvio-contract-validation.yml
+++ b/.github/workflows/nuvio-contract-validation.yml
@@ -2,7 +2,11 @@ name: Nuvio Contract Validation
 
 on:
   push:
+    branches:
+      - main
   pull_request:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

- restrict Nuvio Contract Validation pushes to main
- run pull request validation only when targeting main
- preserve the existing manual-dispatch trigger and all validation job behavior

## Validation

- git diff --check
- exact trigger-only workflow structure comparison against the baseline

Builder and live TMDB suites were not run because no product or runtime code changed.

Closes #184