### PR TITLE
Preserve TMDB Source editability after Nuvio round trips

### DIFF
--- a/builder/src/source-add/decades-classification.js
+++ b/builder/src/source-add/decades-classification.js
@@ -47,7 +47,7 @@ function canonicalText(value) {
 }
 
 function validRating(value) {
-	return value === undefined || (typeof value === "number" && Number.isFinite(value) && value >= 0 && value <= 10);
+	return value === undefined || value === null || (typeof value === "number" && Number.isFinite(value) && value >= 0 && value <= 10);
 }
 
 function inspectEffectiveDecadeSource(value, identity) {
@@ -73,12 +73,12 @@ function inspectEffectiveDecadeSource(value, identity) {
 		&& typeof value.filters.voteAverageLte === "number"
 		&& value.filters.voteAverageGte > value.filters.voteAverageLte
 	) return null;
-	if (value.filters.voteCountGte !== undefined && (!Number.isSafeInteger(value.filters.voteCountGte) || value.filters.voteCountGte < 0)) return null;
-	if (value.filters.withOriginalLanguage !== undefined && (typeof value.filters.withOriginalLanguage !== "string" || !/^[a-z]{2}$/.test(value.filters.withOriginalLanguage))) return null;
-	if (value.filters.withOriginCountry !== undefined && (typeof value.filters.withOriginCountry !== "string" || !/^[A-Z]{2}$/.test(value.filters.withOriginCountry))) return null;
+	if (value.filters.voteCountGte !== undefined && value.filters.voteCountGte !== null && (!Number.isSafeInteger(value.filters.voteCountGte) || value.filters.voteCountGte < 0)) return null;
+	if (value.filters.withOriginalLanguage !== undefined && value.filters.withOriginalLanguage !== null && (typeof value.filters.withOriginalLanguage !== "string" || !/^[a-z]{2}$/.test(value.filters.withOriginalLanguage))) return null;
+	if (value.filters.withOriginCountry !== undefined && value.filters.withOriginCountry !== null && (typeof value.filters.withOriginCountry !== "string" || !/^[A-Z]{2}$/.test(value.filters.withOriginCountry))) return null;
 
 	let genre = null;
-	if (value.filters.withGenres !== undefined) {
+	if (value.filters.withGenres !== undefined && value.filters.withGenres !== null) {
 		if (typeof value.filters.withGenres !== "string" || !/^[1-9]\d*$/.test(value.filters.withGenres)) return null;
 		const genreId = Number(value.filters.withGenres);
 		if (!Number.isSafeInteger(genreId)) return null;
@@ -88,7 +88,7 @@ function inspectEffectiveDecadeSource(value, identity) {
 	}
 
 	const excludedGenres = [];
-	if (value.filters.withoutGenres !== undefined) {
+	if (value.filters.withoutGenres !== undefined && value.filters.withoutGenres !== null) {
 		if (typeof value.filters.withoutGenres !== "string" || !/^[1-9]\d*(,[1-9]\d*)*$/.test(value.filters.withoutGenres)) return null;
 		for (const token of value.filters.withoutGenres.split(",")) {
 			const reference = officialGenreReference(mediaType, Number(token));

--- a/builder/src/source-add/genre-advanced.js
+++ b/builder/src/source-add/genre-advanced.js
@@ -270,7 +270,7 @@ export function compileGenreAdvancedFilters(value, {
 }
 
 function exactYear(value, suffix) {
-	if (value === undefined) return "";
+	if (value === undefined || value === null) return "";
 	if (typeof value !== "string") return null;
 	const match = new RegExp(`^(\\d{4})-${suffix}$`).exec(value);
 	if (!match) return null;
@@ -285,20 +285,20 @@ export function readGenreAdvancedFilters(filters, { mediaType, includedGenre } =
 	const yearFrom = exactYear(filters.releaseDateGte, "01-01");
 	const yearTo = exactYear(filters.releaseDateLte, "12-31");
 	if (yearFrom === null || yearTo === null) return null;
-	const rating = (value) => value === undefined ? "" : typeof value === "number" && Number.isFinite(value) && value >= 0 && value <= 10 ? String(value) : null;
+	const rating = (value) => value === undefined || value === null ? "" : typeof value === "number" && Number.isFinite(value) && value >= 0 && value <= 10 ? String(value) : null;
 	const minimumRating = rating(filters.voteAverageGte);
 	const maximumRating = rating(filters.voteAverageLte);
 	if (minimumRating === null || maximumRating === null) return null;
-	const minimumVotes = filters.voteCountGte === undefined
+	const minimumVotes = filters.voteCountGte === undefined || filters.voteCountGte === null
 		? ""
 		: Number.isSafeInteger(filters.voteCountGte) && filters.voteCountGte >= 0 ? String(filters.voteCountGte) : null;
 	if (minimumVotes === null) return null;
-	const originalLanguage = filters.withOriginalLanguage === undefined ? "" : filters.withOriginalLanguage;
-	const originCountry = filters.withOriginCountry === undefined ? "" : filters.withOriginCountry;
-	if ((originalLanguage && (typeof originalLanguage !== "string" || !/^[a-z]{2}$/.test(originalLanguage)))
-		|| (originCountry && (typeof originCountry !== "string" || !/^[A-Z]{2}$/.test(originCountry)))) return null;
+	const originalLanguage = filters.withOriginalLanguage ?? "";
+	const originCountry = filters.withOriginCountry ?? "";
+	if ((originalLanguage !== "" && (typeof originalLanguage !== "string" || !/^[a-z]{2}$/.test(originalLanguage)))
+		|| (originCountry !== "" && (typeof originCountry !== "string" || !/^[A-Z]{2}$/.test(originCountry)))) return null;
 	const excludedGenreNames = [];
-	if (filters.withoutGenres !== undefined) {
+	if (filters.withoutGenres !== undefined && filters.withoutGenres !== null) {
 		if (typeof filters.withoutGenres !== "string" || !/^[1-9]\d*(,[1-9]\d*)*$/.test(filters.withoutGenres)) return null;
 		for (const token of filters.withoutGenres.split(",")) {
 			const reference = officialGenreReference(mediaType, Number(token));

--- a/builder/src/source-edit/decade-editor.js
+++ b/builder/src/source-edit/decade-editor.js
@@ -159,9 +159,9 @@ function readInitialState(source) {
 		sortOptionId: inspected?.sortOptionId ?? null,
 		sortTouched: false,
 		advanced: Object.freeze({
-			minimumRating: inspected?.value?.filters?.voteAverageGte === undefined ? "" : String(inspected.value.filters.voteAverageGte),
-			maximumRating: inspected?.value?.filters?.voteAverageLte === undefined ? "" : String(inspected.value.filters.voteAverageLte),
-			minimumVotes: inspected?.value?.filters?.voteCountGte === undefined ? "" : String(inspected.value.filters.voteCountGte),
+			minimumRating: String(inspected?.value?.filters?.voteAverageGte ?? ""),
+			maximumRating: String(inspected?.value?.filters?.voteAverageLte ?? ""),
+			minimumVotes: String(inspected?.value?.filters?.voteCountGte ?? ""),
 			originalLanguage: inspected?.value?.filters?.withOriginalLanguage ?? "",
 			originCountry: inspected?.value?.filters?.withOriginCountry ?? "",
 			ordinaryExcludedGenres: Object.freeze(genreName === null ? excludedNames : []),

--- a/builder/src/source-edit/tmdb-list-editor.js
+++ b/builder/src/source-edit/tmdb-list-editor.js
@@ -1,4 +1,5 @@
 import { canonicalPositiveId, diagnostic, isPlainObject, validateTouchedSourceTitle } from "./source-edit-utils.js";
+import { resolveEffectiveDiscoverSource } from "../nuvio/discover.js";
 
 export const TMDB_LIST_SOURCE_EDITOR_ID = "tmdb-list";
 
@@ -14,7 +15,7 @@ export function tmdbListEditIdentity(editable) {
 		&& mediaType === "MOVIE"
 		&& editable.sortBy === "original"
 		&& isPlainObject(filters)
-		&& Object.keys(filters).length === 0
+		&& Object.values(filters).every((value) => value === null)
 		&& id !== null
 		&& id <= 2_147_483_647
 		? `tmdb|LIST|${id}|MOVIE`
@@ -38,7 +39,11 @@ export const tmdbListSourceEditor = Object.freeze({
 	label: "TMDB List",
 	ownedFields: Object.freeze(["title"]),
 	duplicateMessage: "This folder already contains that TMDB List source.",
-	canEdit(source) { return source?.nodeType === "source" && source.category === "native-tmdb" && tmdbListEditIdentity(source.editable) !== null; },
+	canEdit(source) {
+		// Inspect the preserved filter overlay too: unknown non-null filters are not an empty List configuration.
+		const effective = resolveEffectiveDiscoverSource(source);
+		return effective.ok && tmdbListEditIdentity(effective.value) !== null;
+	},
 	identity: tmdbListEditIdentity,
 	readInitialState,
 	validateDraft,

--- a/docs/v2/BUILDER_DECADES.md
+++ b/docs/v2/BUILDER_DECADES.md
@@ -2,6 +2,8 @@
 
 ## 1. Status and boundary
 
+Issue [#196](https://github.com/davecollections/tmdb-id-lookup/issues/196), in local owner review, preserves Edit for otherwise valid Movie/Series Decade, Year and early-period Sources whose unused optional filters are expanded to null by Nuvio desktop. Optional Genre, rating, vote, language, country and exclusion controls read those nulls as inactive; zero ratings/votes remain zero. Canonical periods, required media and meaningful malformed values retain their safeguards. Import, opening and untouched no-op Save do not rewrite the Source. Intentional Advanced editing may omit unused known null filters while preserving unknown data and raw snapshots; see [Source editing](./BUILDER_SOURCE_EDITING.md#desktop-round-trip-preservation).
+
 Status: deterministic foundation merged through issue [#112](https://github.com/davecollections/tmdb-id-lookup/issues/112) / PR [#114](https://github.com/davecollections/tmdb-id-lookup/pull/114), with the visible owner-reviewed flow merged through issue [#113](https://github.com/davecollections/tmdb-id-lookup/issues/113) / PR [#115](https://github.com/davecollections/tmdb-id-lookup/pull/115). No current-client Decades hierarchy import/export result is claimed.
 
 Issue #112 provides the deterministic, non-UI Decades foundation consumed by the later visible issue #113.

--- a/docs/v2/BUILDER_GENRES.md
+++ b/docs/v2/BUILDER_GENRES.md
@@ -2,7 +2,9 @@
 
 ## 1. Status and scope
 
-Last reviewed: 2026-09-04
+Last reviewed: 2026-09-06
+
+Issue [#196](https://github.com/davecollections/tmdb-id-lookup/issues/196), in local owner review, allows otherwise valid Movie/Series Genre imports to retain Edit when unused optional filters contain null placeholders from Nuvio desktop. Those controls open empty, not as the text "null". Required official Genre/media identity, supported sort, malformed-value safeguards and field-specific blank handling remain unchanged. Importing/opening does not rewrite a Source; an intentional Advanced edit may replace unused known null placeholders with compact settings under the [Source editing preservation contract](./BUILDER_SOURCE_EDITING.md#desktop-round-trip-preservation).
 
 Issue [#110](https://github.com/davecollections/tmdb-id-lookup/issues/110) is closed/completed through merged [PR #111](https://github.com/davecollections/tmdb-id-lookup/pull/111) after desktop and physical-iPhone owner acceptance. It implements official TMDB Genres as a focused consumer of [`BUILDER_DISCOVER_CORE.md`](./BUILDER_DISCOVER_CORE.md):
 

--- a/docs/v2/BUILDER_KNOWLEDGE.md
+++ b/docs/v2/BUILDER_KNOWLEDGE.md
@@ -2,7 +2,13 @@
 
 Status: Active isolated builder and contract groundwork
 
-Last reviewed: 2026-09-03
+Last reviewed: 2026-09-06
+
+## 2026-09-06 — Nuvio desktop Source round trips (#196; local owner review)
+
+Nuvio desktop exports can expand unused Source and filter fields to explicit null values. Issue [#196](https://github.com/davecollections/tmdb-id-lookup/issues/196) corrects Genre and Decade/Year optional-filter readers and draft hydration, and accepts empty or all-null TMDB List filters. The three owner-supplied profiles each retain 4 Collections, 51 Folders and 197 Sources; all 35 Genre and 162 Decade/Year Sources now retain their editors in the local implementation. The List case is a synthetic regression, not a supplied client export. The warning screenshots were from a different custom collection; this task does not change warnings.
+
+Only absent/null optional values gain this interpretation. Valid zero values retain their meaning; required identities, meaningful unsupported or malformed values, and non-object filters keep their safeguards. Provider-led classification, comparison identities and serialization remain unchanged. Import, opening/Cancel, untouched no-op Save, and title/sort-only edits preserve the established imported-data contract. Intentionally changing Advanced settings may replace recognized filters with compact settings, omitting unused known nulls while preserving unknown fields, unrelated compatibility properties and raw snapshots. See [Source editing](./BUILDER_SOURCE_EDITING.md#desktop-round-trip-preservation).
 
 This is a living record of confirmed v2/Nuvio findings, current decisions, unsupported behaviour, and open questions. GitHub issues remain the source of truth for implementation scope. See [`BUILDER_PRODUCT_PLAN.md`](./BUILDER_PRODUCT_PLAN.md) for durable product direction, [`BUILDER_HIERARCHY_CREATION.md`](./BUILDER_HIERARCHY_CREATION.md) for the shared hierarchy-family standard, and [`PROJECT_WORKFLOW.md`](./PROJECT_WORKFLOW.md) for the Dave/ChatGPT/Codex process.
 

--- a/docs/v2/BUILDER_SOURCE_EDITING.md
+++ b/docs/v2/BUILDER_SOURCE_EDITING.md
@@ -2,7 +2,7 @@
 
 Status: merged foundation through issue [#78](https://github.com/davecollections/tmdb-id-lookup/issues/78) / PR [#79](https://github.com/davecollections/tmdb-id-lookup/pull/79); extended through Studio #92 / PR #93, Network #98 / PR #99, Streaming #104 / PR #105, official Genre #110 / PR #111, canonical Decade #113 / PR #115, and title-only TMDB Lists #170 / PR #171. Issue #158 added current-draft title Preview to the first seven adapters; issue #170 completed the eighth adapter after Worker deployment, live acceptance, owner review, publication, and merge.
 
-Last reviewed: 2026-09-03
+Last reviewed: 2026-09-06
 
 ## Scope
 
@@ -15,9 +15,9 @@ The current narrow source-editing surface edits one existing physical source in 
 - simple native TMDB Streaming `DISCOVER` Movie/TV sources with one uppercase Region, one positive Provider ID, and no other meaningful filter or unknown data.
 - native TMDB Genre `DISCOVER` Movie/TV sources with exactly one official media-correct positive `withGenres` ID and only the losslessly representable issue #110 year, rating, vote, language, country, and comma-separated official exclusion filters.
 - canonical native TMDB Decade-period `DISCOVER` Movie/TV sources classified by issue #112, optionally with one official media-correct included Genre and only the approved rating, vote, language, country, and comma-separated official exclusion filters.
-- native TMDB List sources with canonical positive signed-32-bit identity `tmdb|LIST|<list id>|MOVIE`, `sortBy: original`, and explicit empty filters.
+- native TMDB List sources with canonical positive signed-32-bit identity `tmdb|LIST|<list id>|MOVIE`, `sortBy: original`, and an explicit filters object that is empty or contains only null placeholders.
 
-Addon-backed, opaque/community, Discover shapes outside the recognized simple Streaming, official single-Genre, or canonical Decade-period boundaries, differently configured/incomplete Lists, incomplete Company/Network, and other unsupported native source shapes remain readable, movable, preservable, and removable, but do not expose Edit. Unknown imported fields remain preserved and do not prevent title-only editing when the recognized List fields are canonical. The editor never treats several sources as one logical bundle.
+Addon-backed, opaque/community, Discover shapes outside the recognized simple Streaming, official single-Genre, or canonical Decade-period boundaries, differently configured/incomplete Lists, incomplete Company/Network, and other unsupported native source shapes remain readable, movable, preservable, and removable, but do not expose Edit. Unknown top-level List metadata remains preserved and does not prevent title-only editing when the recognized List fields are valid; non-null imported List filters remain unsupported. The editor never treats several sources as one logical bundle.
 
 ## Architecture
 
@@ -34,7 +34,7 @@ Source editing is framework-independent under `builder/src/source-edit/`:
 - `streaming-editor.js` recognizes only simple Streaming-shaped DISCOVER nodes, owns title/sort validation and difference-only patches, and delegates functional identity to DISCOVER Core;
 - `genre-editor.js` recognizes only official media-correct single-Genre DISCOVER nodes whose approved filters are losslessly representable, owns title/sort/filter validation and difference-only patches, and delegates functional identity to DISCOVER Core;
 - `decade-editor.js` recognizes only canonical issue #112 Decade periods, owns title/sort/nonstructural-filter validation and difference-only patches, rebuilds its candidate through the shared one-period Decade composition helper, and keeps period/media/included-Genre structure fixed;
-- `tmdb-list-editor.js` recognizes only canonical `LIST`/`MOVIE`/`original`/empty-filter sources, owns title only, and keeps List ID plus all functional configuration fixed;
+- `tmdb-list-editor.js` recognizes only `LIST`/`MOVIE`/`original` sources with empty or all-null filters, including the preserved filter overlay, owns title only, and keeps List ID plus all functional configuration fixed;
 - `source-edit-actions.js` binds the exact physical source, performs stale-state and duplicate checks, and delegates a real change to `controller.updateNode()` exactly once;
 - `source-edit-utils.js` contains shared canonicalisation, title validation, and safe-label helpers.
 
@@ -47,7 +47,7 @@ Issue #118's `nuvio-people-assets` manifest is a creation-time canonical-name/ca
 | Source | Editable | Fixed and preserved |
 | --- | --- | --- |
 | Movie Collection | title; TMDB collection identity selected through the existing collection search/details boundary | provider, source type, media type, sort, filters, category, raw snapshot, unknown fields, Nuvio-facing source ID |
-| TMDB List | display title only | List TMDB ID, provider, `LIST`, canonical source-level `MOVIE`, `original`, empty filters, category, raw snapshot, unknown fields, Nuvio-facing source ID |
+| TMDB List | display title only | List TMDB ID, provider, `LIST`, canonical source-level `MOVIE`, `original`, empty/all-null filters, category, raw snapshot, unknown fields, Nuvio-facing source ID |
 | People | title; one of Acting Movies, Acting Series, Directed Movies, or Directed Series; evidenced sort order | person TMDB ID, provider, filters, category, raw snapshot, unknown fields, Nuvio-facing source ID |
 | Studio Movie/Series | display title and evidenced media-correct sort order | Studio TMDB ID, provider, `COMPANY`, `MOVIE`/`TV`, filters, category, raw snapshot, unknown fields, Nuvio-facing source ID |
 | Network Series | display title and evidenced TV sort order | Network TMDB ID, provider, `NETWORK`, `TV`, filters, category, raw snapshot, unknown fields, Nuvio-facing source ID |
@@ -91,6 +91,12 @@ Duplicate identity is evaluated only inside the destination folder and excludes 
 Cancel, validation failure, duplicate rejection, stale-state rejection, and an unchanged save perform zero controller mutation calls and advance no project revision. A real edit builds only changed owned fields and calls `controller.updateNode(sourceInternalId, patch)` once, producing one content revision.
 
 The existing preservation-first controller/domain/serializer path remains authoritative. Source and folder order, raw IDs, compact or verbose imported representation, unknown/community fields, null/default fields, untouched sort/filter values, addon compatibility projections, collection/folder presentation, and unrelated sources remain untouched. Serialization continues to overlay recognised edited fields onto imported raw snapshots and emits no builder `internalId`, title-management mode, count state, or source-edit state.
+
+## Desktop round-trip preservation
+
+Nuvio desktop may add unused properties with null values. Issue [#196](https://github.com/davecollections/tmdb-id-lookup/issues/196) lets otherwise valid Genre and Decade/Year Sources read optional null filters as inactive, and lets valid TMDB Lists use empty or all-null filters. Required identity fields and non-object filters remain invalid. Meaningful malformed/unsupported values still prevent editing; empty strings and whitespace do not gain a general exception. Genre and Decade editors open from stored values without a request until explicit Preview.
+
+Importing, opening/Cancel and an untouched no-op Save preserve the established imported-data contract. Title-only and sort-only edits retain unrelated filter and compatibility values. Intentionally changing Advanced settings uses the existing replacement of recognized filters with compact settings, so unused known null placeholders may disappear. Unknown fields, unrelated top-level compatibility properties, source ordering/IDs and preserved raw snapshots remain protected. This does not promise identical bytes after an intentional settings change. List title editing never replaces filters.
 
 ## UI and accessibility
 

--- a/docs/v2/BUILDER_TMDB_LISTS.md
+++ b/docs/v2/BUILDER_TMDB_LISTS.md
@@ -2,7 +2,9 @@
 
 Status: complete through issue [#170](https://github.com/davecollections/tmdb-id-lookup/issues/170) / merged [PR #171](https://github.com/davecollections/tmdb-id-lookup/pull/171) at `3e1ceace849d137e17ddfedb8637bc147f511285`; the reviewed Worker bytes were manually deployed, bounded live production-path and current-Nuvio gates passed, owner review completed, and Pages publication succeeded
 
-Last reviewed: 2026-09-02
+Last reviewed: 2026-09-06
+
+Issue [#196](https://github.com/davecollections/tmdb-id-lookup/issues/196), in local owner review, treats an imported List filters object containing only null placeholders as empty for Source Edit eligibility. The List ID, `LIST`/`MOVIE`/`original` requirements remain fixed. Any non-null filter value, including an unknown preserved filter, stays outside the editor contract; non-object filters remain invalid. Import, opening/Cancel, no-op and title-only Save preserve those placeholders and unknown top-level metadata. Creation still emits `{}` filters and request/output behavior is unchanged. This List case is synthetic regression evidence; the supplied desktop exports demonstrate Genre/Year Sources.
 
 ## Product contract
 
@@ -54,7 +56,7 @@ The LIST-only subtitle is derived from the usable loaded sample and the provider
 
 ## Source Edit
 
-A complete supported native `LIST`/`MOVIE` source with `sortBy: "original"` and empty filters is registered through the existing fail-closed source-editor adapter registry. Edit owns only Source name, repeats the Nuvio/customisation helper, describes the fixed sort as **Original order**, and presents the numeric List ID as a safe new-tab link to `https://www.themoviedb.org/list/<id>`. List ID, provider, source type, canonical media configuration, filters, category, raw imported values, unknown fields, and physical identity stay fixed. Preview uses the same List provider/cache and mixed **Titles** presentation. Unknown imported fields remain preserved and do not prevent a canonical List source from receiving a title-only edit; incomplete, differently configured, filtered, or otherwise unsupported List shapes remain preservable and Delete-only. Other source editors retain their existing identity presentation.
+A complete supported native `LIST`/`MOVIE` source with `sortBy: "original"` and empty or all-null filters is registered through the existing fail-closed source-editor adapter registry. Edit owns only Source name, repeats the Nuvio/customisation helper, describes the fixed sort as **Original order**, and presents the numeric List ID as a safe new-tab link to `https://www.themoviedb.org/list/<id>`. List ID, provider, source type, canonical media configuration, filters, category, raw imported values, unknown fields, and physical identity stay fixed. Preview uses the same List provider/cache and mixed **Titles** presentation. Unknown imported fields remain preserved and do not prevent a canonical List source from receiving a title-only edit; incomplete, differently configured, meaningfully filtered, or otherwise unsupported List shapes remain preservable and Delete-only. Other source editors retain their existing identity presentation.
 
 ## Worker deployment gate
 

--- a/tests/builder-genre-foundation.test.mjs
+++ b/tests/builder-genre-foundation.test.mjs
@@ -266,6 +266,21 @@ test("advanced filter recognition is lossless and fails closed on unsupported sh
 	assert.equal(readGenreAdvancedFilters({ ...filters, withKeywords: "42" }, { mediaType: "MOVIE", includedGenre: "Comedy" }), null);
 });
 
+test("Genre optional readers accept null without admitting blank numeric/date fields or falsy malformed codes", () => {
+	const options = { mediaType: "MOVIE", includedGenre: "Comedy" };
+	const empty = readGenreAdvancedFilters({ withGenres: "35" }, options);
+	for (const field of ["releaseDateGte", "releaseDateLte", "voteAverageGte", "voteAverageLte", "voteCountGte", "withoutGenres", "withOriginalLanguage", "withOriginCountry"]) {
+		assert.deepEqual(readGenreAdvancedFilters({ withGenres: "35", [field]: null }, options), empty, field);
+		assert.equal(readGenreAdvancedFilters({ withGenres: "35", [field]: false }, options), null, field);
+		assert.equal(readGenreAdvancedFilters({ withGenres: "35", [field]: " " }, options), null, field);
+		if (!["withOriginalLanguage", "withOriginCountry"].includes(field)) assert.equal(readGenreAdvancedFilters({ withGenres: "35", [field]: "" }, options), null, field);
+	}
+	const zeros = readGenreAdvancedFilters({ withGenres: "35", voteAverageGte: 0, voteAverageLte: 0, voteCountGte: 0 }, options);
+	assert.equal(zeros.minimumRating, "0");
+	assert.equal(zeros.maximumRating, "0");
+	assert.equal(zeros.minimumVotes, "0");
+});
+
 test("Genre draft validation rejects reorder, compound identity and unreviewed filter changes", () => {
 	const options = { genres: ["Comedy", "Action & Adventure"], advanced: fullAdvanced() };
 	const drafts = buildGenreSourceDrafts(options.genres, options).drafts;

--- a/tests/builder-source-details.test.mjs
+++ b/tests/builder-source-details.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import { fileURLToPath } from "node:url";
 import test, { after } from "node:test";
+import { desktopExpandedSource, roundTripSourceCases } from "./fixtures/nuvio-desktop-round-trip.mjs";
 import { createElement } from "../builder/node_modules/react/index.js";
 import { renderToStaticMarkup } from "../builder/node_modules/react-dom/server.js";
 import { createServer } from "../builder/node_modules/vite/dist/node/index.js";
@@ -90,6 +91,19 @@ function controllerFor(sources) {
 	controller.selectNode(controller.getState().project.collections[0].folders[0].internalId);
 	return controller;
 }
+
+test("desktop round trip: family details and Workspace Edit eligibility survive null expansion", () => {
+	for (const { name, source } of roundTripSourceCases) {
+		const compact = controllerFor([source]);
+		const expanded = controllerFor([desktopExpandedSource(source)]);
+		const before = JSON.stringify(expanded.getState());
+		const originalView = buildBuilderViewModel(compact.getState()).sources[0];
+		const view = buildBuilderViewModel(expanded.getState()).sources[0];
+		assert.equal(view.editSupported, true, name);
+		assert.deepEqual(view.metadata, originalView.metadata, name);
+		assert.equal(JSON.stringify(expanded.getState()), before);
+	}
+});
 
 test("names remain independent of metadata and existing hidden/format-only title semantics remain intact", () => {
 	const names = ["Custom display name", "", "   ", "\u200e", "\u200e\u200e", "\u200b"];

--- a/tests/builder-source-edit-foundation.test.mjs
+++ b/tests/builder-source-edit-foundation.test.mjs
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { desktopExpandedSource, roundTripSourceCases } from "./fixtures/nuvio-desktop-round-trip.mjs";
+import { discoverSourceNodeIdentity } from "../builder/src/nuvio/discover.js";
 
 import { createBuilderController } from "../builder/src/application/index.js";
 import {
@@ -1032,4 +1034,164 @@ test("an edited People sort remains exact through export and a second cycle", ()
 	const second = serialize(cycled);
 	assert.deepEqual(second.value, first.value);
 	assert.equal(second.json, first.json);
+});
+
+for (const { name, editorId, source: compact } of roundTripSourceCases) {
+	test(`desktop round trip: ${name} preserves import, hydration, no-op and intentional edits`, () => {
+		for (const route of ["compact", "account-manager", "desktop"]) {
+			const controller = createController();
+			const source = route === "desktop" ? desktopExpandedSource(compact) : structuredClone(compact);
+			if (route === "desktop") {
+				source.unknownNull = null;
+				source.filters.unknownNull = null;
+			}
+			const folder = importFolder(controller, [
+				{ provider: "community", title: "Before", keep: { value: false } },
+				source,
+				{ provider: "community", title: "After", keep: [0, null] },
+			], route === "account-manager" ? { focusGifEnabled: false } : {});
+			const before = serialize(controller);
+			const project = controller.getState().project;
+			const node = folder.sources[1];
+			const identity = editorId === "tmdb-list" ? sourceEditorFor(node).identity(node.editable) : discoverSourceNodeIdentity(node).key;
+			assert.equal(node.category, "native-tmdb");
+			assert.equal(sourceEditorFor(node)?.id, editorId, route);
+			assert.deepEqual(before.value[0].folders[0].sources[1], source);
+			const opened = sessionFor(controller, 1);
+			assert.equal(controller.getState().project, project, "opening/abandoning the draft does not mutate");
+			if (opened.draft.advanced) {
+				for (const key of ["minimumRating", "maximumRating", "minimumVotes", "originalLanguage", "originCountry"]) assert.equal(opened.draft.advanced[key], "", key);
+				assert.equal(JSON.stringify(opened.draft).includes('"null"'), false);
+			}
+			const noop = saveSourceEdit(controller, opened.session, opened.draft);
+			assert.equal(noop.ok, true);
+			assert.equal(noop.changed, false);
+			assert.equal(controller.getState().project, project);
+			assert.equal(serialize(controller).json, before.json);
+
+			const titleSave = saveSourceEdit(controller, opened.session, updateSourceEditTitle(opened.draft, "Intentional title"));
+			assert.equal(titleSave.ok, true);
+			assert.deepEqual(titleSave.patch, { title: "Intentional title" });
+			assert.deepEqual(serialize(controller).value[0].folders[0].sources[1], { ...source, title: "Intentional title" });
+			if (editorId !== "tmdb-list") {
+				const sortOpen = sessionFor(controller, 1);
+				const sortSave = saveSourceEdit(controller, sortOpen.session, { ...sortOpen.draft, sortBy: "vote_average.desc", sortOptionId: "top-rated", sortTouched: true });
+				assert.equal(sortSave.ok, true, JSON.stringify(sortSave.errors));
+				assert.deepEqual(sortSave.patch, { sortBy: "vote_average.desc" });
+				assert.deepEqual(serialize(controller).value[0].folders[0].sources[1], { ...source, title: "Intentional title", sortBy: "vote_average.desc" });
+
+				const advancedOpen = sessionFor(controller, 1);
+				const revision = controller.getState().revision;
+				const changed = saveSourceEdit(controller, advancedOpen.session, { ...advancedOpen.draft, advancedTouched: true, advanced: { ...advancedOpen.draft.advanced, minimumRating: "0", minimumVotes: "0" } });
+				assert.equal(changed.ok, true, JSON.stringify(changed.errors));
+				assert.equal(controller.getState().revision, revision + 1);
+				assert.deepEqual(Object.keys(changed.patch), ["filters"]);
+				const after = serialize(controller).value[0].folders[0];
+				assert.deepEqual(after.sources[1].filters, { ...(route === "desktop" ? { unknownNull: null } : {}), ...compact.filters, voteAverageGte: 0, voteCountGte: 0 });
+				assert.deepEqual({ ...after.sources[1], filters: source.filters }, { ...source, title: "Intentional title", sortBy: "vote_average.desc" });
+				assert.deepEqual(after.sources[0], before.value[0].folders[0].sources[0]);
+				assert.deepEqual(after.sources[2], before.value[0].folders[0].sources[2]);
+				const reopened = sessionFor(controller, 1);
+				assert.equal(reopened.draft.advanced.minimumRating, "0");
+				assert.equal(reopened.draft.advanced.minimumVotes, "0");
+			}
+			const finalNode = controller.getState().project.collections[0].folders[0].sources[1];
+			assert.equal(finalNode.internalId, node.internalId);
+			assert.deepEqual(finalNode.rawImported, source);
+			assert.equal(sourceEditorFor(finalNode).id, editorId);
+			assert.deepEqual(controller.getState().project.collections.map((c) => [c.internalId, c.editable.id, c.folders.map((f) => [f.internalId, f.editable.id, f.sources.map((s) => s.internalId)])]), project.collections.map((c) => [c.internalId, c.editable.id, c.folders.map((f) => [f.internalId, f.editable.id, f.sources.map((s) => s.internalId)])]));
+			if (editorId === "tmdb-list") assert.equal(sourceEditorFor(finalNode).identity(finalNode.editable), identity);
+			const second = createController();
+			assert.equal(second.importValue(serialize(controller).value).ok, true);
+			assert.deepEqual(serialize(second).value, serialize(controller).value);
+		}
+	});
+}
+
+test("desktop round trip: required identities and meaningful malformed values remain unsupported", () => {
+	for (const entry of roundTripSourceCases) {
+		const expanded = desktopExpandedSource(entry.source);
+		const invalid = [
+			{ ...expanded, provider: "addon" },
+			{ ...expanded, provider: null },
+			{ ...expanded, provider: "community" },
+			{ ...expanded, tmdbSourceType: null },
+			{ ...expanded, tmdbSourceType: "UNKNOWN" },
+			{ ...expanded, mediaType: null },
+			{ ...expanded, mediaType: "invalid" },
+			...[[1], null, false, ""].map((filters) => ({ ...expanded, filters })),
+			...[false, 0, "", " ", "bad", [], {}].map((value) => ({ ...expanded, filters: { ...expanded.filters, futureFilter: value } })).filter((source) => !["", " "].includes(source.filters.futureFilter) || entry.editorId === "tmdb-list"),
+		];
+		if (entry.editorId === "tmdb-list") {
+			for (const tmdbId of [null, 0, -1, "abc", 2_147_483_648]) invalid.push({ ...expanded, tmdbId });
+			invalid.push({ ...expanded, sortBy: "popularity.desc" }, { ...expanded, mediaType: "TV" });
+			for (const value of [false, 0, "", " ", "28", [], {}]) invalid.push({ ...expanded, filters: { withGenres: value } });
+		} else {
+			for (const key of ["addonId", "catalogId", "type"]) invalid.push({ ...expanded, [key]: "meaningful" });
+			invalid.push({ ...expanded, tmdbId: 5 }, { ...expanded, sortBy: "unsupported" });
+			const fields = ["voteAverageGte", "voteAverageLte", "voteCountGte", "withoutGenres"];
+			if (entry.editorId === "decade") fields.push("withOriginalLanguage", "withOriginCountry");
+			for (const field of fields) for (const value of [false, "", " ", "bad", [], {}]) {
+				// An empty language/country is already accepted by the Genre fallback for a dated Genre.
+				if (value === "" && expanded.filters.withGenres !== null && ["withOriginalLanguage", "withOriginCountry"].includes(field)) continue;
+				invalid.push({ ...expanded, filters: { ...expanded.filters, [field]: value } });
+			}
+			if (entry.editorId === "genre") {
+				for (const field of ["withGenres", "releaseDateGte", "releaseDateLte"]) for (const value of [false, 0, "", " ", "bad", [], {}]) invalid.push({ ...expanded, filters: { ...expanded.filters, [field]: value } });
+				invalid.push({ ...expanded, filters: { ...expanded.filters, withGenres: null } });
+			} else {
+				invalid.push({ ...expanded, filters: { ...expanded.filters, releaseDateGte: "1984-02-01", releaseDateLte: "1984-12-31", withGenres: null } });
+			}
+		}
+		for (const source of invalid) {
+			const controller = createController();
+			const node = importFolder(controller, [source]).sources[0];
+			assert.equal(canEditSource(node), false, entry.name + " " + JSON.stringify(source));
+			assert.deepEqual(node.rawImported, source);
+		}
+	}
+});
+
+test("desktop round trip: provider, blocking-export and other-family contracts remain unchanged", () => {
+	const controller = createController();
+	const untouched = [collectionSource(), peopleSource(), peopleSource({ tmdbSourceType: "DIRECTOR", mediaType: "TV" }), studioSource(), studioSource({ mediaType: "TV" }), { ...studioSource(), tmdbSourceType: "NETWORK", mediaType: "TV" }, streamingSource()];
+	const folder = importFolder(controller, untouched.map(desktopExpandedSource));
+	assert.deepEqual(folder.sources.map((node) => sourceEditorFor(node)?.id), ["movie-collection", "people", "people", "studio", "studio", "network", "streaming"]);
+	assert.deepEqual(serialize(controller).value[0].folders[0].sources, untouched.map(desktopExpandedSource));
+	for (const [source, category, errorCode] of [
+		[{ provider: "addon", addonId: "example", catalogId: "catalog", type: "movie" }, "addon", null],
+		[{ provider: "addon", addonId: null, catalogId: "", type: null }, "addon", "INCOMPLETE_ADDON_SOURCE"],
+		[{ provider: "community", addonId: "example", catalogId: "catalog", type: "movie", future: { keep: false } }, "opaque", null],
+		[{ ...roundTripSourceCases[0].source, mediaType: "invalid" }, "native-tmdb", "INVALID_NATIVE_MEDIA_TYPE"],
+		[{ ...roundTripSourceCases[0].source, filters: [] }, "native-tmdb", "INVALID_NATIVE_FILTERS"],
+	]) {
+		const c = createController();
+		const node = importFolder(c, [source]).sources[0];
+		assert.equal(node.category, category);
+		assert.equal(canEditSource(node), false);
+		const output = c.serializeProject();
+		assert.equal(output.ok, errorCode === null);
+		if (errorCode) assert.ok(output.errors.some((e) => e.code === errorCode));
+		else {
+			assert.deepEqual(output.value[0].folders[0].sources[0], source);
+			assert.equal(output.value[0].folders[0].catalogSources.length, category === "addon" ? 1 : 0);
+			assert.equal(output.warnings.some((e) => e.code === "OPAQUE_SOURCE_PRESERVED"), category === "opaque");
+		}
+	}
+});
+
+test("desktop round trip: duplicate and stale Advanced saves do not mutate", () => {
+	for (const entry of roundTripSourceCases.filter((entry) => entry.editorId !== "tmdb-list")) {
+		const c = createController();
+		importFolder(c, [desktopExpandedSource(entry.source), { ...entry.source, filters: { ...entry.source.filters, voteCountGte: 100 } }]);
+		const opened = sessionFor(c);
+		const before = serialize(c).json;
+		const rejected = saveSourceEdit(c, opened.session, { ...opened.draft, advancedTouched: true, advanced: { ...opened.draft.advanced, minimumVotes: "100" } });
+		assert.equal(rejected.errors[0].code, "SOURCE_EDIT_DUPLICATE_IDENTITY", entry.name);
+		assert.equal(serialize(c).json, before);
+		c.updateNode(opened.source.internalId, { title: "Changed outside editor" });
+		const staleBefore = serialize(c).json;
+		assert.equal(saveSourceEdit(c, opened.session, opened.draft).errors[0].code, "SOURCE_EDIT_PROJECT_STALE");
+		assert.equal(serialize(c).json, staleBefore);
+	}
 });

--- a/tests/builder-source-edit-mounted.test.mjs
+++ b/tests/builder-source-edit-mounted.test.mjs
@@ -65,6 +65,7 @@ async function waitForJson(url, timeoutMs = 10000) {
 async function runMountedPage() {
 	const launcherOnly = process.env.TMDB_ID_LOOKUP_LAUNCHER_ONLY === "1";
 	const sourceDetailsOnly = process.env.TMDB_SOURCE_DETAILS_ONLY === "1";
+	const roundTripOnly = process.env.TMDB_SOURCE_ROUND_TRIP_ONLY === "1";
 	const devToolsStartupMs = resolveDevToolsStartupTimeout(process.env.DEVTOOLS_STARTUP_MS);
 	const resources = {
 		browserExecutable: null,
@@ -173,7 +174,7 @@ async function runMountedPage() {
 		await resources.pageConnection.command("Runtime.enable");
 		const address = resources.vite.httpServer.address();
 		await resources.pageConnection.command("Page.navigate", {
-			url: `http://127.0.0.1:${address.port}/tests/fixtures/builder-source-edit-mounted.html${sourceDetailsOnly ? "?source-details-only" : ""}`,
+			url: `http://127.0.0.1:${address.port}/tests/fixtures/builder-source-edit-mounted.html${roundTripOnly ? "?source-round-trip-only" : sourceDetailsOnly ? "?source-details-only" : ""}`,
 		});
 		const deadline = Date.now() + 30000;
 		while (Date.now() < deadline) {
@@ -183,6 +184,16 @@ async function runMountedPage() {
 			});
 			const result = evaluated.result?.value;
 			if (result?.status === "complete") {
+				if (!sourceDetailsOnly) {
+					result.results.desktopRoundTripWidths = [];
+					for (const width of [360, 384, 393, 402, 412, 900]) {
+						await resources.pageConnection.command("Emulation.setDeviceMetricsOverride", { width, height: 1000, deviceScaleFactor: 1, mobile: width < 900 });
+						const evaluated = await resources.pageConnection.command("Runtime.evaluate", { expression: "window.__runDesktopRoundTripScenario()", awaitPromise: true, returnByValue: true });
+						if (evaluated.exceptionDetails) throw new Error(evaluated.exceptionDetails.exception?.description ?? evaluated.exceptionDetails.text);
+						result.results.desktopRoundTripWidths.push(evaluated.result.value);
+					}
+					if (roundTripOnly) return result.results;
+				}
 				// Reuse the mounted Workspace and browser lifecycle for Source-only details.
 				for (const width of [393, 900, 1280]) {
 					await resources.pageConnection.command("Emulation.setDeviceMetricsOverride", { width, height: 1100, deviceScaleFactor: 1, mobile: width === 393 });
@@ -635,7 +646,7 @@ async function runMountedPage() {
 			`Mounted browser required process-tree fallback after graceful shutdown failed: ${execution.cleanupReport.browser.gracefulError?.message ?? "unknown error"}`,
 		);
 	}
-	if (!sourceDetailsOnly && process.env.TMDB_MOUNTED_BROWSER_DIAGNOSTICS === "1") {
+	if (!sourceDetailsOnly && !roundTripOnly && process.env.TMDB_MOUNTED_BROWSER_DIAGNOSTICS === "1") {
 		console.log(`MOUNTED_BROWSER_DIAGNOSTICS ${JSON.stringify({
 			browserExecutable: execution.cleanupReport.browserExecutable,
 			debugPort: resources.debugPort,
@@ -761,6 +772,23 @@ function assertRequiredNameFailure(result) {
 
 test("mounted Workspace Source details remain compact, accessible and naturally wrapped", () => {
 	assert.equal(mountedResults.sourceDetailsVerified, true);
+});
+
+test("mounted desktop round trip restores Genre, Decade and List Edit without requests or no-op mutation", () => {
+	assert.deepEqual(mountedResults.desktopRoundTripWidths.map((entry) => entry.width), [360, 384, 393, 402, 412, 900]);
+	for (const result of mountedResults.desktopRoundTripWidths) {
+		assert.deepEqual(result.requests, [], `${result.width}px requests`);
+		assert.deepEqual(result.consoleErrors, [], `${result.width}px console errors`);
+		assert.equal(result.exportOk, true);
+		assert.equal(result.exportWarnings, 0);
+		assert.equal(result.exportUnchanged, true);
+		assert.equal(result.unchanged, true);
+		assert.equal(result.cases.length, 15);
+		for (const entry of result.cases) {
+			assert.equal(entry.adapter, entry.expectedAdapter, entry.name);
+			for (const key of ["editBeforeDelete", "noNullControls", "emptyNumericControls", "noOverflow", "cancelClosed", "cancelUnchanged", "saveClosed", "saveUnchanged"]) assert.equal(entry[key], true, `${result.width}px ${entry.name}: ${key}`);
+		}
+	}
 });
 
 test("mounted People validation focuses Source name after rendering and performs zero mutation", () => {

--- a/tests/fixtures/builder-source-edit-mounted.jsx
+++ b/tests/fixtures/builder-source-edit-mounted.jsx
@@ -1,6 +1,8 @@
 import { act, createElement, useSyncExternalStore } from "react";
 import { createRoot } from "react-dom/client";
 import { createBuilderController } from "../../builder/src/application/index.js";
+import { desktopExpandedSource, roundTripSourceCases } from "./nuvio-desktop-round-trip.mjs";
+import { createCollectionExportPayload } from "../../builder/src/ui/export-collections.js";
 import {
 	applyGenreHierarchyPlan,
 	applyStreamingHierarchyPlan,
@@ -1471,6 +1473,58 @@ async function prepareSourceDetailsScenario() {
 	};
 }
 window.__prepareSourceDetailsScenario = prepareSourceDetailsScenario;
+
+// Local import/editor behavior only. Record and forward any unexpected fetch; never synthesize a response.
+async function runDesktopRoundTripScenario() {
+	const controller = createController();
+	const folder = importSources(controller, roundTripSourceCases.map(({ source }) => desktopExpandedSource(source)));
+	controller.selectNode(folder.internalId);
+	const project = controller.getState().project;
+	const before = serializedValue(controller);
+	const requests = [];
+	const originalFetch = window.fetch;
+	window.fetch = (...args) => { requests.push(String(args[0])); return originalFetch(...args); };
+	const consoleErrors = [];
+	const originalConsoleError = console.error;
+	console.error = (...args) => { consoleErrors.push(args.map(String).join(" ")); originalConsoleError(...args); };
+	const host = document.createElement("div");
+	document.body.append(host);
+	const root = createRoot(host);
+	const cases = [];
+	try {
+		await act(async () => { root.render(createElement(MountedWorkspace, { controller })); await afterCommittedEffects(); });
+		for (const [index, entry] of roundTripSourceCases.entries()) {
+			const result = { name: entry.name, expectedAdapter: entry.editorId };
+			for (const action of ["cancel", "save"]) {
+				const trigger = host.querySelectorAll('[data-action="open-source-actions"]')[index];
+				await act(async () => { trigger.scrollIntoView({ block: "center" }); await afterCommittedEffects(); });
+				await clickAndSettle(trigger);
+				const edit = document.querySelector('[data-actions-menu="source"]:not([hidden]) [data-action="edit-source"]');
+				if (!edit) throw new Error(`${entry.name} has no Edit source action`);
+				result.editBeforeDelete = edit.nextElementSibling?.dataset.action === "delete-source";
+				await clickAndSettle(edit);
+				const dialog = document.querySelector('[data-source-edit-modal="true"]');
+				if (!dialog) throw new Error(`${entry.name} editor did not open`);
+				result.adapter = dialog.dataset.sourceEditAdapter;
+				result.noNullControls = [...dialog.querySelectorAll("input, select, textarea")].every((input) => input.value !== "null");
+				result.emptyNumericControls = [...dialog.querySelectorAll('input[type="number"]')].every((input) => input.value === "");
+				result.noOverflow = dialog.scrollWidth <= dialog.clientWidth + 1 && document.documentElement.scrollWidth <= window.innerWidth;
+				await clickAndSettle(dialog.querySelector(`[data-action="${action}-source-edit"]`));
+				result[`${action}Closed`] = document.querySelector('[data-source-edit-modal="true"]') === null;
+				result[`${action}Unchanged`] = controller.getState().project === project && serializedValue(controller) === before;
+			}
+			cases.push(result);
+		}
+		const exported = createCollectionExportPayload(controller)();
+		return { width: window.innerWidth, cases, requests, consoleErrors, exportOk: exported.ok, exportWarnings: exported.warnings.length, exportUnchanged: JSON.stringify(exported.collections) === before, unchanged: controller.getState().project === project };
+	} finally {
+		await act(async () => root.unmount());
+		host.remove();
+		window.fetch = originalFetch;
+		console.error = originalConsoleError;
+	}
+}
+window.__runDesktopRoundTripScenario = runDesktopRoundTripScenario;
 
 async function runBlankCreationScenario() {
 	const controller = createController();
@@ -7876,7 +7930,7 @@ window.__runTmdbListLivePreviewScenario = runTmdbListLivePreviewScenario;
 window.__prepareSourceChooserKeyboardScenario = prepareSourceChooserKeyboardScenario;
 window.__inspectSourceChooserKeyboardFocus = inspectSourceChooserKeyboardFocus;
 window.__finishSourceChooserKeyboardScenario = finishSourceChooserKeyboardScenario;
-(new URLSearchParams(window.location.search).has("source-details-only") ? Promise.resolve({}) : runMountedRegressions()).then(
+(["source-details-only", "source-round-trip-only"].some((key) => new URLSearchParams(window.location.search).has(key)) ? Promise.resolve({}) : runMountedRegressions()).then(
 	(results) => { window.__builderSourceEditMounted = { status: "complete", results }; },
 	(error) => {
 		window.__builderSourceEditMounted = {

--- a/tests/fixtures/nuvio-desktop-round-trip.mjs
+++ b/tests/fixtures/nuvio-desktop-round-trip.mjs
@@ -1,0 +1,31 @@
+// Small synthetic import envelopes, not external-service responses or personal collections.
+const desktopFilterFields = [
+	"withGenres", "withoutGenres", "releaseDateGte", "releaseDateLte",
+	"voteAverageGte", "voteAverageLte", "voteCountGte", "withOriginalLanguage",
+	"withOriginCountry", "withKeywords", "withoutKeywords", "withCompanies",
+	"withoutCompanies", "withNetworks", "year", "watchRegion",
+	"withWatchProviders", "withoutWatchProviders",
+];
+
+export function desktopExpandedSource(source) {
+	return {
+		...source,
+		addonId: null, catalogId: null, type: null, genre: null, sortHow: null, traktListId: null,
+		filters: { ...Object.fromEntries(desktopFilterFields.map((field) => [field, null])), ...source.filters },
+	};
+}
+
+export const roundTripSourceCases = [];
+for (const mediaType of ["MOVIE", "TV"]) {
+	const base = { provider: "tmdb", tmdbSourceType: "DISCOVER", tmdbId: null, mediaType, sortBy: "popularity.desc" };
+	roundTripSourceCases.push({ name: `Genre ${mediaType}`, editorId: "genre", source: { ...base, title: `Example Genre ${mediaType}`, filters: { withGenres: "35" } } });
+	for (const [name, filters] of [
+		["Decade", { releaseDateGte: "1980-01-01", releaseDateLte: "1989-12-31" }],
+		["Year", { releaseDateGte: "1984-01-01", releaseDateLte: "1984-12-31" }],
+		["Before 1950", { releaseDateLte: "1949-12-31" }],
+		["1950s and earlier", { releaseDateLte: "1959-12-31" }],
+		["Decade with Genre", { releaseDateGte: "1980-01-01", releaseDateLte: "1989-12-31", withGenres: "35" }],
+		["Year with Genre", { releaseDateGte: "1984-01-01", releaseDateLte: "1984-12-31", withGenres: "35" }],
+	]) roundTripSourceCases.push({ name: `${name} ${mediaType}`, editorId: "decade", source: { ...base, title: `Example ${name} ${mediaType}`, filters } });
+}
+roundTripSourceCases.push({ name: "TMDB List", editorId: "tmdb-list", source: { provider: "tmdb", title: "Example List", tmdbSourceType: "LIST", tmdbId: 123, mediaType: "MOVIE", sortBy: "original", filters: {} } });


### PR DESCRIPTION
Nuvio desktop round trips add unused null filter placeholders, causing valid Genre and Decade/Year Sources to lose Edit even though the importer still classifies them as native TMDB.

The existing family readers now treat undefined/null optional values as inactive without truthiness or broader blank-value normalization. Genre and Decade controls hydrate safely; canonical TMDB Lists accept empty or all-null filters while meaningful preserved filters remain unsupported. Required identities and malformed, addon, opaque, duplicate and stale-save safeguards remain intact.

Import, opening/Cancel and untouched no-op Save preserve imported data. Title-only and sort-only edits retain unrelated compatibility fields. Intentional Advanced changes may emit compact known filters while preserving unknown data, raw snapshots, identities and ordering. Provider classification, identity algorithms, serialization, warnings, schema, Worker, v1 and dependencies are unchanged.

Includes 4 production files, 6 test/fixture files and 5 directly affected contract documents. Fixtures contain sanitized synthetic examples; complete user evidence is excluded.

Validation:

- 400 focused tests and the mounted round-trip regression passed during implementation; all 15 synthetic shapes were checked at six mobile/desktop widths.
- All three supplied export routes retained 4 Collections, 51 Folders and 197 editable Sources, with parsed-data preservation.
- `scripts/check.cmd` ran once: 1,586 passed, zero failures, two unchanged deployment-gated Decades skips. No retry was needed.
- `npm run build --prefix builder` and `git diff --check` passed; existing bundle-size advisory only.

Closes #196
